### PR TITLE
Add one-click Autofill for calculated tax recommendations

### DIFF
--- a/api/services/tax_services.py
+++ b/api/services/tax_services.py
@@ -13,6 +13,7 @@ from datetime import date
 from decimal import Decimal
 from typing import Dict, List, Optional
 
+from django.db import transaction as db_transaction
 from django.db.models import QuerySet
 
 from api.models import Account, TaxCharge
@@ -42,6 +43,32 @@ class TaxAccountRecommendation:
     """Tax account with recommended tax amount."""
     account: Account
     recommended_tax: Optional[Decimal]
+
+
+@dataclass
+class ApplyRecommendationResult:
+    """Result of applying a recommended tax amount to a tax charge."""
+    success: bool
+    tax_charge: Optional[TaxCharge] = None
+    error: Optional[str] = None
+
+
+def _recommended_amount_for(
+    account: Account,
+    taxable_income: Decimal,
+) -> Optional[Decimal]:
+    """
+    Compute the recommended tax amount for a single account.
+
+    Uses account.tax_rate * taxable_income for percentage-based taxes,
+    or the flat account.tax_amount for fixed taxes (e.g. property tax).
+    Returns None when the account has neither configured.
+    """
+    if account.tax_rate:
+        return account.tax_rate * taxable_income
+    if account.tax_amount:
+        return account.tax_amount
+    return None
 
 
 def get_taxable_income(end_date: date) -> TaxableIncomeData:
@@ -154,21 +181,55 @@ def get_tax_account_recommendations(
     recommendations: List[TaxAccountRecommendation] = []
 
     for account in tax_accounts:
-        if account.tax_rate:
-            recommended_tax = account.tax_rate * taxable_income
-        elif account.tax_amount:
-            recommended_tax = account.tax_amount
-        else:
-            recommended_tax = None
-
         recommendations.append(
             TaxAccountRecommendation(
                 account=account,
-                recommended_tax=recommended_tax,
+                recommended_tax=_recommended_amount_for(account, taxable_income),
             )
         )
 
     return recommendations
+
+
+@db_transaction.atomic
+def apply_tax_recommendation(
+    account_pk: int,
+    end_date: date,
+) -> ApplyRecommendationResult:
+    """
+    Apply the recommended tax amount directly to an account's tax charge.
+
+    Recomputes the recommendation server-side (never trusting a client value),
+    then finds or creates the TaxCharge for the given account and month-end date
+    and sets its amount. TaxCharge.save() cascades to the related transaction,
+    journal entry, and reconciliation.
+
+    Args:
+        account_pk: Primary key of the tax account to update.
+        end_date: The month-end date the recommendation was computed for.
+
+    Returns:
+        ApplyRecommendationResult with the updated tax charge or an error.
+    """
+    account = Account.objects.filter(pk=account_pk).first()
+    if account is None:
+        return ApplyRecommendationResult(success=False, error="Account not found")
+
+    taxable_income = get_taxable_income(end_date).amount
+    amount = _recommended_amount_for(account, taxable_income)
+    if amount is None:
+        return ApplyRecommendationResult(
+            success=False, error="No recommendation available for account"
+        )
+
+    tax_charge, created = TaxCharge.objects.get_or_create(
+        account=account, date=end_date, defaults={"amount": amount}
+    )
+    if not created:
+        tax_charge.amount = amount
+        tax_charge.save()
+
+    return ApplyRecommendationResult(success=True, tax_charge=tax_charge)
 
 
 def get_filtered_tax_charges(

--- a/api/tests/services/test_tax_services.py
+++ b/api/tests/services/test_tax_services.py
@@ -16,9 +16,11 @@ from django.test import TestCase
 
 from api.models import Account, TaxCharge, Transaction
 from api.services.tax_services import (
+    ApplyRecommendationResult,
     TaxableIncomeData,
     TaxChargeWithRate,
     TaxAccountRecommendation,
+    apply_tax_recommendation,
     get_taxable_income,
     enrich_tax_charges_with_rates,
     get_tax_account_recommendations,
@@ -303,6 +305,133 @@ class GetTaxAccountRecommendationsTest(TestCase):
         # Should only return the federal tax account
         self.assertEqual(len(result), 1)
         self.assertEqual(result[0].account.special_type, Account.SpecialType.FEDERAL_TAXES)
+
+
+class ApplyTaxRecommendationTest(TestCase):
+    """Tests for apply_tax_recommendation() function."""
+
+    def setUp(self):
+        """Create a tax account (with payable) and a percentage rate."""
+        self.tax_payable = AccountFactory(type=Account.Type.LIABILITY)
+        self.federal_account = AccountFactory(
+            type=Account.Type.EXPENSE,
+            special_type=Account.SpecialType.FEDERAL_TAXES,
+            tax_payable_account=self.tax_payable,
+            tax_rate=Decimal("0.25"),
+            tax_amount=None,
+        )
+        self.end_date = date(2024, 1, 31)
+
+    @patch("api.services.tax_services.get_taxable_income")
+    def test_updates_existing_charge_amount(self, mock_get_taxable_income):
+        """Applies tax_rate * taxable_income to an existing charge."""
+        mock_get_taxable_income.return_value = TaxableIncomeData(
+            amount=Decimal("10000.00"),
+            start_date=date(2024, 1, 1),
+            end_date=self.end_date,
+        )
+        existing = TaxCharge.objects.create(
+            account=self.federal_account, date=self.end_date, amount=Decimal("0")
+        )
+
+        result = apply_tax_recommendation(self.federal_account.pk, self.end_date)
+
+        self.assertIsInstance(result, ApplyRecommendationResult)
+        self.assertTrue(result.success)
+        self.assertEqual(result.tax_charge.pk, existing.pk)
+        existing.refresh_from_db()
+        self.assertEqual(existing.amount, Decimal("2500.00"))
+
+    @patch("api.services.tax_services.get_taxable_income")
+    def test_updates_related_transaction(self, mock_get_taxable_income):
+        """The cascade through TaxCharge.save() updates the transaction amount."""
+        mock_get_taxable_income.return_value = TaxableIncomeData(
+            amount=Decimal("10000.00"),
+            start_date=date(2024, 1, 1),
+            end_date=self.end_date,
+        )
+        existing = TaxCharge.objects.create(
+            account=self.federal_account, date=self.end_date, amount=Decimal("0")
+        )
+
+        apply_tax_recommendation(self.federal_account.pk, self.end_date)
+
+        existing.refresh_from_db()
+        self.assertEqual(existing.transaction.amount, Decimal("2500.00"))
+
+    @patch("api.services.tax_services.get_taxable_income")
+    def test_creates_charge_when_none_exists(self, mock_get_taxable_income):
+        """Creates a charge for the account/date when none exists yet."""
+        mock_get_taxable_income.return_value = TaxableIncomeData(
+            amount=Decimal("10000.00"),
+            start_date=date(2024, 1, 1),
+            end_date=self.end_date,
+        )
+
+        result = apply_tax_recommendation(self.federal_account.pk, self.end_date)
+
+        self.assertTrue(result.success)
+        charge = TaxCharge.objects.get(
+            account=self.federal_account, date=self.end_date
+        )
+        self.assertEqual(charge.amount, Decimal("2500.00"))
+
+    @patch("api.services.tax_services.get_taxable_income")
+    def test_uses_flat_tax_amount(self, mock_get_taxable_income):
+        """Uses the flat tax_amount for fixed (e.g. property) taxes."""
+        mock_get_taxable_income.return_value = TaxableIncomeData(
+            amount=Decimal("10000.00"),
+            start_date=date(2024, 1, 1),
+            end_date=self.end_date,
+        )
+        property_payable = AccountFactory(type=Account.Type.LIABILITY)
+        property_account = AccountFactory(
+            type=Account.Type.EXPENSE,
+            special_type=Account.SpecialType.PROPERTY_TAXES,
+            tax_payable_account=property_payable,
+            tax_rate=None,
+            tax_amount=Decimal("500.00"),
+        )
+
+        result = apply_tax_recommendation(property_account.pk, self.end_date)
+
+        self.assertTrue(result.success)
+        result.tax_charge.refresh_from_db()
+        self.assertEqual(result.tax_charge.amount, Decimal("500.00"))
+
+    @patch("api.services.tax_services.get_taxable_income")
+    def test_returns_error_when_no_rate_or_amount(self, mock_get_taxable_income):
+        """Returns failure when the account has neither a rate nor a flat amount."""
+        mock_get_taxable_income.return_value = TaxableIncomeData(
+            amount=Decimal("10000.00"),
+            start_date=date(2024, 1, 1),
+            end_date=self.end_date,
+        )
+        no_rate_payable = AccountFactory(type=Account.Type.LIABILITY)
+        no_rate_account = AccountFactory(
+            type=Account.Type.EXPENSE,
+            special_type=Account.SpecialType.STATE_TAXES,
+            tax_payable_account=no_rate_payable,
+            tax_rate=None,
+            tax_amount=None,
+        )
+
+        result = apply_tax_recommendation(no_rate_account.pk, self.end_date)
+
+        self.assertFalse(result.success)
+        self.assertIsNone(result.tax_charge)
+        self.assertFalse(
+            TaxCharge.objects.filter(
+                account=no_rate_account, date=self.end_date
+            ).exists()
+        )
+
+    def test_returns_error_for_missing_account(self):
+        """Returns failure when the account does not exist."""
+        result = apply_tax_recommendation(999999, self.end_date)
+
+        self.assertFalse(result.success)
+        self.assertEqual(result.error, "Account not found")
 
 
 class GetFilteredTaxChargesTest(TestCase):

--- a/api/views/tax_helpers.py
+++ b/api/views/tax_helpers.py
@@ -5,6 +5,7 @@ These pure functions handle all HTML rendering for tax views,
 replacing the rendering logic from TaxChargeMixIn.
 """
 
+from datetime import date
 from decimal import Decimal
 from typing import List, Optional
 
@@ -33,6 +34,7 @@ def render_tax_form(
     tax_charge: Optional[TaxCharge],
     taxable_income: Decimal,
     tax_accounts: List[TaxAccountRecommendation],
+    end_date: date,
 ) -> str:
     """
     Render the tax charge entry form HTML.
@@ -41,6 +43,8 @@ def render_tax_form(
         tax_charge: Optional existing tax charge to edit.
         taxable_income: Current taxable income amount.
         tax_accounts: List of tax accounts with recommended amounts.
+        end_date: Month-end date the recommendations apply to (used by the
+            per-account apply buttons).
 
     Returns:
         HTML string for the tax form.
@@ -63,6 +67,7 @@ def render_tax_form(
         "taxable_income": taxable_income,
         "tax_accounts": accounts_with_recommendations,
         "tax_charge": tax_charge,
+        "end_date": end_date,
     }
 
     return render_to_string(

--- a/api/views/tax_views.py
+++ b/api/views/tax_views.py
@@ -27,6 +27,46 @@ def _parse_date(value):
     return date.fromisoformat(str(value))
 
 
+def _render_updated_content(post_data) -> str:
+    """
+    Re-render the taxes table + form for an HTMX update.
+
+    Honors the submitted filter form (date range / tax type) so the refreshed
+    content matches the user's current filter, falling back to the default
+    six-month window when the filter form is absent or invalid.
+    """
+    filter_form = TaxChargeFilterForm(post_data)
+    if filter_form.is_valid():
+        date_from = _parse_date(filter_form.cleaned_data["date_from"])
+        date_to = _parse_date(filter_form.cleaned_data["date_to"])
+        tax_charges = tax_services.get_filtered_tax_charges(
+            date_from=date_from,
+            date_to=date_to,
+            tax_type=filter_form.cleaned_data.get("tax_type"),
+        )
+        end_date = date_to
+    else:
+        # Fallback to default date range
+        initial_end_date = utils.get_last_day_of_last_month()
+        six_months_ago = utils.get_last_days_of_month_tuples()[5][0]
+        tax_charges = tax_services.get_filtered_tax_charges(
+            date_from=six_months_ago, date_to=initial_end_date
+        )
+        end_date = initial_end_date
+
+    enriched = tax_services.enrich_tax_charges_with_rates(tax_charges)
+    taxable_income = tax_services.get_taxable_income(end_date)
+    recommendations = tax_services.get_tax_account_recommendations(
+        taxable_income.amount
+    )
+
+    table_html = tax_helpers.render_tax_table(enriched)
+    form_html = tax_helpers.render_tax_form(
+        None, taxable_income.amount, recommendations, end_date
+    )
+    return tax_helpers.render_taxes_content(table_html, form_html)
+
+
 class TaxChargeTableView(LoginRequiredMixin, View):
     """Handle tax charge table filtering."""
 
@@ -52,7 +92,7 @@ class TaxChargeTableView(LoginRequiredMixin, View):
                 taxable_income.amount
             )
             form_html = tax_helpers.render_tax_form(
-                None, taxable_income.amount, recommendations
+                None, taxable_income.amount, recommendations, date_to
             )
 
             html = tax_helpers.render_taxes_content(table_html, form_html)
@@ -76,7 +116,7 @@ class TaxChargeFormView(LoginRequiredMixin, View):
             taxable_income.amount
         )
         html = tax_helpers.render_tax_form(
-            tax_charge, taxable_income.amount, recommendations
+            tax_charge, taxable_income.amount, recommendations, end_date
         )
         return HttpResponse(html)
 
@@ -104,7 +144,7 @@ class TaxesView(LoginRequiredMixin, View):
 
         table_html = tax_helpers.render_tax_table(enriched)
         form_html = tax_helpers.render_tax_form(
-            None, taxable_income.amount, recommendations
+            None, taxable_income.amount, recommendations, initial_end_date
         )
         filter_html = tax_helpers.render_tax_filter_form()
 
@@ -118,36 +158,20 @@ class TaxesView(LoginRequiredMixin, View):
         if form.is_valid():
             form.save()
 
-        # Re-render with updated data
-        filter_form = TaxChargeFilterForm(request.POST)
-        if filter_form.is_valid():
-            date_from = _parse_date(filter_form.cleaned_data["date_from"])
-            date_to = _parse_date(filter_form.cleaned_data["date_to"])
-            tax_charges = tax_services.get_filtered_tax_charges(
-                date_from=date_from,
-                date_to=date_to,
-                tax_type=filter_form.cleaned_data.get("tax_type"),
-            )
-            end_date = date_to
-        else:
-            # Fallback to default date range
-            initial_end_date = utils.get_last_day_of_last_month()
-            six_months_ago = utils.get_last_days_of_month_tuples()[5][0]
-            tax_charges = tax_services.get_filtered_tax_charges(
-                date_from=six_months_ago, date_to=initial_end_date
-            )
-            end_date = initial_end_date
+        return HttpResponse(_render_updated_content(request.POST))
 
-        enriched = tax_services.enrich_tax_charges_with_rates(tax_charges)
-        taxable_income = tax_services.get_taxable_income(end_date)
-        recommendations = tax_services.get_tax_account_recommendations(
-            taxable_income.amount
+
+class ApplyTaxRecommendationView(LoginRequiredMixin, View):
+    """Apply a calculated tax recommendation directly to an account's charge."""
+
+    login_url = "/login/"
+    redirect_field_name = "next"
+
+    def post(self, request, account_pk, end_date, *args, **kwargs):
+        result = tax_services.apply_tax_recommendation(
+            account_pk, _parse_date(end_date)
         )
+        if not result.success:
+            return HttpResponse(result.error, status=400)
 
-        table_html = tax_helpers.render_tax_table(enriched)
-        form_html = tax_helpers.render_tax_form(
-            None, taxable_income.amount, recommendations
-        )
-
-        html = tax_helpers.render_taxes_content(table_html, form_html)
-        return HttpResponse(html)
+        return HttpResponse(_render_updated_content(request.POST))

--- a/ledger/templates/api/entry_forms/edit-tax-charge-form.html
+++ b/ledger/templates/api/entry_forms/edit-tax-charge-form.html
@@ -81,8 +81,21 @@
                     {% for account in tax_accounts %}
                     <tr>
                         <th scope="row">{{ account.name }}</th>
-                        <td class="copyable">
-                            ${{ account.recommended_tax|floatformat:2|intcomma }} <i class="bi bi-clipboard"></i>
+                        <td>
+                            <div class="d-flex justify-content-between align-items-center">
+                                <span>${{ account.recommended_tax|floatformat:2|intcomma }}</span>
+                                {% if account.recommended_tax is not None %}
+                                <button
+                                    type="button"
+                                    class="btn btn-outline-primary btn-sm py-0"
+                                    style="font-size: 0.75rem; line-height: 1.4;"
+                                    title="Apply this amount to the tax charge"
+                                    hx-post="{% url 'apply-tax-recommendation' account_pk=account.pk end_date=end_date|date:'Y-m-d' %}"
+                                    hx-target="#table-and-form"
+                                    hx-include="#taxes-filter-form"
+                                >Autofill</button>
+                                {% endif %}
+                            </div>
                         </td>
                     </tr>
                     {% endfor %}
@@ -91,37 +104,3 @@
         </div>
     </div>
 </div>
-
-{% block extra_js %}
-<script>
-  document.querySelectorAll(".copyable").forEach((el) => {
-    const icon = el.querySelector("i");
-
-    icon.addEventListener("click", async (event) => {
-      event.stopPropagation(); // prevent bubbling
-
-      const input = document.querySelector("#id_amount");
-      if (!input) return;
-
-      // Get the text of the parent element (without icon text)
-      const textToCopy = el.textContent.replace(icon.textContent, "").trim();
-
-      // Remove any dollar signs or commas before setting the value
-      const numericValue = textToCopy.replace(/[\$,]/g, "");
-
-      // Fill the input
-      input.value = numericValue;
-
-      // Change icon to check
-      icon.classList.remove("bi-clipboard");
-      icon.classList.add("bi-check2", "text-success");
-
-      // Revert after 3 seconds
-      setTimeout(() => {
-        icon.classList.remove("bi-check2", "text-success");
-        icon.classList.add("bi-clipboard");
-      }, 3000);
-    });
-  });
-</script>
-{% endblock %}

--- a/ledger/urls.py
+++ b/ledger/urls.py
@@ -28,7 +28,12 @@ from api.views.journal_entry_views import (
 from api.views.reconciliation_views import ReconciliationTableView, ReconciliationView
 from api.views.search_views import SearchBulkUpdateView, SearchContentView, SearchView
 from api.views.statement_views import StatementDetailView, StatementView
-from api.views.tax_views import TaxChargeFormView, TaxChargeTableView, TaxesView
+from api.views.tax_views import (
+    ApplyTaxRecommendationView,
+    TaxChargeFormView,
+    TaxChargeTableView,
+    TaxesView,
+)
 from api.views.transaction_views import (
     LinkTransactionsContentView,
     LinkTransactionsView,
@@ -115,6 +120,11 @@ urlpatterns = [
     # Taxes page
     path("taxes/", TaxesView.as_view(), name="taxes"),
     path("taxes/<int:pk>/", TaxesView.as_view(), name="edit-tax-charge"),
+    path(
+        "taxes/apply/<int:account_pk>/<str:end_date>/",
+        ApplyTaxRecommendationView.as_view(),
+        name="apply-tax-recommendation",
+    ),
     path("tax-charge-table/", TaxChargeTableView.as_view(), name="tax-charge-table"),
     path("taxes/form/", TaxChargeFormView.as_view(), name="tax-form"),
     path("taxes/form/<int:pk>/", TaxChargeFormView.as_view(), name="tax-form-bound"),


### PR DESCRIPTION
## Summary

On the Taxes page, applying a calculated tax value used to require a clipboard click (which only *populated* the amount field), making sure the form's account dropdown matched the row you copied from, and then a second Save click.

This replaces that flow with a per-account **Autofill** button on each recommendation row. Clicking it updates *that account's* tax charge for the displayed month in a single click — no dropdown alignment, no second click. The manual account/date/amount/Save form stays for custom amounts and row-click edits.

## How it works

- New `apply_tax_recommendation(account_pk, end_date)` service (atomic) **recomputes** the recommendation server-side (never trusting a client value), finds-or-creates the matching `TaxCharge`, and sets its amount. `TaxCharge.save()` cascades to the transaction, journal entry, and reconciliation as before.
- Extracted `_recommended_amount_for()` so the button and the recommendations table share one calculation.
- Extracted `_render_updated_content()` in the views, reused by both `TaxesView.post` and the new `ApplyTaxRecommendationView`, so the refresh honors the active filter.
- New route: `taxes/apply/<account_pk>/<end_date>/`.

## Files

- `api/services/tax_services.py` — `apply_tax_recommendation`, `ApplyRecommendationResult`, `_recommended_amount_for`
- `api/views/tax_views.py` — `ApplyTaxRecommendationView`, `_render_updated_content`
- `api/views/tax_helpers.py` — `render_tax_form` gains `end_date`
- `ledger/urls.py` — new route
- `edit-tax-charge-form.html` — clipboard icon + JS replaced with Autofill buttons (right-aligned in the cell)
- `api/tests/services/test_tax_services.py` — 6 new tests

## Testing

- `test_tax_services`: 23/23 pass.
- Full suite: only pre-existing Playwright e2e environment errors (`Sync API inside the asyncio loop`) fail; unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)