### PR TITLE
Align and tighten filter-bar field spacing

### DIFF
--- a/ledger/templates/api/base.html
+++ b/ledger/templates/api/base.html
@@ -25,6 +25,11 @@
         .form-sm .form-control {
             padding: .3rem; /* smaller padding */
             font-size: 0.75rem; /* smaller font-size */
+            /* Match height to the reduced padding (Bootstrap's default height assumes
+               .75rem padding). This is the same formula .ta-trigger uses, so date
+               inputs, selects, text inputs and typeahead triggers are all the same
+               height and every filter column lines up row-for-row. */
+            height: calc(1.5em + .6rem + 2px);
         }
         .form-sm .input-group-text {
             padding: .3rem .5rem; /* smaller padding */
@@ -86,6 +91,10 @@
         /* Field labels across all compact forms (the direct-child selector excludes
            the in-popover checkbox labels, .ta-check, which style themselves) */
         .form-sm .form-group > label { font-size: .75rem; font-weight: 500; margin-bottom: 3px; }
+        /* Vertical gap between fields stacked in the same column. Owned here once
+           (not via per-field mb-* utilities) so every column lines up row-for-row.
+           .ta-field is also a .form-group, so typeaheads participate automatically. */
+        .form-sm .form-group + .form-group { margin-top: .25rem; }
         .ta-label { color: #212529; cursor: pointer; user-select: none; }
         .ta-badge { background: #007bff; color: #fff; font-size: .62rem; font-weight: 600; line-height: 1;
                     padding: 2px 6px; border-radius: .7rem; margin-left: 5px; vertical-align: middle; }

--- a/ledger/templates/api/filter_forms/search-filter-form.html
+++ b/ledger/templates/api/filter_forms/search-filter-form.html
@@ -19,7 +19,7 @@
 
         <!-- Date From and Date To -->
         <div class="col-md-2">
-            <div class="form-group mb-2">
+            <div class="form-group">
                 <label for="id_date_from">Date From</label>
                 <input type="date" name="date_from" id="id_date_from" class="form-control"
                        value="{{ form.date_from.value|default_if_none:'' }}">

--- a/ledger/templates/api/filter_forms/transactions-filter-form.html
+++ b/ledger/templates/api/filter_forms/transactions-filter-form.html
@@ -14,9 +14,10 @@
         <div class="col-md-2">
             <div class="form-group">
                 <label for="id_date_from">Date From</label>
-                <input type="date" name="{{ filter_form.date_from.html_name }}" id="{{ filter_form.date_from.auto_id }}" class="form-control mb-2"
+                <input type="date" name="{{ filter_form.date_from.html_name }}" id="{{ filter_form.date_from.auto_id }}" class="form-control"
                        value="{{ filter_form.date_from.value|default_if_none:'' }}">
-
+            </div>
+            <div class="form-group">
                 <label for="id_date_to">Date To</label>
                 <input type="date" name="{{ filter_form.date_to.html_name }}" id="{{ filter_form.date_to.auto_id }}" class="form-control"
                        value="{{ filter_form.date_to.value|default_if_none:'' }}">
@@ -36,7 +37,7 @@
 
         <!-- Stacked Is Closed and Linked Fields -->
         <div class="col-md-2">
-            <div class="form-group mb-2">
+            <div class="form-group">
                 <label for="id_is_closed">Is Closed</label>
                 <select name="{{ filter_form.is_closed.html_name }}" id="{{ filter_form.is_closed.auto_id }}" class="form-control">
                     {% for option in filter_form.is_closed %}


### PR DESCRIPTION
## Summary

The Transactions filter bar's stacked fields weren't level — "Related Account" sat above "Date To" — and the rows were a touch loose. Both issues are fixed in CSS so field spacing has a single source of truth instead of per-field utility classes.

### Root causes (measured in a headless browser, not guessed)

1. **Control height mismatch.** Bootstrap 4.5's `.form-control` sets `height: calc(1.5em + .75rem + 2px)` (32px). `.form-sm` only shrank the *padding* to `.3rem`, never the height — so date inputs/selects stayed 32px, while the hand-tuned `.ta-trigger` was 29.59px. That 2.41px difference accumulated down the Date column and dropped "Date To" below "Related Account". Fix: give `.form-sm .form-control` the **same height formula** the trigger already uses, so every compact control (date inputs, selects, text inputs, typeahead triggers) is identically sized.

2. **Inconsistent inter-field gaps.** Stacked fields used ad-hoc `mb-2` utilities, and the Date column crammed both dates into a single `.form-group`. Fix: each field is now its own `.form-group`, and the vertical gap is owned once by `.form-sm .form-group + .form-group` — then tightened to `.25rem` per request.

### Changes
- `base.html` — match `.form-sm .form-control` height to its padding; add the single stacked-field gap rule (`.25rem`)
- `transactions-filter-form.html` — split Date column into two real `.form-group`s; drop ad-hoc margins
- `search-filter-form.html` — remove redundant `mb-2`

### Testing
Rendered the filter layout in headless Chrome with the production Bootstrap 4.5 + app CSS; "Date To" and "Related Account" label/input top positions now match to 0.00px. No textareas or visible multi-selects use `.form-sm .form-control`, so the fixed height is safe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)