### PR TITLE
Preserve paystub link when journal entry form re-renders on error

### DIFF
--- a/api/tests/views/test_journal_entry_views.py
+++ b/api/tests/views/test_journal_entry_views.py
@@ -5,14 +5,30 @@ These tests verify the complete HTTP request/response flow for journal entries,
 ensuring views, services, and helpers work together correctly.
 """
 
+import re
 from decimal import Decimal
 
 from django.contrib.auth.models import User
 from django.test import Client, TestCase
 from django.urls import reverse
 
-from api.models import Account, Entity, JournalEntry, JournalEntryItem, Transaction
-from api.tests.testing_factories import AccountFactory, TransactionFactory
+from django.utils import timezone
+
+from api.models import (
+    Account,
+    Entity,
+    JournalEntry,
+    JournalEntryItem,
+    Paystub,
+    PaystubValue,
+    S3File,
+    Transaction,
+)
+from api.tests.testing_factories import (
+    AccountFactory,
+    PrefillFactory,
+    TransactionFactory,
+)
 
 
 class JournalEntryViewTest(TestCase):
@@ -25,9 +41,11 @@ class JournalEntryViewTest(TestCase):
         self.client.login(username="testuser", password="testpass")
 
         # Create test data
-        self.asset_account = AccountFactory(type=Account.Type.ASSET, name="Cash")
+        self.asset_account = AccountFactory(
+            type=Account.Type.ASSET, name="Cash", is_closed=False
+        )
         self.expense_account = AccountFactory(
-            type=Account.Type.EXPENSE, name="Office Supplies"
+            type=Account.Type.EXPENSE, name="Office Supplies", is_closed=False
         )
         self.entity = Entity.objects.create(name="Test Vendor")
 
@@ -233,6 +251,117 @@ class JournalEntryViewTest(TestCase):
 
         # Should not crash - status 200 or 400 is fine, just not 500
         self.assertIn(response.status_code, [200, 400])
+
+    def _make_paystub(self):
+        """Create an unlinked paystub with values for fill-paystub tests."""
+        prefill = PrefillFactory()
+        s3file = S3File.objects.create(
+            prefill=prefill,
+            url="https://example.com/paystub.pdf",
+            user_filename="paystub.pdf",
+            s3_filename="paystub.pdf",
+            textract_job_id="job123",
+            analysis_complete=timezone.now(),
+        )
+        paystub = Paystub.objects.create(
+            document=s3file,
+            page_id="page1",
+            title="Test Paystub",
+            journal_entry=None,
+        )
+        PaystubValue.objects.create(
+            paystub=paystub,
+            account=self.asset_account,
+            amount=Decimal("100.00"),
+            journal_entry_item_type=JournalEntryItem.JournalEntryType.DEBIT,
+        )
+        PaystubValue.objects.create(
+            paystub=paystub,
+            account=self.expense_account,
+            amount=Decimal("100.00"),
+            journal_entry_item_type=JournalEntryItem.JournalEntryType.CREDIT,
+        )
+        return paystub
+
+    def _make_post_data(self, paystub_id, debit_amount):
+        """Build a balanced journal-entry POST payload, varying only the debit amount."""
+        return {
+            "filter-is_closed": "False",
+            "filter-transaction_type": [Transaction.TransactionType.PURCHASE],
+            "index": "0",
+            "paystub_id": paystub_id,
+            "debits-TOTAL_FORMS": "10",
+            "debits-INITIAL_FORMS": "0",
+            "debits-MIN_NUM_FORMS": "0",
+            "debits-MAX_NUM_FORMS": "1000",
+            "debits-0-account": self.asset_account.name,
+            "debits-0-amount": debit_amount,
+            "debits-0-entity": "Test Vendor",
+            "debits-0-id": "",
+            "credits-TOTAL_FORMS": "10",
+            "credits-INITIAL_FORMS": "0",
+            "credits-MIN_NUM_FORMS": "0",
+            "credits-MAX_NUM_FORMS": "1000",
+            "credits-0-account": self.expense_account.name,
+            "credits-0-amount": "100.00",
+            "credits-0-entity": "Test Vendor",
+            "credits-0-id": "",
+        }
+
+    def test_validation_error_preserves_paystub_id(self):
+        """A field-level validation error must keep the paystub_id on the re-rendered form.
+
+        Regression: a negative line-item amount fails validation, and the form was
+        re-rendered without the paystub_id, disassociating it from the paystub.
+        """
+        paystub = self._make_paystub()
+        url = reverse("journal-entries", args=[self.transaction.pk])
+
+        # Negative amount -> fails MinValueValidator(0.00) -> field error
+        post_data = self._make_post_data(str(paystub.id), "-100.00")
+
+        response = self.client.post(url, post_data)
+
+        self.assertEqual(response.status_code, 200)
+        # The re-rendered form must still carry the paystub_id hidden input.
+        self.assertContains(response, 'name="paystub_id"')
+        self.assertContains(response, f'value="{paystub.id}"')
+
+        # Paystub must remain unlinked since the save failed.
+        paystub.refresh_from_db()
+        self.assertIsNone(paystub.journal_entry)
+
+    def test_paystub_resolved_after_correcting_validation_error(self):
+        """After fixing a validation error, resubmitting links (resolves) the paystub."""
+        paystub = self._make_paystub()
+        url = reverse("journal-entries", args=[self.transaction.pk])
+
+        # First submission fails (negative amount).
+        failing_data = self._make_post_data(str(paystub.id), "-100.00")
+        failing_response = self.client.post(url, failing_data)
+        self.assertEqual(failing_response.status_code, 200)
+        paystub.refresh_from_db()
+        self.assertIsNone(paystub.journal_entry)
+
+        # Simulate the browser resubmitting the re-rendered form: the corrected
+        # POST carries whatever paystub_id the error response put in the hidden
+        # field. If that was dropped, the paystub won't be resolved.
+        match = re.search(
+            r'name="paystub_id"[^>]*value="([^"]*)"',
+            failing_response.content.decode(),
+        )
+        self.assertIsNotNone(match, "paystub_id hidden input missing from error form")
+        resubmitted_paystub_id = match.group(1)
+
+        valid_data = self._make_post_data(resubmitted_paystub_id, "100.00")
+        valid_response = self.client.post(url, valid_data)
+        self.assertEqual(valid_response.status_code, 200)
+
+        paystub.refresh_from_db()
+        self.transaction.refresh_from_db()
+        self.assertTrue(self.transaction.is_closed)
+        self.assertIsNotNone(paystub.journal_entry)
+        self.assertEqual(paystub.journal_entry, self.transaction.journal_entry)
 
 
 class JournalEntryTableViewTest(TestCase):

--- a/api/views/journal_entry_views.py
+++ b/api/views/journal_entry_views.py
@@ -206,6 +206,14 @@ class JournalEntryView(LoginRequiredMixin, View):
         )
         metadata_form = JournalEntryMetadataForm(request.POST)
 
+        # Preserve paystub linkage and row index across error re-renders so a
+        # validation failure doesn't disassociate the form from its paystub.
+        submitted_paystub_id = request.POST.get("paystub_id") or None
+        try:
+            submitted_index = int(request.POST.get("index") or 0)
+        except ValueError:
+            submitted_index = 0
+
         # 2. Validate forms (field-level)
         if not (
             debit_formset.is_valid()
@@ -215,6 +223,8 @@ class JournalEntryView(LoginRequiredMixin, View):
             # Render form with field errors
             entry_form_html = render_journal_entry_form(
                 transaction=transaction,
+                index=submitted_index,
+                paystub_id=submitted_paystub_id,
                 debit_formset=debit_formset,
                 credit_formset=credit_formset,
                 form_errors=[],
@@ -234,6 +244,8 @@ class JournalEntryView(LoginRequiredMixin, View):
             # Render form with validation errors
             entry_form_html = render_journal_entry_form(
                 transaction=transaction,
+                index=submitted_index,
+                paystub_id=submitted_paystub_id,
                 debit_formset=debit_formset,
                 credit_formset=credit_formset,
                 form_errors=validation_result.errors,


### PR DESCRIPTION
## Summary
Fixing a validation error on a paystub-filled journal entry no longer
disassociates the form from its paystub. Previously, if a "fill paystub"
produced an invalid line item (e.g. a negative amount), the error
re-render dropped the hidden `paystub_id`, so correcting and resubmitting
saved the entry but left the paystub unresolved.

## Changes
**Backend (`api/views/`)**
- `JournalEntryView.post` now reads `paystub_id` and `index` from the
  submitted POST and passes them into both error-path form re-renders, so
  the hidden fields survive a validation failure.

**Tests**
- `test_validation_error_preserves_paystub_id` — a negative amount fails
  validation and the re-rendered form must still carry the `paystub_id`.
- `test_paystub_resolved_after_correcting_validation_error` — full round
  trip: the corrected resubmission carries whatever id the error form
  rendered, and the paystub ends up linked to the transaction's entry.

## Reviewer focus
- ⚠️ Error paths read `paystub_id`/`index` from raw `request.POST` rather
  than `metadata_form.cleaned_data` (which the success path uses). This is
  deliberate: the field-error branch fires precisely when a form is
  invalid — possibly `metadata_form` itself (its `index` is required) — so
  `cleaned_data` may be empty there.

## Test plan
- [ ] `uv run python manage.py test api.tests.views.test_journal_entry_views`
- [ ] Manually: fill a journal entry from a paystub, submit with a negative
      line item, fix it, resubmit — confirm the paystub is resolved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)