### PR TITLE
Move depreciation to bottom of operations section

### DIFF
--- a/api/statement.py
+++ b/api/statement.py
@@ -360,11 +360,11 @@ class CashFlowStatement(Statement):
         ]
         return (
             net_income_less_gains_and_losses
-            + depreciation
             + accounts_receivable_accounts
             + prepaid_expenses_accounts
             + short_term_debt_accounts
             + taxes_payable_accounts
+            + depreciation
         )
 
     def get_cash_from_financing_balances(self):


### PR DESCRIPTION
Reorder the cash flow Operations section so depreciation accounts appear after net income and working-capital changes instead of immediately after Realized Net Income.