### PR TITLE
Add expandable/resizable multi-select component for account filters

### DIFF
--- a/ledger/templates/api/components/expandable-multiselect.html
+++ b/ledger/templates/api/components/expandable-multiselect.html
@@ -1,0 +1,24 @@
+<div class="form-group"
+     x-data="{ expanded: false, collapsedHeight: '0px', maxHeight: '0px' }"
+     x-init="
+         $refs.select.style.height = 'auto';
+         collapsedHeight = $refs.select.offsetHeight + 'px';
+         maxHeight = ($refs.select.scrollHeight + 4) + 'px';
+         $refs.select.style.height = '100%';
+     ">
+    <label for="{{ field.auto_id }}"
+           @click="expanded = !expanded"
+           style="cursor: pointer; user-select: none;">
+        {{ label }} <i :class="expanded ? 'bi bi-chevron-up' : 'bi bi-chevron-down'" style="font-size: 0.7em;"></i>
+    </label>
+    <div style="resize: vertical; overflow: auto;"
+         :style="{ height: expanded ? maxHeight : collapsedHeight, minHeight: collapsedHeight, maxHeight: maxHeight }">
+        <select x-ref="select" name="{{ field.html_name }}" id="{{ field.auto_id }}" class="form-control" multiple style="height: 100%;">
+            {% for option in field.field.queryset %}
+                <option value="{{ option.pk }}" {% if option.pk|stringformat:"s" in field.value %}selected{% endif %}>
+                    {{ option }}
+                </option>
+            {% endfor %}
+        </select>
+    </div>
+</div>

--- a/ledger/templates/api/filter_forms/search-filter-form.html
+++ b/ledger/templates/api/filter_forms/search-filter-form.html
@@ -33,30 +33,12 @@
 
         <!-- Transaction Account -->
         <div class="col-md-3">
-            <div class="form-group">
-                <label for="id_account">Account</label>
-                <select name="account" id="id_account" class="form-control" multiple>
-                    {% for account in form.account.field.queryset %}
-                        <option value="{{ account.pk }}" {% if account.pk|stringformat:"s" in form.account.value %}selected{% endif %}>
-                            {{ account }}
-                        </option>
-                    {% endfor %}
-                </select>
-            </div>
+            {% include "api/components/expandable-multiselect.html" with field=form.account label="Account" %}
         </div>
 
         <!-- Related Account -->
         <div class="col-md-3">
-            <div class="form-group">
-                <label for="id_related_account">Related Account</label>
-                <select name="related_account" id="id_related_account" class="form-control" multiple>
-                    {% for account in form.related_account.field.queryset %}
-                        <option value="{{ account.pk }}" {% if account.pk|stringformat:"s" in form.related_account.value %}selected{% endif %}>
-                            {{ account }}
-                        </option>
-                    {% endfor %}
-                </select>
-            </div>
+            {% include "api/components/expandable-multiselect.html" with field=form.related_account label="Related Account" %}
         </div>
 
         <!-- Type -->

--- a/ledger/templates/api/filter_forms/transactions-filter-form.html
+++ b/ledger/templates/api/filter_forms/transactions-filter-form.html
@@ -23,30 +23,12 @@
 
         <!-- Account Field -->
         <div class="col-md-3">
-            <div class="form-group">
-                <label for="id_account">Account</label>
-                <select name="{{ filter_form.account.html_name }}" id="{{ filter_form.account.auto_id }}" class="form-control" multiple>
-                    {% for account in filter_form.account.field.queryset %}
-                        <option value="{{ account.pk }}" {% if account.pk|stringformat:"s" in filter_form.account.value %}selected{% endif %}>
-                            {{ account }}
-                        </option>
-                    {% endfor %}
-                </select>
-            </div>
+            {% include "api/components/expandable-multiselect.html" with field=filter_form.account label="Account" %}
         </div>
 
         <!-- Related Account Field -->
         <div class="col-md-3">
-            <div class="form-group">
-                <label for="id_related_account">Related Account</label>
-                <select name="{{ filter_form.related_account.html_name }}" id="{{ filter_form.related_account.auto_id }}" class="form-control" multiple>
-                    {% for account in filter_form.related_account.field.queryset %}
-                        <option value="{{ account.pk }}" {% if account.pk|stringformat:"s" in filter_form.related_account.value %}selected{% endif %}>
-                            {{ account }}
-                        </option>
-                    {% endfor %}
-                </select>
-            </div>
+            {% include "api/components/expandable-multiselect.html" with field=filter_form.related_account label="Related Account" %}
         </div>
 
         <!-- Type Field -->


### PR DESCRIPTION
Extracts a reusable Alpine.js component that lets users click-to-expand or drag-to-resize account filter selects. Applies it to both the Journal Entries and Search filter forms.