### PR TITLE
Run migrations automatically via Heroku release phase

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,2 +1,3 @@
+release: python manage.py migrate
 web: gunicorn --config gunicorn.conf.py ledger.wsgi
 worker: celery -A api worker --loglevel=info


### PR DESCRIPTION
## Summary

Adds a `release` process to the `Procfile` so Django migrations run automatically on every Heroku deploy.

Heroku executes the release command after the build and before new `web`/`worker` dynos start serving traffic. If a migration fails, Heroku aborts the release and keeps the current version running.

`migrate` is idempotent, so running it on every deploy is a no-op when there are no new migrations.

## Changes

- `Procfile`: add `release: python manage.py migrate`

🤖 Generated with [Claude Code](https://claude.com/claude-code)