### PR TITLE
Improve admin views and add search with bulk account change

### DIFF
--- a/api/admin.py
+++ b/api/admin.py
@@ -115,8 +115,18 @@ class PrefillAdmin(admin.ModelAdmin):
         return obj.name
 
 
+class PaystubValueInline(admin.TabularInline):
+    model = PaystubValue
+    extra = 0
+
+
 class PaystubAdmin(admin.ModelAdmin):
     list_display = ("title", "journal_entry")
+    inlines = [PaystubValueInline]
+
+
+class S3FileAdmin(admin.ModelAdmin):
+    list_display = ("user_filename", "prefill", "analysis_complete")
 
 
 # Register your models here
@@ -132,7 +142,7 @@ admin.site.register(TaxCharge)
 admin.site.register(CSVColumnValuePair)
 admin.site.register(Amortization)
 admin.site.register(PrefillItem)
-admin.site.register(S3File)
+admin.site.register(S3File, S3FileAdmin)
 admin.site.register(DocSearch)
 admin.site.register(Paystub, PaystubAdmin)
 admin.site.register(PaystubValue)

--- a/api/forms.py
+++ b/api/forms.py
@@ -437,7 +437,15 @@ class JournalEntryItemForm(forms.ModelForm):
         return instance
 
 
-class TransactionFilterForm(forms.Form):
+IS_CLOSED_CHOICES = (
+    (None, "---------"),
+    (True, "True"),
+    (False, "False"),
+)
+
+
+class BaseFilterForm(forms.Form):
+    """Shared filter fields for transaction search/filter forms."""
     date_from = forms.DateField(required=False)
     date_to = forms.DateField(required=False)
     account = forms.ModelMultipleChoiceField(
@@ -446,11 +454,33 @@ class TransactionFilterForm(forms.Form):
     transaction_type = forms.MultipleChoiceField(
         choices=Transaction.TransactionType.choices, required=False
     )
-    IS_CLOSED_CHOICES = (
-        (None, "---------"),
-        (True, "True"),
-        (False, "False"),
+    related_account = forms.ModelMultipleChoiceField(
+        queryset=Account.objects.all(), required=False
     )
+
+
+class SearchFilterForm(BaseFilterForm):
+    description = forms.CharField(required=False)
+
+
+class BulkAccountChangeForm(forms.Form):
+    from_account = forms.ModelChoiceField(
+        queryset=Account.objects.all(), required=True
+    )
+    to_account = forms.ModelChoiceField(
+        queryset=Account.objects.all(), required=True
+    )
+
+    def clean(self):
+        cleaned_data = super().clean()
+        from_account = cleaned_data.get("from_account")
+        to_account = cleaned_data.get("to_account")
+        if from_account and to_account and from_account == to_account:
+            raise forms.ValidationError("FROM and TO accounts must be different.")
+        return cleaned_data
+
+
+class TransactionFilterForm(BaseFilterForm):
     is_closed = forms.ChoiceField(required=False, choices=IS_CLOSED_CHOICES)
     LINKED_TRANSACTION_CHOICES = (
         (None, "---------"),
@@ -459,9 +489,6 @@ class TransactionFilterForm(forms.Form):
     )
     has_linked_transaction = forms.ChoiceField(
         required=False, choices=LINKED_TRANSACTION_CHOICES
-    )
-    related_account = forms.ModelMultipleChoiceField(
-        queryset=Account.objects.all(), required=False
     )
 
     def clean_is_closed(self):

--- a/api/services/search_services.py
+++ b/api/services/search_services.py
@@ -1,0 +1,138 @@
+"""
+Search service layer for searching transactions and bulk-updating JournalEntryItems.
+
+All search-related business logic and database writes go through these service functions.
+Services are pure functions with no HTTP dependencies.
+"""
+
+import datetime
+from dataclasses import dataclass
+from typing import List, Optional
+
+from django.db import transaction as db_transaction
+
+from api.models import Account, JournalEntryItem, Transaction
+from api.services.transaction_services import TransactionFilterResult
+
+
+@dataclass
+class BulkPreviewResult:
+    """Result of previewing a bulk account change."""
+    affected_count: int
+    from_account: Account
+    to_account: Account
+
+
+@dataclass
+class BulkUpdateResult:
+    """Result of applying a bulk account change."""
+    success: bool
+    updated_count: int = 0
+    error: Optional[str] = None
+
+
+def search_transactions(
+    description: Optional[str] = None,
+    date_from: Optional[datetime.date] = None,
+    date_to: Optional[datetime.date] = None,
+    accounts: Optional[List[Account]] = None,
+    transaction_types: Optional[List[str]] = None,
+    is_closed: Optional[bool] = None,
+    related_accounts: Optional[List[Account]] = None,
+) -> TransactionFilterResult:
+    """
+    Searches transactions by various criteria.
+
+    Builds a queryset from Transaction.objects, applying filters.
+    Uses filter_for_table() for all standard filters including related_accounts,
+    then applies additional filters for description.
+
+    Args:
+        description: Case-insensitive substring match on transaction description
+        date_from: Start date filter (inclusive)
+        date_to: End date filter (inclusive)
+        accounts: Filter by transaction account
+        transaction_types: Filter by transaction type
+        is_closed: Filter by closed status
+        related_accounts: Filter by related accounts in journal entries
+
+    Returns:
+        TransactionFilterResult with matching transactions and count
+    """
+    queryset = Transaction.objects.filter_for_table(
+        is_closed=is_closed,
+        transaction_types=transaction_types,
+        accounts=accounts,
+        date_from=date_from,
+        date_to=date_to,
+        related_accounts=related_accounts,
+    )
+
+    if description:
+        queryset = queryset.filter(description__icontains=description)
+
+    queryset = queryset.prefetch_related(
+        "journal_entry__journal_entry_items__account",
+        "journal_entry__journal_entry_items__entity",
+    ).select_related("account")
+
+    transactions = list(queryset)
+    return TransactionFilterResult(transactions=transactions, count=len(transactions))
+
+
+def preview_bulk_account_change(
+    transactions: List[Transaction],
+    from_account: Account,
+    to_account: Account,
+) -> BulkPreviewResult:
+    """
+    Previews how many JournalEntryItems would be affected by a bulk account change.
+
+    Args:
+        transactions: List of transactions to scope the change to
+        from_account: Account to change FROM
+        to_account: Account to change TO
+
+    Returns:
+        BulkPreviewResult with affected count and account objects
+    """
+    transaction_ids = [t.pk for t in transactions]
+    affected_count = JournalEntryItem.objects.filter(
+        journal_entry__transaction_id__in=transaction_ids,
+        account_id=from_account.pk,
+    ).count()
+
+    return BulkPreviewResult(
+        affected_count=affected_count,
+        from_account=from_account,
+        to_account=to_account,
+    )
+
+
+@db_transaction.atomic
+def apply_bulk_account_change(
+    transactions: List[Transaction],
+    from_account_id: int,
+    to_account_id: int,
+) -> BulkUpdateResult:
+    """
+    Applies a bulk account change to JournalEntryItems.
+
+    Updates all JEIs matching the FROM account within the given transactions
+    to use the TO account instead.
+
+    Args:
+        transactions: List of transactions to scope the change to
+        from_account_id: Account ID to change FROM
+        to_account_id: Account ID to change TO
+
+    Returns:
+        BulkUpdateResult with count of updated rows
+    """
+    transaction_ids = [t.pk for t in transactions]
+    updated_count = JournalEntryItem.objects.filter(
+        journal_entry__transaction_id__in=transaction_ids,
+        account_id=from_account_id,
+    ).update(account_id=to_account_id)
+
+    return BulkUpdateResult(success=True, updated_count=updated_count)

--- a/api/tests/services/test_search_services.py
+++ b/api/tests/services/test_search_services.py
@@ -1,0 +1,325 @@
+import datetime
+from decimal import Decimal
+
+from django.test import TestCase
+
+from api.models import (
+    Account,
+    JournalEntryItem,
+    Transaction,
+)
+from api.services.search_services import (
+    apply_bulk_account_change,
+    preview_bulk_account_change,
+    search_transactions,
+)
+from api.tests.testing_factories import (
+    AccountFactory,
+    EntityFactory,
+    JournalEntryFactory,
+    JournalEntryItemFactory,
+    TransactionFactory,
+)
+
+
+class SearchTransactionsTests(TestCase):
+    def setUp(self):
+        self.account_checking = AccountFactory(
+            name="Checking",
+            type=Account.Type.ASSET,
+            sub_type=Account.SubType.CASH,
+            is_closed=False,
+        )
+        self.account_groceries = AccountFactory(
+            name="Groceries",
+            type=Account.Type.EXPENSE,
+            sub_type=Account.SubType.PURCHASES,
+            is_closed=False,
+        )
+        self.account_premium_groceries = AccountFactory(
+            name="Premium Groceries",
+            type=Account.Type.EXPENSE,
+            sub_type=Account.SubType.PURCHASES,
+            is_closed=False,
+        )
+        self.entity = EntityFactory(name="Whole Foods")
+
+        # Create transactions with JEs and JEIs
+        self.txn1 = TransactionFactory(
+            description="Whole Foods Market",
+            category="Groceries",
+            account=self.account_checking,
+            amount=Decimal("-50.00"),
+            date=datetime.date(2025, 1, 15),
+            is_closed=True,
+            type=Transaction.TransactionType.PURCHASE,
+        )
+        je1 = JournalEntryFactory(transaction=self.txn1, date=self.txn1.date)
+        JournalEntryItemFactory(
+            journal_entry=je1,
+            account=self.account_groceries,
+            type=JournalEntryItem.JournalEntryType.DEBIT,
+            amount=Decimal("50.00"),
+            entity=self.entity,
+        )
+        JournalEntryItemFactory(
+            journal_entry=je1,
+            account=self.account_checking,
+            type=JournalEntryItem.JournalEntryType.CREDIT,
+            amount=Decimal("50.00"),
+        )
+
+        self.txn2 = TransactionFactory(
+            description="Trader Joes",
+            category="Groceries",
+            account=self.account_checking,
+            amount=Decimal("-30.00"),
+            date=datetime.date(2025, 2, 10),
+            is_closed=True,
+            type=Transaction.TransactionType.PURCHASE,
+        )
+        je2 = JournalEntryFactory(transaction=self.txn2, date=self.txn2.date)
+        JournalEntryItemFactory(
+            journal_entry=je2,
+            account=self.account_groceries,
+            type=JournalEntryItem.JournalEntryType.DEBIT,
+            amount=Decimal("30.00"),
+        )
+        JournalEntryItemFactory(
+            journal_entry=je2,
+            account=self.account_checking,
+            type=JournalEntryItem.JournalEntryType.CREDIT,
+            amount=Decimal("30.00"),
+        )
+
+        self.txn3 = TransactionFactory(
+            description="Amazon Purchase",
+            category="Shopping",
+            account=self.account_checking,
+            amount=Decimal("-100.00"),
+            date=datetime.date(2025, 3, 5),
+            is_closed=False,
+            type=Transaction.TransactionType.PURCHASE,
+        )
+
+    def test_search_by_description(self):
+        result = search_transactions(description="whole foods")
+        self.assertEqual(result.count, 1)
+        self.assertEqual(result.transactions[0], self.txn1)
+
+    def test_search_by_jei_account(self):
+        result = search_transactions(related_accounts=[self.account_groceries])
+        self.assertEqual(result.count, 2)
+
+    def test_search_by_date_range(self):
+        result = search_transactions(
+            date_from=datetime.date(2025, 2, 1),
+            date_to=datetime.date(2025, 2, 28),
+        )
+        self.assertEqual(result.count, 1)
+        self.assertEqual(result.transactions[0], self.txn2)
+
+    def test_search_combined_filters(self):
+        result = search_transactions(
+            description="whole",
+            related_accounts=[self.account_groceries],
+        )
+        self.assertEqual(result.count, 1)
+        self.assertEqual(result.transactions[0], self.txn1)
+
+    def test_search_no_results(self):
+        result = search_transactions(description="nonexistent")
+        self.assertEqual(result.count, 0)
+
+class PreviewBulkAccountChangeTests(TestCase):
+    def setUp(self):
+        self.account_checking = AccountFactory(
+            name="Checking",
+            type=Account.Type.ASSET,
+            sub_type=Account.SubType.CASH,
+            is_closed=False,
+        )
+        self.account_groceries = AccountFactory(
+            name="Groceries",
+            type=Account.Type.EXPENSE,
+            sub_type=Account.SubType.PURCHASES,
+            is_closed=False,
+        )
+        self.account_premium = AccountFactory(
+            name="Premium Groceries",
+            type=Account.Type.EXPENSE,
+            sub_type=Account.SubType.PURCHASES,
+            is_closed=False,
+        )
+
+        self.txn1 = TransactionFactory(
+            account=self.account_checking,
+            amount=Decimal("-50.00"),
+            is_closed=True,
+            type=Transaction.TransactionType.PURCHASE,
+        )
+        je1 = JournalEntryFactory(transaction=self.txn1, date=self.txn1.date)
+        JournalEntryItemFactory(
+            journal_entry=je1,
+            account=self.account_groceries,
+            type=JournalEntryItem.JournalEntryType.DEBIT,
+            amount=Decimal("50.00"),
+        )
+        JournalEntryItemFactory(
+            journal_entry=je1,
+            account=self.account_checking,
+            type=JournalEntryItem.JournalEntryType.CREDIT,
+            amount=Decimal("50.00"),
+        )
+
+        self.txn2 = TransactionFactory(
+            account=self.account_checking,
+            amount=Decimal("-30.00"),
+            is_closed=True,
+            type=Transaction.TransactionType.PURCHASE,
+        )
+        je2 = JournalEntryFactory(transaction=self.txn2, date=self.txn2.date)
+        JournalEntryItemFactory(
+            journal_entry=je2,
+            account=self.account_groceries,
+            type=JournalEntryItem.JournalEntryType.DEBIT,
+            amount=Decimal("30.00"),
+        )
+        JournalEntryItemFactory(
+            journal_entry=je2,
+            account=self.account_checking,
+            type=JournalEntryItem.JournalEntryType.CREDIT,
+            amount=Decimal("30.00"),
+        )
+
+    def test_preview_returns_correct_count(self):
+        result = preview_bulk_account_change(
+            transactions=[self.txn1, self.txn2],
+            from_account=self.account_groceries,
+            to_account=self.account_premium,
+        )
+        self.assertEqual(result.affected_count, 2)
+        self.assertEqual(result.from_account, self.account_groceries)
+        self.assertEqual(result.to_account, self.account_premium)
+
+    def test_preview_scoped_to_transactions(self):
+        """Only counts JEIs within the provided transactions."""
+        result = preview_bulk_account_change(
+            transactions=[self.txn1],
+            from_account=self.account_groceries,
+            to_account=self.account_premium,
+        )
+        self.assertEqual(result.affected_count, 1)
+
+    def test_preview_no_matches(self):
+        result = preview_bulk_account_change(
+            transactions=[self.txn1, self.txn2],
+            from_account=self.account_premium,
+            to_account=self.account_groceries,
+        )
+        self.assertEqual(result.affected_count, 0)
+
+
+class ApplyBulkAccountChangeTests(TestCase):
+    def setUp(self):
+        self.account_checking = AccountFactory(
+            name="Checking",
+            type=Account.Type.ASSET,
+            sub_type=Account.SubType.CASH,
+            is_closed=False,
+        )
+        self.account_groceries = AccountFactory(
+            name="Groceries",
+            type=Account.Type.EXPENSE,
+            sub_type=Account.SubType.PURCHASES,
+            is_closed=False,
+        )
+        self.account_premium = AccountFactory(
+            name="Premium Groceries",
+            type=Account.Type.EXPENSE,
+            sub_type=Account.SubType.PURCHASES,
+            is_closed=False,
+        )
+
+        self.txn1 = TransactionFactory(
+            account=self.account_checking,
+            amount=Decimal("-50.00"),
+            is_closed=True,
+            type=Transaction.TransactionType.PURCHASE,
+        )
+        je1 = JournalEntryFactory(transaction=self.txn1, date=self.txn1.date)
+        self.jei_groceries_1 = JournalEntryItemFactory(
+            journal_entry=je1,
+            account=self.account_groceries,
+            type=JournalEntryItem.JournalEntryType.DEBIT,
+            amount=Decimal("50.00"),
+        )
+        self.jei_checking_1 = JournalEntryItemFactory(
+            journal_entry=je1,
+            account=self.account_checking,
+            type=JournalEntryItem.JournalEntryType.CREDIT,
+            amount=Decimal("50.00"),
+        )
+
+        self.txn2 = TransactionFactory(
+            account=self.account_checking,
+            amount=Decimal("-30.00"),
+            is_closed=True,
+            type=Transaction.TransactionType.PURCHASE,
+        )
+        je2 = JournalEntryFactory(transaction=self.txn2, date=self.txn2.date)
+        self.jei_groceries_2 = JournalEntryItemFactory(
+            journal_entry=je2,
+            account=self.account_groceries,
+            type=JournalEntryItem.JournalEntryType.DEBIT,
+            amount=Decimal("30.00"),
+        )
+        self.jei_checking_2 = JournalEntryItemFactory(
+            journal_entry=je2,
+            account=self.account_checking,
+            type=JournalEntryItem.JournalEntryType.CREDIT,
+            amount=Decimal("30.00"),
+        )
+
+    def test_apply_updates_matching_jeis(self):
+        result = apply_bulk_account_change(
+            transactions=[self.txn1, self.txn2],
+            from_account_id=self.account_groceries.pk,
+            to_account_id=self.account_premium.pk,
+        )
+        self.assertTrue(result.success)
+        self.assertEqual(result.updated_count, 2)
+
+        # Verify JEIs were updated
+        self.jei_groceries_1.refresh_from_db()
+        self.jei_groceries_2.refresh_from_db()
+        self.assertEqual(self.jei_groceries_1.account, self.account_premium)
+        self.assertEqual(self.jei_groceries_2.account, self.account_premium)
+
+    def test_apply_leaves_non_matching_jeis_untouched(self):
+        apply_bulk_account_change(
+            transactions=[self.txn1, self.txn2],
+            from_account_id=self.account_groceries.pk,
+            to_account_id=self.account_premium.pk,
+        )
+
+        # Checking account JEIs should be unchanged
+        self.jei_checking_1.refresh_from_db()
+        self.jei_checking_2.refresh_from_db()
+        self.assertEqual(self.jei_checking_1.account, self.account_checking)
+        self.assertEqual(self.jei_checking_2.account, self.account_checking)
+
+    def test_apply_scoped_to_transactions(self):
+        """Only updates JEIs within the provided transactions."""
+        result = apply_bulk_account_change(
+            transactions=[self.txn1],
+            from_account_id=self.account_groceries.pk,
+            to_account_id=self.account_premium.pk,
+        )
+        self.assertEqual(result.updated_count, 1)
+
+        # txn1's JEI updated, txn2's JEI unchanged
+        self.jei_groceries_1.refresh_from_db()
+        self.jei_groceries_2.refresh_from_db()
+        self.assertEqual(self.jei_groceries_1.account, self.account_premium)
+        self.assertEqual(self.jei_groceries_2.account, self.account_groceries)

--- a/api/views/search_helpers.py
+++ b/api/views/search_helpers.py
@@ -1,0 +1,101 @@
+"""
+Helper functions for rendering search HTML.
+
+These pure functions provide testable, reusable rendering
+that takes data and returns HTML strings.
+"""
+
+from typing import List, Optional
+
+from django.template.loader import render_to_string
+
+from api.forms import SearchFilterForm
+from api.models import Account, JournalEntryItem, Transaction
+
+
+def render_search_filter_form(get_url: str) -> str:
+    """Renders the search filter form HTML."""
+    form = SearchFilterForm()
+    return render_to_string(
+        "api/filter_forms/search-filter-form.html",
+        {"form": form, "get_url": get_url},
+    )
+
+
+def render_search_results_table(
+    transactions: List[Transaction],
+    count: int,
+) -> str:
+    """Renders the search results table HTML with JEI details."""
+    # Build per-transaction JEI data without mutating model instances
+    transactions_data = []
+    for txn in transactions:
+        je = getattr(txn, "journal_entry", None)
+        if je:
+            debit_items = []
+            credit_items = []
+            entity_names = set()
+            for i in je.journal_entry_items.all():
+                if i.type == JournalEntryItem.JournalEntryType.DEBIT:
+                    debit_items.append(i)
+                else:
+                    credit_items.append(i)
+                if i.entity:
+                    entity_names.add(i.entity.name)
+            entity_names = sorted(entity_names)
+        else:
+            debit_items = []
+            credit_items = []
+            entity_names = []
+
+        transactions_data.append({
+            "transaction": txn,
+            "debit_items": debit_items,
+            "credit_items": credit_items,
+            "entity_names": entity_names,
+        })
+
+    return render_to_string(
+        "api/tables/search-results-table.html",
+        {"transactions_data": transactions_data, "count": count},
+    )
+
+
+def render_bulk_action_form(accounts: List[Account]) -> str:
+    """Renders the FROM/TO account dropdowns for bulk update."""
+    return render_to_string(
+        "api/entry_forms/bulk-account-change-form.html",
+        {"accounts": accounts},
+    )
+
+
+def render_bulk_preview(
+    affected_count: int,
+    from_account: Account,
+    to_account: Account,
+) -> str:
+    """Renders the bulk update preview/confirmation message."""
+    return render_to_string(
+        "api/components/bulk-preview.html",
+        {
+            "affected_count": affected_count,
+            "from_account": from_account,
+            "to_account": to_account,
+        },
+    )
+
+
+def render_search_content(
+    table_html: str,
+    bulk_form_html: Optional[str] = None,
+    success_message: Optional[str] = None,
+) -> str:
+    """Renders the full search content area (table + bulk form)."""
+    return render_to_string(
+        "api/content/search-content.html",
+        {
+            "table": table_html,
+            "bulk_form": bulk_form_html,
+            "success_message": success_message,
+        },
+    )

--- a/api/views/search_views.py
+++ b/api/views/search_views.py
@@ -1,0 +1,135 @@
+"""
+Search views for HTTP orchestration.
+
+Views handle HTTP requests/responses only, delegating business logic to
+services and rendering to helpers.
+"""
+
+from django.contrib.auth.mixins import LoginRequiredMixin
+from django.http import HttpResponse
+from django.template.loader import render_to_string
+from django.urls import reverse
+from django.views import View
+
+from api.forms import BulkAccountChangeForm, SearchFilterForm
+from api.models import Account
+from api.services import search_services
+from api.services.transaction_services import TransactionFilterResult
+from api.views import search_helpers
+
+
+def _get_search_results_from_form(form):
+    """Parse a SearchFilterForm and return matching transactions via service."""
+    data = form.cleaned_data
+    return search_services.search_transactions(
+        description=data.get("description"),
+        date_from=data.get("date_from"),
+        date_to=data.get("date_to"),
+        accounts=data.get("account") or None,
+        transaction_types=data.get("transaction_type") or None,
+        is_closed=True,
+        related_accounts=data.get("related_account") or None,
+    )
+
+
+def _render_search_content_response(search_result, success_message=None):
+    """Shared rendering for search results + bulk form."""
+    table_html = search_helpers.render_search_results_table(
+        transactions=search_result.transactions,
+        count=search_result.count,
+    )
+    accounts = Account.objects.filter(is_closed=False).order_by("name")
+    bulk_form_html = search_helpers.render_bulk_action_form(accounts=accounts)
+    return search_helpers.render_search_content(
+        table_html=table_html,
+        bulk_form_html=bulk_form_html,
+        success_message=success_message,
+    )
+
+
+class SearchView(LoginRequiredMixin, View):
+    """Full page render with filter form + empty content."""
+    login_url = "/login/"
+
+    def get(self, request):
+        filter_form_html = search_helpers.render_search_filter_form(
+            get_url=reverse("search-content"),
+        )
+        context = {
+            "filter_form": filter_form_html,
+            "search_content": "",
+        }
+        html = render_to_string("api/views/search.html", context)
+        return HttpResponse(html)
+
+
+class SearchContentView(LoginRequiredMixin, View):
+    """HTMX target: renders search results + bulk form from filter params."""
+
+    def get(self, request):
+        form = SearchFilterForm(request.GET)
+        if form.is_valid():
+            result = _get_search_results_from_form(form)
+        else:
+            result = TransactionFilterResult(transactions=[], count=0)
+
+        html = _render_search_content_response(result)
+        return HttpResponse(html)
+
+
+class SearchBulkUpdateView(LoginRequiredMixin, View):
+    """Handles preview and apply actions for bulk account changes."""
+
+    def post(self, request):
+        action = request.POST.get("action")
+
+        # Re-derive transactions from filter params (prevents tampering)
+        filter_form = SearchFilterForm(request.POST)
+        if filter_form.is_valid():
+            search_result = _get_search_results_from_form(filter_form)
+        else:
+            search_result = TransactionFilterResult(transactions=[], count=0)
+
+        bulk_form = BulkAccountChangeForm(request.POST)
+        if not bulk_form.is_valid():
+            errors = bulk_form.errors.as_text()
+            return HttpResponse(f'<div class="alert alert-danger mt-2">{errors}</div>')
+
+        from_account = bulk_form.cleaned_data["from_account"]
+        to_account = bulk_form.cleaned_data["to_account"]
+
+        if action == "preview":
+            preview_result = search_services.preview_bulk_account_change(
+                transactions=search_result.transactions,
+                from_account=from_account,
+                to_account=to_account,
+            )
+            html = search_helpers.render_bulk_preview(
+                affected_count=preview_result.affected_count,
+                from_account=preview_result.from_account,
+                to_account=preview_result.to_account,
+            )
+            return HttpResponse(html)
+
+        elif action == "apply":
+            update_result = search_services.apply_bulk_account_change(
+                transactions=search_result.transactions,
+                from_account_id=from_account.pk,
+                to_account_id=to_account.pk,
+            )
+
+            if not update_result.success:
+                return HttpResponse(
+                    f'<div class="alert alert-danger">{update_result.error}</div>',
+                    status=400,
+                )
+
+            # Re-query to show updated results
+            search_result = _get_search_results_from_form(filter_form)
+            html = _render_search_content_response(
+                search_result,
+                success_message=f"Updated {update_result.updated_count} journal entry items.",
+            )
+            return HttpResponse(html)
+
+        return HttpResponse("Invalid action", status=400)

--- a/ledger/templates/api/components/bulk-preview.html
+++ b/ledger/templates/api/components/bulk-preview.html
@@ -1,0 +1,24 @@
+{% if affected_count > 0 %}
+<div class="alert alert-warning mt-2" role="alert">
+    <strong>{{ affected_count }}</strong> journal entry item{{ affected_count|pluralize }} will be changed from
+    <strong>{{ from_account.name }}</strong> to <strong>{{ to_account.name }}</strong>.
+    <br>
+    <button
+        type="button"
+        class="btn btn-danger mt-2"
+        hx-post="{% url 'search-bulk-update' %}"
+        hx-include="#search-filter-form, #bulk-account-change-form"
+        hx-target="#search-content"
+        hx-swap="innerHTML"
+        hx-confirm="Update {{ affected_count }} journal entry items from {{ from_account.name }} to {{ to_account.name }}?"
+        name="action"
+        value="apply"
+    >
+        Confirm Update
+    </button>
+</div>
+{% else %}
+<div class="alert alert-info mt-2" role="alert">
+    No journal entry items match the selected FROM account within the current search results.
+</div>
+{% endif %}

--- a/ledger/templates/api/components/nav.html
+++ b/ledger/templates/api/components/nav.html
@@ -30,6 +30,9 @@
                 <li class="nav-item {% if request.resolver_match.url_name == 'upload-transactions' %}active{% endif %}">
                     <a class="nav-link" href="{% url 'upload-transactions' %}" hx-get="{% url 'upload-transactions' %}" hx-target="#container">Upload/Download</a>
                 </li>
+                <li class="nav-item {% if request.resolver_match.url_name == 'search' %}active{% endif %}">
+                    <a class="nav-link" href="{% url 'search' %}" hx-get="{% url 'search' %}" hx-target="#container">Search</a>
+                </li>
                 <!-- Dropdown Menu for Financial Statements -->
                 <li class="nav-item dropdown">
                     <a class="nav-link dropdown-toggle" href="#" id="navbarDropdownMenuLink" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">

--- a/ledger/templates/api/content/search-content.html
+++ b/ledger/templates/api/content/search-content.html
@@ -1,0 +1,15 @@
+{{ table }}
+
+{% if success_message %}
+<div class="alert alert-success mt-2" role="alert">
+    {{ success_message }}
+</div>
+{% endif %}
+
+{% if bulk_form %}
+<hr>
+<h5>Bulk Account Change</h5>
+{{ bulk_form }}
+
+<div id="bulk-preview"></div>
+{% endif %}

--- a/ledger/templates/api/entry_forms/bulk-account-change-form.html
+++ b/ledger/templates/api/entry_forms/bulk-account-change-form.html
@@ -1,0 +1,41 @@
+<form id="bulk-account-change-form" method="post">
+    {% csrf_token %}
+    <div class="row g-3 align-items-end">
+        <div class="col-md-3">
+            <div class="form-group">
+                <label for="id_from_account">FROM Account</label>
+                <select name="from_account" id="id_from_account" class="form-control">
+                    <option value="">---------</option>
+                    {% for account in accounts %}
+                        <option value="{{ account.pk }}">{{ account.name }}</option>
+                    {% endfor %}
+                </select>
+            </div>
+        </div>
+        <div class="col-md-3">
+            <div class="form-group">
+                <label for="id_to_account">TO Account</label>
+                <select name="to_account" id="id_to_account" class="form-control">
+                    <option value="">---------</option>
+                    {% for account in accounts %}
+                        <option value="{{ account.pk }}">{{ account.name }}</option>
+                    {% endfor %}
+                </select>
+            </div>
+        </div>
+        <div class="col-md-3">
+            <button
+                type="button"
+                class="btn btn-warning"
+                hx-post="{% url 'search-bulk-update' %}"
+                hx-include="#search-filter-form, #bulk-account-change-form"
+                hx-target="#bulk-preview"
+                hx-swap="innerHTML"
+                name="action"
+                value="preview"
+            >
+                Preview
+            </button>
+        </div>
+    </div>
+</form>

--- a/ledger/templates/api/filter_forms/search-filter-form.html
+++ b/ledger/templates/api/filter_forms/search-filter-form.html
@@ -1,0 +1,82 @@
+<form
+    id="search-filter-form"
+    method="get"
+    hx-get="{{ get_url }}"
+    hx-target="#search-content"
+    hx-trigger="submit"
+    hx-swap="innerHTML"
+    class="mb-3 form-sm"
+>
+    <div class="row g-3">
+        <!-- Description -->
+        <div class="col-md-2">
+            <div class="form-group">
+                <label for="id_description">Description</label>
+                <input type="text" name="description" id="id_description" class="form-control"
+                       value="{{ form.description.value|default_if_none:'' }}">
+            </div>
+        </div>
+
+        <!-- Date From and Date To -->
+        <div class="col-md-2">
+            <div class="form-group mb-2">
+                <label for="id_date_from">Date From</label>
+                <input type="date" name="date_from" id="id_date_from" class="form-control"
+                       value="{{ form.date_from.value|default_if_none:'' }}">
+            </div>
+            <div class="form-group">
+                <label for="id_date_to">Date To</label>
+                <input type="date" name="date_to" id="id_date_to" class="form-control"
+                       value="{{ form.date_to.value|default_if_none:'' }}">
+            </div>
+        </div>
+
+        <!-- Transaction Account -->
+        <div class="col-md-3">
+            <div class="form-group">
+                <label for="id_account">Account</label>
+                <select name="account" id="id_account" class="form-control" multiple>
+                    {% for account in form.account.field.queryset %}
+                        <option value="{{ account.pk }}" {% if account.pk|stringformat:"s" in form.account.value %}selected{% endif %}>
+                            {{ account }}
+                        </option>
+                    {% endfor %}
+                </select>
+            </div>
+        </div>
+
+        <!-- Related Account -->
+        <div class="col-md-3">
+            <div class="form-group">
+                <label for="id_related_account">Related Account</label>
+                <select name="related_account" id="id_related_account" class="form-control" multiple>
+                    {% for account in form.related_account.field.queryset %}
+                        <option value="{{ account.pk }}" {% if account.pk|stringformat:"s" in form.related_account.value %}selected{% endif %}>
+                            {{ account }}
+                        </option>
+                    {% endfor %}
+                </select>
+            </div>
+        </div>
+
+        <!-- Type -->
+        <div class="col-md-2">
+            <div class="form-group">
+                <label for="id_transaction_type">Type</label>
+                <select name="transaction_type" id="id_transaction_type" class="form-control" multiple>
+                    {% for choice in form.transaction_type.field.choices %}
+                        <option value="{{ choice.0 }}" {% if choice.0 in form.transaction_type.value %}selected{% endif %}>
+                            {{ choice.1 }}
+                        </option>
+                    {% endfor %}
+                </select>
+            </div>
+        </div>
+    </div>
+
+    <div class="row mt-2">
+        <div class="col">
+            <button type="submit" class="btn btn-primary">Search</button>
+        </div>
+    </div>
+</form>

--- a/ledger/templates/api/tables/search-results-table.html
+++ b/ledger/templates/api/tables/search-results-table.html
@@ -1,0 +1,48 @@
+{% load humanize %}
+<div class="row">
+    <div class="col">
+        <p class="text-muted">{{ count }} transaction{{ count|pluralize }} found</p>
+        <div id="search-results-table" class="table-responsive" style="max-height: 400px; overflow-y: auto;">
+            <table class="table table-hover table-sm">
+                <thead>
+                    <tr>
+                        <th style="position: sticky; top: 0; background: white; z-index: 10;">Date</th>
+                        <th style="position: sticky; top: 0; background: white; z-index: 10;">Account</th>
+                        <th style="position: sticky; top: 0; background: white; z-index: 10;">Amount</th>
+                        <th style="position: sticky; top: 0; background: white; z-index: 10;">Description</th>
+                        <th style="position: sticky; top: 0; background: white; z-index: 10;">Category</th>
+                        <th style="position: sticky; top: 0; background: white; z-index: 10;">DR Accounts</th>
+                        <th style="position: sticky; top: 0; background: white; z-index: 10;">CR Accounts</th>
+                        <th style="position: sticky; top: 0; background: white; z-index: 10;">Entities</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    {% for row in transactions_data %}
+                    <tr>
+                        <td>{{ row.transaction.date }}</td>
+                        <td>{{ row.transaction.account }}</td>
+                        <td>${{ row.transaction.amount|floatformat:2|intcomma }}</td>
+                        <td>{{ row.transaction.description }}</td>
+                        <td>{{ row.transaction.category }}</td>
+                        <td>
+                            {% for jei in row.debit_items %}
+                                {{ jei.account.name }}{% if not forloop.last %}, {% endif %}
+                            {% endfor %}
+                        </td>
+                        <td>
+                            {% for jei in row.credit_items %}
+                                {{ jei.account.name }}{% if not forloop.last %}, {% endif %}
+                            {% endfor %}
+                        </td>
+                        <td>
+                            {% for entity_name in row.entity_names %}
+                                {{ entity_name }}{% if not forloop.last %}, {% endif %}
+                            {% endfor %}
+                        </td>
+                    </tr>
+                    {% endfor %}
+                </tbody>
+            </table>
+        </div>
+    </div>
+</div>

--- a/ledger/templates/api/views/search.html
+++ b/ledger/templates/api/views/search.html
@@ -1,0 +1,7 @@
+<h2>Search & Bulk Update</h2>
+
+{{ filter_form }}
+
+<div id="search-content">
+    {{ search_content }}
+</div>

--- a/ledger/urls.py
+++ b/ledger/urls.py
@@ -25,6 +25,7 @@ from api.views.journal_entry_views import (
     TriggerAutoTagView,
 )
 from api.views.reconciliation_views import ReconciliationTableView, ReconciliationView
+from api.views.search_views import SearchBulkUpdateView, SearchContentView, SearchView
 from api.views.statement_views import StatementDetailView, StatementView
 from api.views.tax_views import TaxChargeFormView, TaxChargeTableView, TaxesView
 from api.views.transaction_views import (
@@ -130,6 +131,10 @@ urlpatterns = [
         AmortizeFormView.as_view(),
         name="amortize-form",
     ),
+    # Search & Bulk Update
+    path("search/", SearchView.as_view(), name="search"),
+    path("search/content/", SearchContentView.as_view(), name="search-content"),
+    path("search/bulk-update/", SearchBulkUpdateView.as_view(), name="search-bulk-update"),
     # Tagging balances
     path(
         "tag/journal-entry-item/<int:journal_entry_item_id>/",


### PR DESCRIPTION
## Summary
- **S3File admin**: Added `list_display` with `user_filename`, `prefill`, `analysis_complete` columns
- **Paystub admin**: Added `PaystubValueInline` for inline viewing/editing of parsed values
- **Search page**: New HTMX search view with filters (description, date, account, type, related account) and bulk account change (preview + apply) for JournalEntryItems
- **BaseFilterForm**: Extracted shared fields from `SearchFilterForm` and `TransactionFilterForm` to eliminate duplication

## Test plan
- [ ] `python manage.py test` — all 313 tests pass
- [ ] `/admin/api/s3file/` — confirm three new columns visible
- [ ] `/admin/api/paystub/` → click any paystub → confirm PaystubValue inline table
- [ ] `/search/` — filter transactions, verify results table with JEI details
- [ ] `/search/` — bulk account change: preview shows affected count, apply updates JEIs

🤖 Generated with [Claude Code](https://claude.com/claude-code)