### PR TITLE
Render navbar pages cleanly on direct load via hx-boost

### DIFF
--- a/api/views/amortization_views.py
+++ b/api/views/amortization_views.py
@@ -1,11 +1,12 @@
 from django.contrib.auth.mixins import LoginRequiredMixin
 from django.http import HttpResponse
-from django.shortcuts import get_object_or_404, render
+from django.shortcuts import get_object_or_404
 from django.template.loader import render_to_string
 from django.views import View
 
 from api.forms import AmortizationForm, DateForm
 from api.models import Account, Amortization, JournalEntryItem
+from api.views.page_utils import render_full_page
 
 
 class AmortizationTableMixin:
@@ -13,7 +14,7 @@ class AmortizationTableMixin:
     unattached_transactions_content = "api/content/unattached-transactions-content.html"
     page_template = "api/views/amortizations.html"
 
-    def render_page(self, request):
+    def render_page_html(self):
         context = {
             "unattached_transactions": render_to_string(
                 self.unattached_transactions_content,
@@ -27,7 +28,7 @@ class AmortizationTableMixin:
                 {"table": self.get_amortization_table_html()},
             ),
         }
-        return render(request, self.page_template, context)
+        return render_to_string(self.page_template, context)
 
     def get_amortization_table_html(self):
         amortizations = (
@@ -125,13 +126,13 @@ class AmortizationView(AmortizationTableMixin, LoginRequiredMixin, View):
     redirect_field_name = "next"
 
     def get(self, request, *args, **kwargs):
-        return self.render_page(request)
+        return render_full_page(request, self.render_page_html())
 
     def post(self, request):
         form = AmortizationForm(request.POST)
 
         if form.is_valid():
             form.save()
-            return self.render_page(request)
+            return HttpResponse(self.render_page_html())
 
         print(form.errors)

--- a/api/views/entity_views.py
+++ b/api/views/entity_views.py
@@ -14,6 +14,7 @@ from api.forms import JournalEntryItemEntityForm
 from api.models import JournalEntryItem
 from api.services import entity_services
 from api.views import entity_helpers
+from api.views.page_utils import render_full_page
 
 
 def _render_full_page(
@@ -139,4 +140,4 @@ class TagEntitiesView(LoginRequiredMixin, View):
     def get(self, request):
         hide_zero = request.GET.get("hide_zero", "1") != "0"
         html = _render_full_page(is_initial_load=True, hide_zero=hide_zero)
-        return HttpResponse(html)
+        return render_full_page(request, html)

--- a/api/views/frontend_views.py
+++ b/api/views/frontend_views.py
@@ -15,6 +15,7 @@ from api.views.journal_entry_helpers import (
     render_paystubs_table,
     render_paystubs_table_oob_swap,
 )
+from api.views.page_utils import render_full_page
 
 
 class UploadTransactionsView(View):
@@ -38,8 +39,7 @@ class UploadTransactionsView(View):
         paystub_table_html = render_paystubs_table(
             get_paystubs_table_data(), show_fill_button=False
         )
-        return render(
-            request,
+        html = render_to_string(
             template,
             {
                 "form": csv_form_html,
@@ -47,6 +47,7 @@ class UploadTransactionsView(View):
                 "paystubs_table": paystub_table_html,
             },
         )
+        return render_full_page(request, html)
 
     def handle_transactions_form(self, request):
         form = UploadTransactionsForm(request.POST, request.FILES)

--- a/api/views/journal_entry_views.py
+++ b/api/views/journal_entry_views.py
@@ -30,6 +30,7 @@ from api.views.journal_entry_helpers import (
     render_paystubs_table,
 )
 from api.views import transaction_helpers
+from api.views.page_utils import render_full_page
 
 
 class TriggerAutoTagView(LoginRequiredMixin, View):
@@ -167,7 +168,7 @@ class JournalEntryView(LoginRequiredMixin, View):
         }
 
         html = render_to_string(self.view_template, context)
-        return HttpResponse(html)
+        return render_full_page(request, html)
 
     def post(self, request, transaction_id):
         """

--- a/api/views/page_utils.py
+++ b/api/views/page_utils.py
@@ -1,0 +1,18 @@
+"""Shared view utilities for full-page rendering.
+
+Navbar-destination views build their content as an HTML fragment (the same
+fragment HTMX swaps into ``#container``) and wrap it in the full ``base.html``
+shell via :func:`render_full_page`. This means a direct browser load of any
+navbar URL (open-in-new-tab, refresh, bookmark) returns a complete, styled
+page. In-app navigation stays fast because the navbar uses ``hx-boost`` with
+``hx-select="#container"``, which extracts just ``#container`` out of this
+full response.
+"""
+
+from django.http import HttpResponse
+from django.shortcuts import render
+
+
+def render_full_page(request, content_html: str) -> HttpResponse:
+    """Wrap a pre-rendered content fragment in the base.html shell."""
+    return render(request, "api/shell.html", {"content": content_html})

--- a/api/views/reconciliation_views.py
+++ b/api/views/reconciliation_views.py
@@ -1,7 +1,7 @@
 from django.contrib.auth.mixins import LoginRequiredMixin
 from django.forms import modelformset_factory
 from django.http import HttpResponse
-from django.shortcuts import get_object_or_404, render
+from django.shortcuts import get_object_or_404
 from django.template.loader import render_to_string
 from django.views import View
 
@@ -10,6 +10,7 @@ from api.factories import ReconciliationFactory
 from api.forms import ReconciliationFilterForm, ReconciliationForm
 from api.models import Reconciliation
 from api.statement import BalanceSheet
+from api.views.page_utils import render_full_page
 
 
 class ReconciliationTableMixin:
@@ -98,7 +99,8 @@ class ReconciliationView(ReconciliationTableMixin, LoginRequiredMixin, View):
             ),
         }
 
-        return render(request, template, context)
+        html = render_to_string(template, context)
+        return render_full_page(request, html)
 
     def post(self, request):
         if request.POST.get("plug"):

--- a/api/views/search_views.py
+++ b/api/views/search_views.py
@@ -16,6 +16,7 @@ from api.models import Account
 from api.services import search_services
 from api.services.transaction_services import TransactionFilterResult
 from api.views import search_helpers
+from api.views.page_utils import render_full_page
 
 
 def _get_search_results_from_form(form):
@@ -60,7 +61,7 @@ class SearchView(LoginRequiredMixin, View):
             "search_content": "",
         }
         html = render_to_string("api/views/search.html", context)
-        return HttpResponse(html)
+        return render_full_page(request, html)
 
 
 class SearchContentView(LoginRequiredMixin, View):

--- a/api/views/statement_views.py
+++ b/api/views/statement_views.py
@@ -15,6 +15,7 @@ from api.forms import FromToDateForm
 from api.services import statement_services
 from api.statement import BalanceSheet, IncomeStatement
 from api.views import statement_helpers
+from api.views.page_utils import render_full_page
 
 
 class StatementDetailView(LoginRequiredMixin, View):
@@ -79,7 +80,8 @@ class StatementView(LoginRequiredMixin, View):
             "title": title,
         }
         template = "api/views/statement.html"
-        return HttpResponse(render_to_string(template, context))
+        html = render_to_string(template, context)
+        return render_full_page(request, html)
 
     def _get_default_dates(self):
         """Get last month date range."""

--- a/api/views/tax_views.py
+++ b/api/views/tax_views.py
@@ -18,6 +18,7 @@ from api.forms import TaxChargeFilterForm, TaxChargeForm
 from api.models import TaxCharge
 from api.services import tax_services
 from api.views import tax_helpers
+from api.views.page_utils import render_full_page
 
 
 def _parse_date(value):
@@ -109,7 +110,7 @@ class TaxesView(LoginRequiredMixin, View):
         filter_html = tax_helpers.render_tax_filter_form()
 
         html = tax_helpers.render_taxes_page(table_html, form_html, filter_html)
-        return HttpResponse(html)
+        return render_full_page(request, html)
 
     def post(self, request, pk=None, *args, **kwargs):
         tax_charge = get_object_or_404(TaxCharge, pk=pk) if pk else None

--- a/api/views/transaction_views.py
+++ b/api/views/transaction_views.py
@@ -19,6 +19,7 @@ from api.forms import TransactionFilterForm, TransactionForm, TransactionLinkFor
 from api.models import Transaction
 from api.services import transaction_services
 from api.views import transaction_helpers
+from api.views.page_utils import render_full_page
 
 
 # ------------------Transactions View-----------------------
@@ -111,7 +112,7 @@ class TransactionsView(LoginRequiredMixin, View):
 
         view_template = "api/views/transactions.html"
         html = render_to_string(view_template, context)
-        return HttpResponse(html)
+        return render_full_page(request, html)
 
     def post(self, request, transaction_id=None):
         # Parse filter form to get current transaction list
@@ -257,7 +258,7 @@ class LinkTransactionsView(LoginRequiredMixin, View):
 
         view_template = "api/views/transactions-linking.html"
         html = render_to_string(view_template, context)
-        return HttpResponse(html)
+        return render_full_page(request, html)
 
     def post(self, request):
         # Parse link form

--- a/ledger/templates/api/components/nav.html
+++ b/ledger/templates/api/components/nav.html
@@ -5,44 +5,44 @@
             <span class="navbar-toggler-icon"></span>
         </button>
         <div class="collapse navbar-collapse" id="navbarNav">
-            <ul class="navbar-nav">
+            <ul class="navbar-nav" hx-boost="true" hx-target="#container" hx-select="#container" hx-swap="outerHTML show:window:top">
                 <li class="nav-item {% if request.resolver_match.url_name == 'journal-entries' %}active{% endif %}">
-                    <a class="nav-link" href="{% url 'journal-entries' %}" hx-get="{% url 'journal-entries' %}" hx-target="#container">Entries</a>
+                    <a class="nav-link" href="{% url 'journal-entries' %}">Entries</a>
                 </li>
                 <li class="nav-item {% if request.resolver_match.url_name == 'link-transactions' %}active{% endif %}">
-                    <a class="nav-link" href="{% url 'link-transactions' %}" hx-get="{% url 'link-transactions' %}" hx-target="#container">Links</a>
+                    <a class="nav-link" href="{% url 'link-transactions' %}">Links</a>
                 </li>
                 <li class="nav-item {% if request.resolver_match.url_name == 'transactions' %}active{% endif %}">
-                    <a class="nav-link" href="{% url 'transactions' %}" hx-get="{% url 'transactions' %}" hx-target="#container">Transactions</a>
+                    <a class="nav-link" href="{% url 'transactions' %}">Transactions</a>
                 </li>
                 <li class="nav-item {% if request.resolver_match.url_name == 'taxes' %}active{% endif %}">
-                    <a class="nav-link" href="{% url 'taxes' %}" hx-get="{% url 'taxes' %}" hx-target="#container">Taxes</a>
+                    <a class="nav-link" href="{% url 'taxes' %}">Taxes</a>
                 </li>
                 <li class="nav-item {% if request.resolver_match.url_name == 'reconciliation' %}active{% endif %}">
-                    <a class="nav-link" href="{% url 'reconciliation' %}" hx-get="{% url 'reconciliation' %}" hx-target="#container">Reconciliations</a>
+                    <a class="nav-link" href="{% url 'reconciliation' %}">Reconciliations</a>
                 </li>
                 <li class="nav-item {% if request.resolver_match.url_name == 'amortization' %}active{% endif %}">
-                    <a class="nav-link" href="{% url 'amortization' %}" hx-get="{% url 'amortization' %}" hx-target="#container">Amortizations</a>
+                    <a class="nav-link" href="{% url 'amortization' %}">Amortizations</a>
                 </li>
                 <li class="nav-item {% if request.resolver_match.url_name == 'tag-entities' %}active{% endif %}">
-                    <a class="nav-link" href="{% url 'tag-entities' %}" hx-get="{% url 'tag-entities' %}" hx-target="#container">Balances</a>
+                    <a class="nav-link" href="{% url 'tag-entities' %}">Balances</a>
                 </li>
                 <li class="nav-item {% if request.resolver_match.url_name == 'upload-transactions' %}active{% endif %}">
-                    <a class="nav-link" href="{% url 'upload-transactions' %}" hx-get="{% url 'upload-transactions' %}" hx-target="#container">Upload/Download</a>
+                    <a class="nav-link" href="{% url 'upload-transactions' %}">Upload/Download</a>
                 </li>
                 <li class="nav-item {% if request.resolver_match.url_name == 'search' %}active{% endif %}">
-                    <a class="nav-link" href="{% url 'search' %}" hx-get="{% url 'search' %}" hx-target="#container">Search</a>
+                    <a class="nav-link" href="{% url 'search' %}">Search</a>
                 </li>
                 <!-- Dropdown Menu for Financial Statements -->
                 <li class="nav-item dropdown">
-                    <a class="nav-link dropdown-toggle" href="#" id="navbarDropdownMenuLink" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+                    <a class="nav-link dropdown-toggle" href="#" id="navbarDropdownMenuLink" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false" hx-boost="false">
                         Financials
                     </a>
                     <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-                        <!-- hx include to maintain filters between statements -->
-                        <a class="dropdown-item" href="{% url 'statements' 'income' %}" hx-get="{% url 'statements' 'income' %}" hx-target="#container" hx-include="#statement-form">Income Statement</a>
-                        <a class="dropdown-item" href="{% url 'statements' 'balance' %}" hx-get="{% url 'statements' 'balance' %}" hx-target="#container" hx-include="#statement-form">Balance Sheet</a>
-                        <a class="dropdown-item" href="{% url 'statements' 'cash' %}" hx-get="{% url 'statements' 'cash' %}" hx-target="#container" hx-include="#statement-form">Cash Flow</a>
+                        <!-- hx-include to maintain filters between statements -->
+                        <a class="dropdown-item" href="{% url 'statements' 'income' %}" hx-include="#statement-form">Income Statement</a>
+                        <a class="dropdown-item" href="{% url 'statements' 'balance' %}" hx-include="#statement-form">Balance Sheet</a>
+                        <a class="dropdown-item" href="{% url 'statements' 'cash' %}" hx-include="#statement-form">Cash Flow</a>
                     </div>
                 </li>
             </ul>

--- a/ledger/templates/api/shell.html
+++ b/ledger/templates/api/shell.html
@@ -1,0 +1,2 @@
+{% extends "api/base.html" %}
+{% block content %}{{ content|safe }}{% endblock %}


### PR DESCRIPTION
## Problem

Navbar links carried both an `href` and `hx-get`/`hx-target`, and the destination views returned **bare HTML fragments**. Left-clicking worked (HTMX swapped the fragment into `#container`), but **right-click → open in new tab**, refresh, or bookmark triggered a normal GET that returned just the fragment — unstyled, with no navbar or layout.

## Approach

Make every navbar-destination view return a **complete page** and let `hx-boost` keep in-app navigation a fast partial swap. A direct/new-tab/refresh load then works by construction, with no `HX-Request` branching.

- New `api/views/page_utils.py` → `render_full_page(request, html)` wraps a pre-rendered fragment in a new `api/shell.html` (`{% extends "api/base.html" %}`).
- The 10 navbar-destination GET methods now return `render_full_page(...)` instead of a bare `HttpResponse`.
- `nav.html`: scoped `hx-boost="true" hx-target="#container" hx-select="#container" hx-swap="outerHTML show:window:top"` on the `<ul>`; per-link `hx-get`/`hx-target` removed; `hx-boost="false"` on the dropdown toggle; `hx-include="#statement-form"` kept on statement items.

### Why wrap at the GET site instead of having each template extend base

Several page templates (`journal-entry-view.html`, `payables-receivables.html`, `amortizations.html`) are **reused as HTMX partial responses** from POST handlers. Making them extend `base.html` would double-wrap the layout on those swaps. Wrapping only in the GET path keeps the content templates as pure fragments, so the shared ones keep working as partials.

### Navbar visibility on tall pages

`show:window:top` on the boosted swap scrolls to the top after navigation, so tall pages (entries, income statement, balance sheet) show the navbar instead of htmx's default `scrollIntoViewOnBoost` aligning `#container` to the top and pushing it off-screen.

## Testing

- `uv run python manage.py test` — 345/345 non-e2e tests pass (the 5 errors are pre-existing Playwright infra failures unrelated to this change).
- `uv run python manage.py check` — clean.
- Verified via the test client that navbar GETs now return a full document (`<!DOCTYPE html>` + `<nav>` + `#container` + content).

Worth a manual click-through to confirm boosted nav (content-only swap, navbar stays) and new-tab loads render fully.

🤖 Generated with [Claude Code](https://claude.com/claude-code)