### PR TITLE
Add retry button and compact error display for failed paystubs

### DIFF
--- a/api/models.py
+++ b/api/models.py
@@ -51,6 +51,16 @@ class S3File(models.Model):
     def __str__(self):
         return self.prefill.name + " " + self.s3_filename
 
+    @property
+    def short_error(self) -> str:
+        """A compact, human-friendly label for the stored error_message."""
+        msg = self.error_message or ""
+        if "503" in msg or "UNAVAILABLE" in msg:
+            return "server busy (503)"
+        if "429" in msg:
+            return "rate limited (429)"
+        return "processing error"
+
     def create_textract_job(self):
         job_id = create_textract_job(filename=self.s3_filename)
         self.textract_job_id = job_id

--- a/api/services/paystub_services.py
+++ b/api/services/paystub_services.py
@@ -18,6 +18,7 @@ class PaystubsTableData:
     has_pending_jobs: bool
     paystubs: List[Paystub]
     pending_files: List[S3File] = field(default_factory=list)
+    has_active_jobs: bool = False
 
 
 @dataclass
@@ -41,7 +42,16 @@ def get_paystubs_table_data() -> PaystubsTableData:
     )
 
     if pending_files:
-        return PaystubsTableData(has_pending_jobs=True, paystubs=[], pending_files=pending_files)
+        has_active_jobs = any(
+            f.status in (S3File.Status.PENDING, S3File.Status.PROCESSING)
+            for f in pending_files
+        )
+        return PaystubsTableData(
+            has_pending_jobs=True,
+            paystubs=[],
+            pending_files=pending_files,
+            has_active_jobs=has_active_jobs,
+        )
 
     paystubs = list(
         Paystub.objects.filter(journal_entry__isnull=True)

--- a/api/services/paystub_upload_services.py
+++ b/api/services/paystub_upload_services.py
@@ -22,6 +22,16 @@ class UploadResult:
     error: Optional[str] = None
 
 
+def _dispatch_gemini_processing(s3file_pk: int) -> None:
+    """Dispatches the async Gemini paystub task.
+
+    The import is local because api.tasks imports from this module.
+    """
+    from api.tasks import process_gemini_paystub
+
+    process_gemini_paystub.delay(s3file_pk)
+
+
 def process_paystub_upload(file, prefill: Prefill) -> UploadResult:
     """
     Orchestrates the paystub upload flow:
@@ -36,8 +46,6 @@ def process_paystub_upload(file, prefill: Prefill) -> UploadResult:
     Returns:
         UploadResult with the created S3File on success
     """
-    from api.tasks import process_gemini_paystub
-
     # 1. Upload to S3 (network call)
     unique_name = upload_file_to_s3(file=file)
     if isinstance(unique_name, dict):
@@ -56,7 +64,25 @@ def process_paystub_upload(file, prefill: Prefill) -> UploadResult:
     )
 
     # 3. Dispatch Celery task — Gemini call and DB writes happen on the worker
-    process_gemini_paystub.delay(s3file.pk)
+    _dispatch_gemini_processing(s3file.pk)
+
+    return UploadResult(success=True, s3file=s3file)
+
+
+def retry_paystub_processing(s3file_id: int) -> UploadResult:
+    """
+    Resets a failed S3File to PENDING and re-dispatches the Gemini task.
+
+    Used by the Retry button on the paystubs poller when Gemini returns a
+    transient error (e.g. 503 UNAVAILABLE).
+    """
+    s3file = S3File.objects.get(pk=s3file_id)
+    s3file.status = S3File.Status.PENDING
+    s3file.error_message = ""
+    s3file.analysis_complete = None
+    s3file.save(update_fields=["status", "error_message", "analysis_complete"])
+
+    _dispatch_gemini_processing(s3file.pk)
 
     return UploadResult(success=True, s3file=s3file)
 

--- a/api/tests/models/test_s3file.py
+++ b/api/tests/models/test_s3file.py
@@ -53,3 +53,29 @@ class S3FileCreationTests(TestCase):
         self.assertEqual(s3file.user_filename, 'test.pdf')
         self.assertEqual(s3file.s3_filename, 'unique-test.pdf')
         self.assertFalse(s3file.textract_job_id)  # Empty string or None
+
+
+class S3FileShortErrorTests(TestCase):
+    """Tests for the S3File.short_error display property."""
+
+    def setUp(self):
+        self.prefill = Prefill.objects.create(name='Test Prefill')
+
+    def _s3file(self, error_message):
+        return S3File(
+            prefill=self.prefill,
+            url='https://example.com/test.pdf',
+            user_filename='test.pdf',
+            s3_filename='unique-test.pdf',
+            error_message=error_message,
+        )
+
+    def test_maps_503_to_server_busy(self):
+        msg = "503 UNAVAILABLE. {'error': {'code': 503, 'message': 'high demand'}}"
+        self.assertEqual(self._s3file(msg).short_error, 'server busy (503)')
+
+    def test_maps_429_to_rate_limited(self):
+        self.assertEqual(self._s3file('429 RESOURCE_EXHAUSTED').short_error, 'rate limited (429)')
+
+    def test_defaults_to_processing_error(self):
+        self.assertEqual(self._s3file('KeyError: Company').short_error, 'processing error')

--- a/api/tests/services/test_paystub_services.py
+++ b/api/tests/services/test_paystub_services.py
@@ -91,6 +91,39 @@ class GetPaystubsTableDataTest(TestCase):
         self.assertFalse(result.has_pending_jobs)
         self.assertEqual(result.paystubs, [])
 
+    def test_has_active_jobs_true_when_file_processing(self):
+        """has_active_jobs=True when a pending file is still PENDING/PROCESSING."""
+        S3File.objects.create(
+            prefill=self.prefill,
+            url="https://example.com/processing.pdf",
+            user_filename="processing.pdf",
+            s3_filename="processing.pdf",
+            status=S3File.Status.PROCESSING,
+            analysis_complete=None,
+        )
+
+        result = get_paystubs_table_data()
+
+        self.assertTrue(result.has_pending_jobs)
+        self.assertTrue(result.has_active_jobs)
+
+    def test_has_active_jobs_false_when_only_failed(self):
+        """has_active_jobs=False when all pending files are terminal (FAILED)."""
+        S3File.objects.create(
+            prefill=self.prefill,
+            url="https://example.com/failed.pdf",
+            user_filename="failed.pdf",
+            s3_filename="failed.pdf",
+            status=S3File.Status.FAILED,
+            error_message="503 UNAVAILABLE",
+            analysis_complete=None,
+        )
+
+        result = get_paystubs_table_data()
+
+        self.assertTrue(result.has_pending_jobs)
+        self.assertFalse(result.has_active_jobs)
+
     def test_paystubs_ordered_by_title(self):
         """Paystubs returned in title order."""
         s3file = S3File.objects.create(

--- a/api/tests/services/test_paystub_upload_services.py
+++ b/api/tests/services/test_paystub_upload_services.py
@@ -14,6 +14,7 @@ from api.models import (
 from api.services.paystub_upload_services import (
     create_paystubs_from_data,
     process_paystub_upload,
+    retry_paystub_processing,
 )
 from api.tests.testing_factories import AccountFactory, EntityFactory, PrefillFactory
 
@@ -267,3 +268,29 @@ class ProcessGeminiPaystubTaskTest(TestCase):
         # S3File remains in pending state so the poller keeps showing the spinner
         self.s3file.refresh_from_db()
         self.assertIsNone(self.s3file.analysis_complete)
+
+
+class RetryPaystubProcessingTest(TestCase):
+    def setUp(self):
+        self.prefill = PrefillFactory(name="Payroll")
+        self.s3file = S3File.objects.create(
+            prefill=self.prefill,
+            url="https://bucket.s3.amazonaws.com/test.pdf",
+            user_filename="paystub.pdf",
+            s3_filename="uuid-test.pdf",
+            status=S3File.Status.FAILED,
+            error_message="503 UNAVAILABLE. Model is experiencing high demand.",
+        )
+
+    @patch("api.tasks.process_gemini_paystub")
+    def test_resets_failed_file_and_redispatches(self, mock_task):
+        result = retry_paystub_processing(self.s3file.pk)
+
+        self.assertTrue(result.success)
+
+        self.s3file.refresh_from_db()
+        self.assertEqual(self.s3file.status, S3File.Status.PENDING)
+        self.assertEqual(self.s3file.error_message, "")
+        self.assertIsNone(self.s3file.analysis_complete)
+
+        mock_task.delay.assert_called_once_with(self.s3file.pk)

--- a/api/views/journal_entry_helpers.py
+++ b/api/views/journal_entry_helpers.py
@@ -33,7 +33,10 @@ def render_paystubs_table(data: PaystubsTableData, show_fill_button: bool = True
     if data.has_pending_jobs:
         return render_to_string(
             "api/tables/paystubs-table-poller.html",
-            {"pending_files": data.pending_files},
+            {
+                "pending_files": data.pending_files,
+                "has_active_jobs": data.has_active_jobs,
+            },
         )
 
     return render_to_string(

--- a/api/views/journal_entry_views.py
+++ b/api/views/journal_entry_views.py
@@ -23,6 +23,7 @@ from api.services.paystub_services import (
     get_paystub_detail_data,
     get_paystubs_table_data,
 )
+from api.services.paystub_upload_services import retry_paystub_processing
 from api.views.journal_entry_helpers import (
     render_journal_entry_form,
     render_paystub_detail,
@@ -99,6 +100,13 @@ class PaystubTableView(LoginRequiredMixin, View):
     def get(self, request):
         paystubs_table_data = get_paystubs_table_data()
         html = render_paystubs_table(paystubs_table_data)
+        return HttpResponse(html)
+
+
+class PaystubRetryView(LoginRequiredMixin, View):
+    def post(self, request, s3file_id):
+        retry_paystub_processing(s3file_id)
+        html = render_paystubs_table(get_paystubs_table_data())
         return HttpResponse(html)
 
 

--- a/ledger/templates/api/tables/paystubs-table-poller.html
+++ b/ledger/templates/api/tables/paystubs-table-poller.html
@@ -1,6 +1,6 @@
 <div id="paystubs-table-poller"
      hx-get="{% url 'paystub-table' %}"
-     hx-trigger="every 2s"
+     {% if has_active_jobs %}hx-trigger="every 2s"{% endif %}
      hx-swap="outerHTML">
     <br>
     <h5>Paystubs</h5>
@@ -21,7 +21,11 @@
                     {% elif s3file.status == "PROCESSING" %}
                         <span class="text-primary">⚙️ Sending to Gemini...</span>
                     {% elif s3file.status == "FAILED" %}
-                        <span class="text-danger">❌ Failed: {{ s3file.error_message }}</span>
+                        <span class="text-danger" title="{{ s3file.error_message }}">❌ Failed — {{ s3file.short_error }}</span>
+                        <button type="button" class="btn btn-sm btn-outline-secondary ms-2"
+                                hx-post="{% url 'paystub-retry' s3file.id %}"
+                                hx-target="#paystubs-table-poller"
+                                hx-swap="outerHTML">↻ Retry</button>
                     {% endif %}
                 </td>
             </tr>

--- a/ledger/urls.py
+++ b/ledger/urls.py
@@ -21,6 +21,7 @@ from api.views.journal_entry_views import (
     JournalEntryTableView,
     JournalEntryView,
     PaystubDetailView,
+    PaystubRetryView,
     PaystubTableView,
     TriggerAutoTagView,
 )
@@ -74,6 +75,11 @@ urlpatterns = [
         name="journal-entries-table",
     ),
     path("paystubs/", PaystubTableView.as_view(), name="paystub-table"),
+    path(
+        "paystubs/<int:s3file_id>/retry/",
+        PaystubRetryView.as_view(),
+        name="paystub-retry",
+    ),
     path(
         "paystubs/<int:paystub_id>/", PaystubDetailView.as_view(), name="paystub-detail"
     ),


### PR DESCRIPTION
## Summary
When Gemini returns a transient 503 ("model experiencing high demand"), a paystub upload was marked FAILED and the only way to recover was to re-upload the file. The poller also rendered the full raw exception string, inflating the component. This adds a manual Retry button and a compact error display.

## Changes
**Backend (`api/`)**
- `retry_paystub_processing` service resets a failed `S3File` to PENDING (clears error/`analysis_complete`) and re-dispatches the existing `process_gemini_paystub` task via a shared `_dispatch_gemini_processing` helper.
- `PaystubRetryView` (POST `paystubs/<id>/retry/`) wires the button to the service and re-renders the poller.
- `S3File.short_error` maps the raw error to a short label (e.g. "server busy (503)").
- `PaystubsTableData.has_active_jobs` flags whether anything is still PENDING/PROCESSING.

**Frontend**
- Failed rows show `❌ Failed — <short_error>` (full error in a hover `title`) plus a `↻ Retry` button; the 2s poll is now conditional on `has_active_jobs`, so it stops once only failed rows remain.

**Tests**
- `retry_paystub_processing` resets state + re-dispatches; `has_active_jobs` true/false cases; `short_error` mapping.

## Reviewer focus
- ⚠️ Retry reuses the same `.delay()` dispatch; CSRF on the HTMX POST rides the global `htmx:configRequest` handler in `base.html` (no per-button token).
- `short_error` does substring matching on the raw exception string — deliberately shallow for now; a structured `error_type` at the source was considered and deferred (would need a migration).

## Test plan
- [ ] `uv run python manage.py test api.tests.services.test_paystub_upload_services api.tests.services.test_paystub_services api.tests.models.test_s3file` *(could not run locally — `uv` unavailable in the authoring environment)*
- [ ] Manual: force a 503 in `parse_paystub_with_gemini`, upload a paystub, confirm the compact failed row, hover for full error, polling stops, and Retry re-dispatches (row returns to ⏳/⚙️).

🤖 Generated with [Claude Code](https://claude.com/claude-code)