### PR TITLE
Add CI test workflow and Heroku deploy on merge to main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,25 @@
+name: CI
+
+on:
+  pull_request:
+  workflow_call:
+
+jobs:
+  test:
+    name: test
+    runs-on: ubuntu-latest
+    env:
+      SECRET_KEY: ci-dummy-secret-key
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+        with:
+          enable-cache: true
+
+      - name: Install dependencies
+        run: uv sync --dev
+
+      - name: Run tests
+        run: uv run python manage.py test --exclude-tag=e2e --verbosity=2

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,25 @@
+name: Deploy
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  test:
+    uses: ./.github/workflows/ci.yml
+
+  deploy:
+    name: deploy
+    needs: test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Deploy to Heroku
+        env:
+          HEROKU_API_KEY: ${{ secrets.HEROKU_API_KEY }}
+        run: |
+          git push -f https://heroku:$HEROKU_API_KEY@git.heroku.com/fast-cliffs-86166.git HEAD:refs/heads/main

--- a/api/tests/e2e/test_journal_entry_playwright.py
+++ b/api/tests/e2e/test_journal_entry_playwright.py
@@ -20,7 +20,7 @@ from decimal import Decimal
 os.environ["DJANGO_ALLOW_ASYNC_UNSAFE"] = "true"
 
 from django.contrib.auth.models import User
-from django.test import Client, LiveServerTestCase
+from django.test import Client, LiveServerTestCase, tag
 from django.utils import timezone
 from playwright.sync_api import sync_playwright
 
@@ -40,6 +40,7 @@ from api.tests.testing_factories import (
 )
 
 
+@tag("e2e")
 class JournalEntryE2EBase(LiveServerTestCase):
     """Base class: spins up Playwright Chromium and handles auth cookie injection."""
 


### PR DESCRIPTION
## Summary
Sets up GitHub Actions for continuous integration and automated deployment.

- **`.github/workflows/ci.yml`** — runs the Django test suite on every PR (and is reusable via `workflow_call`). Job is named `test`; installs deps with `uv sync --dev` and runs `manage.py test --exclude-tag=e2e`.
- **`.github/workflows/deploy.yml`** — on push to `main`, reuses the CI test job and only deploys if it passes, then git-pushes to the Heroku app `fast-cliffs-86166`.
- **`api/tests/e2e/test_journal_entry_playwright.py`** — tagged the base class `@tag("e2e")` so CI can exclude the browser-based suite (kept runnable locally).

## Follow-up (manual, outside this PR)
- Add a `HEROKU_API_KEY` repo secret (Settings → Secrets and variables → Actions) for the deploy to work.
- Enable branch protection on `main` requiring the `test` status check to block merges.

## Verification
Ran `uv run python manage.py test --exclude-tag=e2e` locally: 341 tests pass, e2e correctly skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)