### PR TITLE
Group balances by account with hide-zero toggle

### DIFF
--- a/api/services/entity_services.py
+++ b/api/services/entity_services.py
@@ -29,6 +29,28 @@ class EntityBalance:
 
 
 @dataclass
+class AccountEntityBalance:
+    """Entity balance scoped to a specific account."""
+    account_id: int
+    account_name: str
+    entity_id: int
+    entity_name: str
+    total_debits: Decimal
+    total_credits: Decimal
+    balance: Decimal
+
+
+@dataclass
+class GroupedEntityBalances:
+    """Entity balances for a single account, for grouped display."""
+    account_id: int
+    account_name: str
+    net_balance: Decimal
+    rows: List[AccountEntityBalance]
+    zero_count: int  # number of $0-balance entities not in rows
+
+
+@dataclass
 class EntityHistoryItem:
     """A journal entry item with its running balance for display."""
     journal_entry_item: JournalEntryItem
@@ -40,6 +62,8 @@ class EntityHistoryData:
     """Entity history with all items and running balances."""
     items: List[EntityHistoryItem]
     entity_id: int
+    entity_name: str = ""
+    account_name: Optional[str] = None
 
 
 @dataclass
@@ -107,6 +131,98 @@ def get_entities_balances() -> List[EntityBalance]:
     ]
 
 
+def get_grouped_entities_balances(hide_zero: bool = True) -> List[GroupedEntityBalances]:
+    """
+    Gets entity balances grouped by account for all AR-type accounts.
+
+    Returns one GroupedEntityBalances per account, ordered by account name.
+    Within each group, rows are ordered by absolute balance (desc), then by
+    most recent activity. When hide_zero is True, $0-balance entities are
+    excluded from rows but their count is tracked in zero_count.
+    """
+    zero_eps = Decimal("0.005")
+
+    qs = (
+        JournalEntryItem.objects.filter(
+            account__sub_type__in=[Account.SubType.ACCOUNTS_RECEIVABLE]
+        )
+        .exclude(entity__isnull=True)
+        .values(
+            "account__id",
+            "account__name",
+            "entity__id",
+            "entity__name",
+        )
+        .annotate(
+            total_debits=Sum(
+                Case(
+                    When(
+                        type=JournalEntryItem.JournalEntryType.DEBIT,
+                        then=F("amount"),
+                    ),
+                    default=Value(0),
+                    output_field=DecimalField(),
+                )
+            ),
+            total_credits=Sum(
+                Case(
+                    When(
+                        type=JournalEntryItem.JournalEntryType.CREDIT,
+                        then=F("amount"),
+                    ),
+                    default=Value(0),
+                    output_field=DecimalField(),
+                )
+            ),
+            balance=F("total_credits") - F("total_debits"),
+            abs_balance=Abs(F("balance")),
+            last_activity=Max("journal_entry__date"),
+        )
+        .order_by("account__name", "-abs_balance", "-last_activity")
+    )
+
+    raw_groups: dict = {}
+    for row in qs:
+        acct_key = (row["account__id"], row["account__name"])
+        if acct_key not in raw_groups:
+            raw_groups[acct_key] = []
+        raw_groups[acct_key].append(
+            AccountEntityBalance(
+                account_id=row["account__id"],
+                account_name=row["account__name"],
+                entity_id=row["entity__id"],
+                entity_name=row["entity__name"],
+                total_debits=row["total_debits"] or Decimal("0.00"),
+                total_credits=row["total_credits"] or Decimal("0.00"),
+                balance=row["balance"] or Decimal("0.00"),
+            )
+        )
+
+    result = []
+    for (acct_id, acct_name), all_rows in raw_groups.items():
+        net_balance = Decimal("0.00")
+        nonzero_rows = []
+        zero_count = 0
+        for r in all_rows:
+            net_balance += r.balance
+            if abs(r.balance) < zero_eps:
+                zero_count += 1
+            else:
+                nonzero_rows.append(r)
+
+        result.append(
+            GroupedEntityBalances(
+                account_id=acct_id,
+                account_name=acct_name,
+                net_balance=net_balance,
+                rows=nonzero_rows if hide_zero else all_rows,
+                zero_count=zero_count if hide_zero else 0,
+            )
+        )
+
+    return result
+
+
 def get_untagged_journal_entry_items() -> UntaggedItemsData:
     """
     Gets journal entry items without an assigned entity.
@@ -131,21 +247,24 @@ def get_untagged_journal_entry_items() -> UntaggedItemsData:
     return UntaggedItemsData(items=untagged_items, first_item=first_item)
 
 
-def get_entity_history(entity_id: int) -> EntityHistoryData:
+def get_entity_history(
+    entity_id: int, account_id: Optional[int] = None
+) -> EntityHistoryData:
     """
     Gets the transaction history for an entity with running balances.
 
-    Returns all journal entry items for the entity, ordered by date,
-    with calculated running balance for each item.
+    When account_id is supplied, history is scoped to that account only.
+    Returns items ordered by date with a calculated running balance.
     """
+    qs = JournalEntryItem.objects.filter(
+        entity__pk=entity_id,
+        account__sub_type__in=[Account.SubType.ACCOUNTS_RECEIVABLE],
+    )
+    if account_id is not None:
+        qs = qs.filter(account__pk=account_id)
+
     journal_entry_items = list(
-        JournalEntryItem.objects.filter(
-            entity__pk=entity_id,
-            account__sub_type__in=[
-                Account.SubType.ACCOUNTS_RECEIVABLE,
-            ],
-        )
-        .select_related("journal_entry__transaction")
+        qs.select_related("journal_entry__transaction", "account", "entity")
         .order_by("journal_entry__date")
     )
 
@@ -165,7 +284,21 @@ def get_entity_history(entity_id: int) -> EntityHistoryData:
             )
         )
 
-    return EntityHistoryData(items=history_items, entity_id=entity_id)
+    entity_name = (
+        journal_entry_items[0].entity.name if journal_entry_items else ""
+    )
+    account_name = (
+        journal_entry_items[0].account.name
+        if journal_entry_items and account_id is not None
+        else None
+    )
+
+    return EntityHistoryData(
+        items=history_items,
+        entity_id=entity_id,
+        entity_name=entity_name,
+        account_name=account_name,
+    )
 
 
 @db_transaction.atomic

--- a/api/tests/services/test_entity_services.py
+++ b/api/tests/services/test_entity_services.py
@@ -7,9 +7,11 @@ from api.services.entity_services import (
     EntityBalance,
     EntityHistoryData,
     EntityHistoryItem,
+    GroupedEntityBalances,
     UntaggedItemsData,
     get_entities_balances,
     get_entity_history,
+    get_grouped_entities_balances,
     get_untagged_journal_entry_items,
     tag_journal_entry_item,
     untag_journal_entry_item,
@@ -142,6 +144,119 @@ class GetEntitiesBalancesTest(TestCase):
         balances = get_entities_balances()
 
         self.assertEqual(balances, [])
+
+
+class GetGroupedEntitiesBalancesTest(TestCase):
+    """Tests for get_grouped_entities_balances() function."""
+
+    def setUp(self):
+        self.ar_account = AccountFactory(
+            type=Account.Type.ASSET,
+            sub_type=Account.SubType.ACCOUNTS_RECEIVABLE,
+        )
+        self.non_ar_account = AccountFactory(
+            type=Account.Type.ASSET,
+            sub_type=Account.SubType.CASH,
+        )
+        self.entity1 = EntityFactory(name="Entity One")
+        self.entity2 = EntityFactory(name="Entity Two")
+
+    def _make_item(self, account, entity, type, amount):
+        je = JournalEntryFactory()
+        return JournalEntryItemFactory(
+            journal_entry=je, account=account, entity=entity,
+            type=type, amount=Decimal(amount),
+        )
+
+    def test_returns_grouped_entity_balances_instances(self):
+        self._make_item(self.ar_account, self.entity1, JournalEntryItem.JournalEntryType.CREDIT, "100.00")
+
+        result = get_grouped_entities_balances()
+
+        self.assertEqual(len(result), 1)
+        self.assertIsInstance(result[0], GroupedEntityBalances)
+
+    def test_groups_by_account(self):
+        ar_account2 = AccountFactory(
+            type=Account.Type.ASSET,
+            sub_type=Account.SubType.ACCOUNTS_RECEIVABLE,
+        )
+        self._make_item(self.ar_account, self.entity1, JournalEntryItem.JournalEntryType.CREDIT, "100.00")
+        self._make_item(ar_account2, self.entity2, JournalEntryItem.JournalEntryType.CREDIT, "200.00")
+
+        result = get_grouped_entities_balances()
+
+        self.assertEqual(len(result), 2)
+        account_ids = {g.account_id for g in result}
+        self.assertIn(self.ar_account.id, account_ids)
+        self.assertIn(ar_account2.id, account_ids)
+
+    def test_calculates_net_balance_per_group(self):
+        self._make_item(self.ar_account, self.entity1, JournalEntryItem.JournalEntryType.CREDIT, "100.00")
+        self._make_item(self.ar_account, self.entity2, JournalEntryItem.JournalEntryType.DEBIT, "40.00")
+
+        result = get_grouped_entities_balances(hide_zero=False)
+
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result[0].net_balance, Decimal("60.00"))
+
+    def test_hide_zero_true_excludes_zero_balance_entities(self):
+        # entity1: zero balance (credit and debit cancel)
+        je = JournalEntryFactory()
+        JournalEntryItemFactory(
+            journal_entry=je, account=self.ar_account, entity=self.entity1,
+            type=JournalEntryItem.JournalEntryType.CREDIT, amount=Decimal("50.00"),
+        )
+        JournalEntryItemFactory(
+            journal_entry=je, account=self.ar_account, entity=self.entity1,
+            type=JournalEntryItem.JournalEntryType.DEBIT, amount=Decimal("50.00"),
+        )
+        # entity2: non-zero balance
+        self._make_item(self.ar_account, self.entity2, JournalEntryItem.JournalEntryType.CREDIT, "100.00")
+
+        result = get_grouped_entities_balances(hide_zero=True)
+
+        self.assertEqual(len(result[0].rows), 1)
+        self.assertEqual(result[0].rows[0].entity_id, self.entity2.id)
+        self.assertEqual(result[0].zero_count, 1)
+
+    def test_hide_zero_false_includes_all_entities(self):
+        je = JournalEntryFactory()
+        JournalEntryItemFactory(
+            journal_entry=je, account=self.ar_account, entity=self.entity1,
+            type=JournalEntryItem.JournalEntryType.CREDIT, amount=Decimal("50.00"),
+        )
+        JournalEntryItemFactory(
+            journal_entry=je, account=self.ar_account, entity=self.entity1,
+            type=JournalEntryItem.JournalEntryType.DEBIT, amount=Decimal("50.00"),
+        )
+        self._make_item(self.ar_account, self.entity2, JournalEntryItem.JournalEntryType.CREDIT, "100.00")
+
+        result = get_grouped_entities_balances(hide_zero=False)
+
+        self.assertEqual(len(result[0].rows), 2)
+        self.assertEqual(result[0].zero_count, 0)
+
+    def test_excludes_non_ar_accounts(self):
+        self._make_item(self.non_ar_account, self.entity1, JournalEntryItem.JournalEntryType.CREDIT, "100.00")
+
+        result = get_grouped_entities_balances()
+
+        self.assertEqual(result, [])
+
+    def test_excludes_items_without_entity(self):
+        je = JournalEntryFactory()
+        JournalEntryItemFactory(
+            journal_entry=je, account=self.ar_account, entity=None,
+            type=JournalEntryItem.JournalEntryType.CREDIT, amount=Decimal("100.00"),
+        )
+
+        result = get_grouped_entities_balances()
+
+        self.assertEqual(result, [])
+
+    def test_returns_empty_when_no_data(self):
+        self.assertEqual(get_grouped_entities_balances(), [])
 
 
 class GetUntaggedJournalEntryItemsTest(TestCase):
@@ -288,6 +403,79 @@ class GetEntityHistoryTest(TestCase):
 
         self.assertEqual(result.items, [])
         self.assertEqual(result.entity_id, self.entity.id)
+
+    def test_populates_entity_name(self):
+        journal_entry = JournalEntryFactory()
+        JournalEntryItemFactory(
+            journal_entry=journal_entry,
+            account=self.ar_account,
+            entity=self.entity,
+            type=JournalEntryItem.JournalEntryType.CREDIT,
+            amount=Decimal("100.00"),
+        )
+
+        result = get_entity_history(self.entity.id)
+
+        self.assertEqual(result.entity_name, self.entity.name)
+
+    def test_entity_name_empty_when_no_items(self):
+        result = get_entity_history(self.entity.id)
+
+        self.assertEqual(result.entity_name, "")
+
+    def test_account_id_scopes_history_to_that_account(self):
+        ar_account2 = AccountFactory(
+            type=Account.Type.ASSET,
+            sub_type=Account.SubType.ACCOUNTS_RECEIVABLE,
+        )
+        je = JournalEntryFactory()
+        item_account1 = JournalEntryItemFactory(
+            journal_entry=je,
+            account=self.ar_account,
+            entity=self.entity,
+            type=JournalEntryItem.JournalEntryType.CREDIT,
+            amount=Decimal("100.00"),
+        )
+        JournalEntryItemFactory(
+            journal_entry=je,
+            account=ar_account2,
+            entity=self.entity,
+            type=JournalEntryItem.JournalEntryType.CREDIT,
+            amount=Decimal("200.00"),
+        )
+
+        result = get_entity_history(self.entity.id, account_id=self.ar_account.id)
+
+        self.assertEqual(len(result.items), 1)
+        self.assertEqual(result.items[0].journal_entry_item.id, item_account1.id)
+
+    def test_account_name_set_when_account_id_provided(self):
+        je = JournalEntryFactory()
+        JournalEntryItemFactory(
+            journal_entry=je,
+            account=self.ar_account,
+            entity=self.entity,
+            type=JournalEntryItem.JournalEntryType.CREDIT,
+            amount=Decimal("100.00"),
+        )
+
+        result = get_entity_history(self.entity.id, account_id=self.ar_account.id)
+
+        self.assertEqual(result.account_name, self.ar_account.name)
+
+    def test_account_name_none_when_no_account_id(self):
+        je = JournalEntryFactory()
+        JournalEntryItemFactory(
+            journal_entry=je,
+            account=self.ar_account,
+            entity=self.entity,
+            type=JournalEntryItem.JournalEntryType.CREDIT,
+            amount=Decimal("100.00"),
+        )
+
+        result = get_entity_history(self.entity.id)
+
+        self.assertIsNone(result.account_name)
 
     def test_returns_entity_history_items(self):
         """Test items are EntityHistoryItem instances."""

--- a/api/views/entity_helpers.py
+++ b/api/views/entity_helpers.py
@@ -11,7 +11,10 @@ from django.template.loader import render_to_string
 
 from api.forms import JournalEntryItemEntityForm
 from api.models import Entity, JournalEntryItem
-from api.services.entity_services import EntityBalance, EntityHistoryData
+from api.services.entity_services import (
+    EntityHistoryData,
+    GroupedEntityBalances,
+)
 
 
 def render_untagged_entries_table(items: List[JournalEntryItem]) -> Optional[str]:
@@ -29,37 +32,24 @@ def render_untagged_entries_table(items: List[JournalEntryItem]) -> Optional[str
     )
 
 
-def render_entity_balances_table(
-    balances: List[EntityBalance],
-    preselected_entity: Optional[Entity],
+def render_entity_grouped_balances_table(
+    grouped_balances: List[GroupedEntityBalances],
+    hide_zero: bool,
     history_html: str,
 ) -> str:
     """
-    Renders the entity balances table with optional history panel.
+    Renders the grouped entity balances table with history panel.
 
     Args:
-        balances: List of EntityBalance dataclass instances
-        preselected_entity: Entity to highlight in the table
+        grouped_balances: List of GroupedEntityBalances (one per account)
+        hide_zero: Whether $0-balance entities are currently hidden
         history_html: Pre-rendered history table HTML
     """
-    # Convert dataclass instances to dict format expected by template
-    # Template expects entity__id, entity__name, total_debits, total_credits, balance
-    balances_for_template = [
-        {
-            "entity__id": balance.entity_id,
-            "entity__name": balance.entity_name,
-            "total_debits": balance.total_debits,
-            "total_credits": balance.total_credits,
-            "balance": balance.balance,
-        }
-        for balance in balances
-    ]
-
     return render_to_string(
-        "api/tables/entity-balances-table.html",
+        "api/tables/entity-balances-grouped.html",
         {
-            "entities_balances": balances_for_template,
-            "preselected_entity": preselected_entity,
+            "grouped_balances": grouped_balances,
+            "hide_zero": hide_zero,
             "entity_history_table": history_html,
         },
     )
@@ -74,18 +64,22 @@ def render_entity_history_table(history_data: EntityHistoryData) -> str:
     if not history_data.items:
         return ""
 
-    # Transform history items to format expected by template
-    # Template expects journal_entry_items with .balance attribute
     journal_entry_items = []
     for history_item in history_data.items:
         item = history_item.journal_entry_item
-        # Attach balance to the item for template access
         item.balance = history_item.running_balance
         journal_entry_items.append(item)
 
+    final_balance = history_data.items[-1].running_balance
+
     return render_to_string(
         "api/tables/entity-history-table.html",
-        {"journal_entry_items": journal_entry_items},
+        {
+            "journal_entry_items": journal_entry_items,
+            "entity_name": history_data.entity_name,
+            "account_name": history_data.account_name,
+            "final_balance": final_balance,
+        },
     )
 
 

--- a/api/views/entity_views.py
+++ b/api/views/entity_views.py
@@ -20,6 +20,7 @@ def _render_full_page(
     is_initial_load: bool = False,
     preloaded_entity=None,
     preselected_entity=None,
+    hide_zero: bool = True,
 ) -> str:
     """
     Helper to render the full entities page.
@@ -28,10 +29,13 @@ def _render_full_page(
         is_initial_load: Whether this is the initial page load (shows header)
         preloaded_entity: Entity to pre-select in the form dropdown
         preselected_entity: Entity to highlight in the balances table
+        hide_zero: Whether to hide $0-balance entities in the grouped view
     """
     # Get data via services
     untagged = entity_services.get_untagged_journal_entry_items()
-    balances = entity_services.get_entities_balances()
+    grouped_balances = entity_services.get_grouped_entities_balances(
+        hide_zero=hide_zero
+    )
 
     # Get history if entity selected
     history_html = ""
@@ -48,8 +52,8 @@ def _render_full_page(
             untagged.first_item, preloaded_entity
         )
 
-    balances_html = entity_helpers.render_entity_balances_table(
-        balances, preselected_entity, history_html
+    balances_html = entity_helpers.render_entity_grouped_balances_table(
+        grouped_balances, hide_zero, history_html
     )
 
     return entity_helpers.render_entity_page(
@@ -76,7 +80,9 @@ class EntityHistoryTable(LoginRequiredMixin, View):
     redirect_field_name = "next"
 
     def get(self, request, entity_id):
-        history_data = entity_services.get_entity_history(entity_id)
+        account_id_str = request.GET.get("account")
+        account_id = int(account_id_str) if account_id_str else None
+        history_data = entity_services.get_entity_history(entity_id, account_id)
         html = entity_helpers.render_entity_history_table(history_data)
         return HttpResponse(html)
 
@@ -107,6 +113,23 @@ class TagEntitiesForm(LoginRequiredMixin, View):
         return HttpResponse(html)
 
 
+class EntityGroupedBalancesView(LoginRequiredMixin, View):
+    """Returns just the grouped balances section (for hide-zero toggle)."""
+
+    login_url = "/login/"
+    redirect_field_name = "next"
+
+    def get(self, request):
+        hide_zero = request.GET.get("hide_zero", "1") != "0"
+        grouped_balances = entity_services.get_grouped_entities_balances(
+            hide_zero=hide_zero
+        )
+        html = entity_helpers.render_entity_grouped_balances_table(
+            grouped_balances, hide_zero, history_html=""
+        )
+        return HttpResponse(html)
+
+
 class TagEntitiesView(LoginRequiredMixin, View):
     """Main page for entity tagging (payables/receivables)."""
 
@@ -114,5 +137,6 @@ class TagEntitiesView(LoginRequiredMixin, View):
     redirect_field_name = "next"
 
     def get(self, request):
-        html = _render_full_page(is_initial_load=True)
+        hide_zero = request.GET.get("hide_zero", "1") != "0"
+        html = _render_full_page(is_initial_load=True, hide_zero=hide_zero)
         return HttpResponse(html)

--- a/ledger/templates/api/tables/entity-balances-grouped.html
+++ b/ledger/templates/api/tables/entity-balances-grouped.html
@@ -1,0 +1,83 @@
+{% load humanize %}
+<h4 class="mb-1">Balances</h4>
+<div class="d-flex align-items-center justify-content-between mb-2">
+    <span class="text-secondary" style="font-size:.75rem;">All accounts · grouped</span>
+    <a href="#"
+       hx-get="{% url 'entity-balances' %}?hide_zero={% if hide_zero %}0{% else %}1{% endif %}"
+       hx-target="#balances-table"
+       style="font-size:.75rem; text-decoration:none;">
+        {% if hide_zero %}
+            <i class="bi bi-eye"></i> Show zero balances
+        {% else %}
+            <i class="bi bi-eye-slash"></i> Hide zero balances
+        {% endif %}
+    </a>
+</div>
+
+<div class="row no-gutters">
+    <div class="col-md-7 pr-2">
+        {% for group in grouped_balances %}
+            <div class="group-section mb-3">
+                <div class="group-header d-flex align-items-baseline justify-content-between">
+                    <div>
+                        {{ group.account_name }}
+                        <span class="text-secondary ml-2" style="font-size:.7rem; font-weight:normal;">
+                            {% if group.rows %}
+                                {{ group.rows|length }}{% if group.zero_count %} of {{ group.rows|length|add:group.zero_count }}{% endif %}
+                                {{ group.rows|length|pluralize:"entity,entities" }}
+                                {% if group.zero_count %}· {{ group.zero_count }} hidden{% endif %}
+                            {% else %}
+                                {{ group.zero_count }} zero-balance {{ group.zero_count|pluralize:"entity,entities" }} hidden
+                            {% endif %}
+                        </span>
+                    </div>
+                    <div class="text-secondary" style="font-size:.7rem;">
+                        Net ${{ group.net_balance|floatformat:2|intcomma }}
+                    </div>
+                </div>
+                {% if group.rows %}
+                    <div class="table-responsive">
+                        <table class="table table-hover table-sm mb-0">
+                            <thead>
+                                <tr>
+                                    <th>Entity Name</th>
+                                    <th class="text-right">Total Debits</th>
+                                    <th class="text-right">Total Credits</th>
+                                    <th class="text-right">Balance</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                {% for row in group.rows %}
+                                    <tr class="clickable-row"
+                                        hx-get="{% url 'entity-history' row.entity_id %}?account={{ row.account_id }}"
+                                        hx-target="#history-table">
+                                        <td>{{ row.entity_name }}</td>
+                                        <td class="text-right">${{ row.total_debits|floatformat:2|intcomma }}</td>
+                                        <td class="text-right">${{ row.total_credits|floatformat:2|intcomma }}</td>
+                                        <td class="text-right
+                                            {% if row.balance > 0 %}text-success
+                                            {% elif row.balance < 0 %}text-danger
+                                            {% else %}text-muted{% endif %}">
+                                            ${{ row.balance|floatformat:2|intcomma }}
+                                        </td>
+                                    </tr>
+                                {% endfor %}
+                            </tbody>
+                        </table>
+                    </div>
+                {% endif %}
+            </div>
+        {% endfor %}
+    </div>
+    <div class="col-md-5 pl-2" style="border-left:1px solid #dee2e6;">
+        <div id="history-table" style="position:sticky; top:1rem;">
+            {% if entity_history_table %}
+                {{ entity_history_table }}
+            {% else %}
+                <div class="text-muted text-center" style="padding-top:3rem; font-size:.75rem;">
+                    Select an entity to see its transaction history.
+                </div>
+            {% endif %}
+        </div>
+    </div>
+</div>

--- a/ledger/templates/api/tables/entity-history-table.html
+++ b/ledger/templates/api/tables/entity-history-table.html
@@ -1,13 +1,30 @@
 {% load humanize %}
-<div id="payables-receivables-table" class="table-responsive">
-    <table class="table table-hover table-sm">
+{% if entity_name %}
+    <div class="d-flex align-items-baseline justify-content-between mb-1">
+        <div>
+            <strong>{{ entity_name }}</strong>
+            {% if account_name %}
+                <span class="text-secondary ml-1" style="font-size:.75rem;">
+                    · {{ account_name }}
+                </span>
+            {% endif %}
+        </div>
+        {% if final_balance is not None %}
+            <div class="small {% if final_balance > 0 %}text-success{% elif final_balance < 0 %}text-danger{% else %}text-muted{% endif %}">
+                Balance: <strong>${{ final_balance|floatformat:2|intcomma }}</strong>
+            </div>
+        {% endif %}
+    </div>
+{% endif %}
+<div id="entity-history-table" class="table-responsive" style="max-height:520px; overflow-y:auto;">
+    <table class="table table-hover table-sm mb-0">
         <thead>
             <tr>
-                <th>Date</th>
-                <th>Transaction</th>
-                <th>Account</th>
-                <th>Balance</th>
-                <th>Action</th>
+                <th style="position:sticky; top:0; background:#fff; box-shadow:inset 0 -1px 0 #dee2e6;">Date</th>
+                <th style="position:sticky; top:0; background:#fff; box-shadow:inset 0 -1px 0 #dee2e6;">Transaction</th>
+                <th class="text-right" style="position:sticky; top:0; background:#fff; box-shadow:inset 0 -1px 0 #dee2e6;">Amount</th>
+                <th class="text-right" style="position:sticky; top:0; background:#fff; box-shadow:inset 0 -1px 0 #dee2e6;">Balance</th>
+                <th style="position:sticky; top:0; background:#fff; box-shadow:inset 0 -1px 0 #dee2e6;"></th>
             </tr>
         </thead>
         <tbody>
@@ -15,15 +32,18 @@
                 <tr id="row-{{ entry.id }}">
                     <td>{{ entry.journal_entry.date }}</td>
                     <td>{{ entry.journal_entry.transaction.description|slice:":24" }}{% if entry.journal_entry.transaction.description|length > 24 %}...{% endif %}</td>
-                    <td>{{ entry.account }}</td>
-                    <td>{% if entry.type == "debit" %}-{% endif %}${{ entry.amount|floatformat:2|intcomma }}</td>
-                    <td>${{ entry.balance|floatformat:2|intcomma }}</td>
+                    <td class="text-right{% if entry.type == 'debit' %} text-danger{% endif %}">
+                        {% if entry.type == "debit" %}-{% endif %}${{ entry.amount|floatformat:2|intcomma }}
+                    </td>
+                    <td class="text-right {% if entry.balance > 0 %}text-success{% elif entry.balance < 0 %}text-danger{% else %}text-muted{% endif %}">
+                        ${{ entry.balance|floatformat:2|intcomma }}
+                    </td>
                     <td>
-                        <button 
-                            class="btn btn-primary btn-sm"
-                            style="padding: 0.125rem 0.25rem; font-size: 0.75rem; line-height: 1;"
-                            hx-post="{% url 'untag-journal-entry' entry.id %}" 
-                            hx-target="#table-and-form" 
+                        <button
+                            class="btn btn-outline-secondary btn-sm"
+                            style="padding:.05rem .3rem; font-size:.7rem;"
+                            hx-post="{% url 'untag-journal-entry' entry.id %}"
+                            hx-target="#table-and-form"
                             hx-swap="outerHTML">
                             Untag
                         </button>

--- a/ledger/urls.py
+++ b/ledger/urls.py
@@ -9,6 +9,7 @@ from api.views.amortization_views import (
     AmortizeFormView,
 )
 from api.views.entity_views import (
+    EntityGroupedBalancesView,
     EntityHistoryTable,
     TagEntitiesForm,
     TagEntitiesView,
@@ -141,6 +142,7 @@ urlpatterns = [
         name="untag-journal-entry",
     ),
     path("tag/", TagEntitiesView.as_view(), name="tag-entities"),
+    path("tag/balances/", EntityGroupedBalancesView.as_view(), name="entity-balances"),
     path(
         "tag/form/<int:journal_entry_item_id>/",
         TagEntitiesForm.as_view(),


### PR DESCRIPTION
The Balances page previously merged all AR-type entities into a single flat list, making it impossible to distinguish which account a balance belonged to. Zero-balance entities also cluttered the view with no way to hide them.

Changes:
- New grouped layout: entity balances are now sectioned by Account, each with a header showing account name, entity count, and net balance
- Zero-balance entities are hidden by default; a toggle reveals them via an HTMX swap (no page reload) with the state reflected in the URL
- Entity history panel now scopes to the selected account when a row is clicked, so clicking an entity in "Deposits" shows only Deposits activity
- History panel header shows entity name, account, and current balance
- New service function get_grouped_entities_balances(hide_zero) and updated get_entity_history(entity_id, account_id) with full test coverage