### PR TITLE
Show interactive paystubs table on Upload Files page

### DIFF
--- a/api/views/frontend_views.py
+++ b/api/views/frontend_views.py
@@ -11,7 +11,10 @@ from api.forms import DocumentForm, UploadTransactionsForm, WalletForm
 from api.services.paystub_services import get_paystubs_table_data
 from api.services.paystub_upload_services import process_paystub_upload
 from api.statement import Trend
-from api.views.journal_entry_helpers import render_paystubs_table
+from api.views.journal_entry_helpers import (
+    render_paystubs_table,
+    render_paystubs_table_oob_swap,
+)
 
 
 class UploadTransactionsView(View):
@@ -32,7 +35,9 @@ class UploadTransactionsView(View):
         template = "api/views/upload-transactions.html"
         csv_form_html = self.get_csv_form_html()
         textract_form_html = self.get_textract_form_html()
-        paystub_table_html = render_paystubs_table(get_paystubs_table_data())
+        paystub_table_html = render_paystubs_table(
+            get_paystubs_table_data(), show_fill_button=False
+        )
         return render(
             request,
             template,
@@ -69,12 +74,15 @@ class UploadTransactionsView(View):
 
         if "transactions" in request.POST:
             form_html = self.handle_transactions_form(request)
+            return HttpResponse(form_html)
         elif "paystubs" in request.POST:
             form_html = self.handle_paystubs_form(request)
+            oob_html = render_paystubs_table_oob_swap(
+                get_paystubs_table_data(), show_fill_button=False
+            )
+            return HttpResponse(form_html + oob_html)
         else:
             return HttpResponse("Unrecognized form submission.", status=400)
-
-        return HttpResponse(form_html)
 
 
 # ------------------Wallet Transactions View-----------------------

--- a/api/views/journal_entry_helpers.py
+++ b/api/views/journal_entry_helpers.py
@@ -19,7 +19,7 @@ from api.services.journal_entry_services import (
 from api.services.paystub_services import PaystubDetailData, PaystubsTableData
 
 
-def render_paystubs_table(data: PaystubsTableData) -> str:
+def render_paystubs_table(data: PaystubsTableData, show_fill_button: bool = True) -> str:
     """
     Renders the paystubs table HTML.
 
@@ -28,6 +28,7 @@ def render_paystubs_table(data: PaystubsTableData) -> str:
 
     Args:
         data: PaystubsTableData containing has_pending_jobs flag and paystubs list.
+        show_fill_button: Whether row-click detail should include the Fill Paystub button.
     """
     if data.has_pending_jobs:
         return render_to_string(
@@ -35,19 +36,38 @@ def render_paystubs_table(data: PaystubsTableData) -> str:
             {"pending_files": data.pending_files},
         )
 
-    return render_to_string("api/tables/paystubs-table.html", {"paystubs": data.paystubs})
+    return render_to_string(
+        "api/tables/paystubs-table.html",
+        {"paystubs": data.paystubs, "show_fill_button": show_fill_button},
+    )
 
 
-def render_paystub_detail(data: PaystubDetailData) -> str:
+def render_paystubs_table_oob_swap(
+    data: PaystubsTableData, show_fill_button: bool = True
+) -> str:
+    """Renders the paystubs table wrapped for an HTMX out-of-band swap into #paystubs."""
+    table_html = render_paystubs_table(data, show_fill_button=show_fill_button)
+    return render_to_string(
+        "api/tables/paystubs-oob-wrapper.html",
+        {"paystubs_table_html": table_html},
+    )
+
+
+def render_paystub_detail(data: PaystubDetailData, show_fill_button: bool = True) -> str:
     """
     Renders the paystub detail view HTML.
 
     Args:
         data: PaystubDetailData containing paystub_values and paystub_id.
+        show_fill_button: Whether to render the Fill Paystub button.
     """
     return render_to_string(
         "api/tables/paystub-detail.html",
-        {"paystub_values": data.paystub_values, "paystub_id": data.paystub_id},
+        {
+            "paystub_values": data.paystub_values,
+            "paystub_id": data.paystub_id,
+            "show_fill_button": show_fill_button,
+        },
     )
 
 

--- a/api/views/journal_entry_views.py
+++ b/api/views/journal_entry_views.py
@@ -106,7 +106,8 @@ class PaystubDetailView(LoginRequiredMixin, View):
 
     def get(self, request, paystub_id):
         detail_data = get_paystub_detail_data(paystub_id)
-        html = render_paystub_detail(detail_data)
+        show_fill_button = request.GET.get("show_fill_button") == "true"
+        html = render_paystub_detail(detail_data, show_fill_button=show_fill_button)
         return HttpResponse(html)
 
 

--- a/ledger/templates/api/tables/paystub-detail.html
+++ b/ledger/templates/api/tables/paystub-detail.html
@@ -19,6 +19,7 @@
     </tbody>
 </table>
 
+{% if show_fill_button %}
 <div class="d-flex justify-content-end">
     <button
         @click="fillPaystub({{ paystub_id }})"
@@ -29,4 +30,5 @@
         Fill Paystub
     </button>
 </div>
+{% endif %}
 {% endif %}

--- a/ledger/templates/api/tables/paystubs-oob-wrapper.html
+++ b/ledger/templates/api/tables/paystubs-oob-wrapper.html
@@ -1,0 +1,1 @@
+<div id="paystubs" hx-swap-oob="true">{{ paystubs_table_html|safe }}</div>

--- a/ledger/templates/api/tables/paystubs-table.html
+++ b/ledger/templates/api/tables/paystubs-table.html
@@ -14,7 +14,7 @@
                 <tr
                     class="clickable-row"
                     style="cursor: pointer;"
-                    @click="togglePaystub({{ paystub.id }}, '{% url 'paystub-detail' paystub.id %}')"
+                    @click="togglePaystub({{ paystub.id }}, '{% url 'paystub-detail' paystub.id %}{% if show_fill_button %}?show_fill_button=true{% endif %}')"
                 >
                     <td class="transaction-column" title="{{ paystub.title }}">{{ paystub.title }}</td>
                     <td class="transaction-column" title="{{ paystub.document.user_filename }}">{{ paystub.document.user_filename }}</td>

--- a/ledger/templates/api/views/upload-transactions.html
+++ b/ledger/templates/api/views/upload-transactions.html
@@ -13,8 +13,23 @@
 
 <div class="row">
     <div class="col-md-4">
-        <div id="paystubs">
-            {{ paystubs_table }}
+        <div x-data="{
+                expandedPaystubId: null,
+                togglePaystub(id, url) {
+                    if (this.expandedPaystubId === id) {
+                        this.expandedPaystubId = null;
+                        return;
+                    }
+                    this.expandedPaystubId = id;
+                    const target = document.getElementById(`paystub-detail-${id}`);
+                    if (!target.innerHTML.trim()) {
+                        htmx.ajax('GET', url, {target: target});
+                    }
+                }
+             }">
+            <div id="paystubs">
+                {{ paystubs_table }}
+            </div>
         </div>
     </div>
 </div>


### PR DESCRIPTION
Reuse the Journal Entry Items paystubs component on the Upload Files page so rows expand inline to show parsed values. The Fill Paystub button is hidden there (no transaction selection exists). After a paystub upload, the paystubs section is also returned via an HTMX OOB swap so the new file appears immediately and the poller takes over without a page reload.