### PR TITLE
Refactor Journal Entries layout: collapsible filter, inline paystub d…

### DIFF
--- a/api/views/journal_entry_helpers.py
+++ b/api/views/journal_entry_helpers.py
@@ -46,7 +46,7 @@ def render_paystub_detail(data: PaystubDetailData) -> str:
         data: PaystubDetailData containing paystub_values and paystub_id.
     """
     return render_to_string(
-        "api/tables/paystubs-table.html",
+        "api/tables/paystub-detail.html",
         {"paystub_values": data.paystub_values, "paystub_id": data.paystub_id},
     )
 

--- a/ledger/templates/api/filter_forms/transactions-filter-form.html
+++ b/ledger/templates/api/filter_forms/transactions-filter-form.html
@@ -7,6 +7,8 @@
     hx-swap="outerHTML"
     class="mb-3 form-sm"
 >
+    <details open>
+        <summary class="mb-2" style="cursor: pointer;"><strong>Filters</strong></summary>
     <div class="row g-3">
         <!-- Stacked Date From and Date To Fields -->
         <div class="col-md-2">
@@ -86,4 +88,5 @@
             </div>
         </div>
     </div>
+    </details>
 </form>

--- a/ledger/templates/api/tables/paystub-detail.html
+++ b/ledger/templates/api/tables/paystub-detail.html
@@ -1,0 +1,32 @@
+{% load humanize %}
+{% if paystub_values %}
+<table class="table table-sm mb-2" style="background: transparent;">
+    <thead>
+        <tr>
+            <th>Account</th>
+            <th style="text-align: right;">Value</th>
+            <th>Type</th>
+        </tr>
+    </thead>
+    <tbody>
+        {% for paystub_value in paystub_values %}
+        <tr>
+            <td>{{ paystub_value.account }}</td>
+            <td style="text-align: right;">${{ paystub_value.amount }}</td>
+            <td>{{ paystub_value.journal_entry_item_type }}</td>
+        </tr>
+        {% endfor %}
+    </tbody>
+</table>
+
+<div class="d-flex justify-content-end">
+    <button
+        @click="fillPaystub({{ paystub_id }})"
+        x-bind:disabled="!selectedRowId"
+        x-bind:class="!selectedRowId ? 'btn btn-secondary btn-sm' : 'btn btn-primary btn-sm'"
+        x-bind:title="!selectedRowId ? 'Select a transaction first' : ''"
+    >
+        Fill Paystub
+    </button>
+</div>
+{% endif %}

--- a/ledger/templates/api/tables/paystubs-table.html
+++ b/ledger/templates/api/tables/paystubs-table.html
@@ -1,75 +1,34 @@
 {% load humanize %}
-{% if paystubs %}
-<br>
-<h5>Paystubs</h5>
-<div class="row">
-    <div class="col-md-6">
-        <div id="paystubs-table" class="table-responsive">
-            <table class="table table-hover table-sm">
-                <thead>
-                    <tr class="clickable-row">
-                        <th style="position: sticky; top: 0; background: white; z-index: 10;">Title</th>
-                        <th style="position: sticky; top: 0; background: white; z-index: 10;">Document</th>
-                    </tr>
-                </thead>
-                <tbody>
-                    {% for paystub in paystubs %}
-                    <tr
-                        class="clickable-row"
-                        hx-get="{% url 'paystub-detail' paystub.id %}"
-                        hx-target="#paystubs-detail"
-                        :data-transaction-id="selectedRowId"
-                    >
-                        <td>{{ paystub.title }}</td>
-                        <td>{{ paystub.document.user_filename }}</td>
-                    </tr>
-                    {% endfor %}
-                </tbody>
-            </table>
-        </div>
+<div id="paystubs-table-wrapper">
+    {% if paystubs %}
+    <div id="paystubs-table" class="table-responsive">
+        <table class="table table-hover table-sm" style="table-layout: fixed; width: 100%;">
+            <thead>
+                <tr>
+                    <th class="fixed-header" style="width: 45%;">Title</th>
+                    <th class="fixed-header" style="width: 55%;">Document</th>
+                </tr>
+            </thead>
+            <tbody>
+                {% for paystub in paystubs %}
+                <tr
+                    class="clickable-row"
+                    style="cursor: pointer;"
+                    @click="togglePaystub({{ paystub.id }}, '{% url 'paystub-detail' paystub.id %}')"
+                >
+                    <td class="transaction-column" title="{{ paystub.title }}">{{ paystub.title }}</td>
+                    <td class="transaction-column" title="{{ paystub.document.user_filename }}">{{ paystub.document.user_filename }}</td>
+                </tr>
+                <tr x-show="expandedPaystubId === {{ paystub.id }}" x-cloak>
+                    <td colspan="2" class="bg-light">
+                        <div id="paystub-detail-{{ paystub.id }}"></div>
+                    </td>
+                </tr>
+                {% endfor %}
+            </tbody>
+        </table>
     </div>
+    {% else %}
+    <p class="text-muted"><small>No unlinked paystubs.</small></p>
     {% endif %}
-    <div class="col-md-6">
-        <div id="paystubs-detail">
-        {% if paystub_values %}
-            <div class="row">
-                <div class="col-md-12">
-                    <table class="table table-sm">
-                        <thead>
-                            <tr class="clickable-row">
-                                <th style="position: sticky; top: 0; background: white; z-index: 10;">Account</th>
-                                <th style="position: sticky; top: 0; background: white; z-index: 10;">Value</th>
-                                <th style="position: sticky; top: 0; background: white; z-index: 10;">Type</th>
-                            </tr>
-                        </thead>
-                        <tbody>
-                            {% for paystub_value in paystub_values %}
-                            <tr>
-                                <td>{{ paystub_value.account }}</td>
-                                <td>${{ paystub_value.amount }}</td>
-                                <td>{{ paystub_value.journal_entry_item_type }}</td>
-                            </tr>
-                            {% endfor %}
-                        </tbody>
-                    </table>
-                </div>
-            </div>
-        
-            <!-- Add button here -->
-            <div class="row">
-                <div class="col-md-12">
-                    <button
-                        @click="if (selectedRowId) htmx.ajax('GET', `/journal-entries/form/${selectedRowId}/?row_index=${rowIndex}&paystub_id={{ paystub_id }}`, {target: '#form-div'})"
-                        x-bind:disabled="!selectedRowId"
-                        x-bind:class="!selectedRowId ? 'btn btn-secondary' : 'btn btn-primary'"
-                        x-bind:title="!selectedRowId ? 'Select a transaction first' : ''"
-                    >
-                        Fill Paystub<br>
-                    </button>
-                </div>
-            </div>
-        {% endif %}
-        </div>
-    </div>
 </div>
-

--- a/ledger/templates/api/tables/transactions-table-new.html
+++ b/ledger/templates/api/tables/transactions-table-new.html
@@ -9,7 +9,6 @@
                         <th style="position: sticky; top: 0; background: white; z-index: 10;">Account</th>
                         <th style="position: sticky; top: 0; background: white; z-index: 10;">Amount</th>
                         <th style="position: sticky; top: 0; background: white; z-index: 10;">Description</th>
-                        <th style="position: sticky; top: 0; background: white; z-index: 10;">Category</th>
                         <th style="position: sticky; top: 0; background: white; z-index: 10;">Type</th>
                     </tr>
                 </thead>
@@ -26,7 +25,6 @@
                         <td>{{ transaction.account }}</td>
                         <td>${{ transaction.amount|floatformat:2|intcomma }}</td>
                         <td>{{ transaction.description }}</td>
-                        <td>{{ transaction.category }}</td>
                         <td>{{ transaction.get_type_display }}</td>
                     </tr>
                     {% endfor %}

--- a/ledger/templates/api/views/journal-entry-view.html
+++ b/ledger/templates/api/views/journal-entry-view.html
@@ -5,11 +5,40 @@
 {{ filter_form }}
 
 <div id="table-and-form">
-    <div x-data="{ selectedRowId: {{ transaction_id|default_if_none:'null' }}, rowIndex: {{index}} }">
+    <div x-data="{
+            selectedRowId: {{ transaction_id|default_if_none:'null' }},
+            rowIndex: {{ index }},
+            expandedPaystubId: null,
+            togglePaystub(id, url) {
+                if (this.expandedPaystubId === id) {
+                    this.expandedPaystubId = null;
+                    return;
+                }
+                this.expandedPaystubId = id;
+                const target = document.getElementById(`paystub-detail-${id}`);
+                if (!target.innerHTML.trim()) {
+                    htmx.ajax('GET', url, {target: target});
+                }
+            },
+            fillPaystub(paystubId) {
+                this.expandedPaystubId = null;
+                if (!this.selectedRowId) return;
+                htmx.ajax(
+                    'GET',
+                    `/journal-entries/form/${this.selectedRowId}/?row_index=${this.rowIndex}&paystub_id=${paystubId}`,
+                    {target: '#form-div'}
+                );
+            }
+         }">
         <div class="row">
-            <div class="col-md-12">
+            <div class="col-md-8">
                 <div id="table">
                     {{ table }}
+                </div>
+            </div>
+            <div class="col-md-4">
+                <div id="paystubs">
+                    {{ paystubs_table }}
                 </div>
             </div>
         </div>
@@ -17,13 +46,6 @@
             <div class="col-md-12">
                 <div id="form-div">
                     {{ entry_form }}
-                </div>
-            </div>
-        </div>
-        <div class="row">
-            <div class="col-md-8">
-                <div id="paystubs">
-                    {{ paystubs_table }}
                 </div>
             </div>
         </div>


### PR DESCRIPTION
…etail

Give the tagging workflow more breathing room. The filter bar is now a native <details> element (open by default, zero JS). The Transactions and Paystubs tables sit side-by-side (col-md-8 / col-md-4) with the Category column dropped. Clicking a paystub expands its detail inline beneath the row instead of opening a modal; re-expanding the same paystub is a pure client-side toggle (no refetch). Reuses existing .fixed-header and .transaction-column classes; toggle/fill logic is extracted to Alpine methods on the view's x-data scope.