### PR TITLE
Fix e2e filter tests for hidden multiselect widget

### DIFF
--- a/api/tests/e2e/test_journal_entry_playwright.py
+++ b/api/tests/e2e/test_journal_entry_playwright.py
@@ -142,7 +142,9 @@ class JournalEntryFilterTests(JournalEntryE2EBase):
         self.assertIn("INCOME_TXN_TEST", content)
         self.assertIn("PURCHASE_TXN_TEST", content)
 
-        self.page.select_option("select[name='filter-transaction_type']", ["income"])
+        self.page.select_option(
+            "select[name='filter-transaction_type']", ["income"], force=True
+        )
         self.apply_filter()
 
         content = self.page.content()
@@ -176,7 +178,7 @@ class JournalEntryFilterTests(JournalEntryE2EBase):
         self.goto_journal_entries()
 
         self.page.select_option(
-            "select[name='filter-transaction_type']", ["income", "purchase"]
+            "select[name='filter-transaction_type']", ["income", "purchase"], force=True
         )
         self.apply_filter()
 
@@ -273,7 +275,9 @@ class JournalEntryFilterTests(JournalEntryE2EBase):
 
         self.goto_journal_entries()
 
-        self.page.select_option("select[name='filter-transaction_type']", ["income"])
+        self.page.select_option(
+            "select[name='filter-transaction_type']", ["income"], force=True
+        )
         self.page.select_option("select[name='filter-is_closed']", "False")
         self.apply_filter()
 
@@ -301,7 +305,9 @@ class JournalEntryEmptyStateTests(JournalEntryE2EBase):
         self.goto_journal_entries()
 
         # Filter to PAYMENT — no payment transactions exist
-        self.page.select_option("select[name='filter-transaction_type']", ["payment"])
+        self.page.select_option(
+            "select[name='filter-transaction_type']", ["payment"], force=True
+        )
         self.apply_filter()
 
         rows = self.page.locator("#transactions-table tbody tr")


### PR DESCRIPTION
## Summary

The `transaction_type` filter was converted to a custom Alpine typeahead-multiselect widget (`typeahead-multiselect.html`) that hides the real `<select>` with `display:none` while keeping it as the actual submitted form field. The four e2e filter tests drive that native select directly, which is valid — but Playwright refuses to interact with a hidden element, so they timed out.

This adds `force=True` to the four `select_option` calls targeting `filter-transaction_type`, bypassing the visibility actionability check. The native `<select>` is still the field the form submits, so the tests continue to exercise real server-side filter behavior. The visible `filter-is_closed` select is left unchanged.

## Notes

- Running these tests requires the Playwright browser locally: `uv run playwright install chromium`.
- CI is unaffected — it runs `manage.py test --exclude-tag=e2e`.

## Test plan

- [x] `uv run python manage.py test api.tests.e2e` — all 13 tests pass (down from 4 errors).

🤖 Generated with [Claude Code](https://claude.com/claude-code)