### PR TITLE
Consolidate tax view rendering and tax-account filter

### DIFF
--- a/api/factories.py
+++ b/api/factories.py
@@ -1,4 +1,5 @@
 from api.models import Account, Reconciliation, TaxCharge
+from api.services.tax_services import get_tax_accounts
 
 
 class ReconciliationFactory:
@@ -32,13 +33,7 @@ class TaxChargeFactory:
     @staticmethod
     def create_bulk_tax_charges(date):
         tax_charges = TaxCharge.objects.filter(date=date)
-        tax_accounts = Account.objects.filter(
-            special_type__in=[
-                Account.SpecialType.FEDERAL_TAXES,
-                Account.SpecialType.PROPERTY_TAXES,
-                Account.SpecialType.STATE_TAXES,
-            ]
-        )
+        tax_accounts = get_tax_accounts()
 
         for account in tax_accounts:
             existing_tax_charge = [

--- a/api/forms.py
+++ b/api/forms.py
@@ -11,6 +11,7 @@ from django.utils import timezone
 
 from api import utils
 from api.factories import ReconciliationFactory
+from api.services.tax_services import get_tax_accounts
 from api.models import (
     Account,
     Amortization,
@@ -201,13 +202,7 @@ class TaxChargeFilterForm(forms.Form):
     date_to = forms.ChoiceField(required=False, choices=[])
     tax_type = forms.ModelChoiceField(
         required=False,
-        queryset=Account.objects.filter(
-            special_type__in=[
-                Account.SpecialType.FEDERAL_TAXES,
-                Account.SpecialType.STATE_TAXES,
-                Account.SpecialType.PROPERTY_TAXES,
-            ]
-        ),
+        queryset=get_tax_accounts(),
     )
 
     def __init__(self, *args, **kwargs):
@@ -255,14 +250,7 @@ class TaxChargeForm(forms.ModelForm):
         self.fields["date"].choices = last_days_of_month_tuples
         last_day_of_last_month = last_days_of_month_tuples[0][0]
         self.fields["date"].initial = last_day_of_last_month
-        tax_accounts = Account.objects.filter(
-            special_type__in=[
-                Account.SpecialType.FEDERAL_TAXES,
-                Account.SpecialType.STATE_TAXES,
-                Account.SpecialType.PROPERTY_TAXES,
-            ]
-        )
-        self.fields["account"].queryset = tax_accounts
+        self.fields["account"].queryset = get_tax_accounts()
 
 
 class TransactionLinkForm(forms.Form):

--- a/api/services/tax_services.py
+++ b/api/services/tax_services.py
@@ -154,6 +154,22 @@ def enrich_tax_charges_with_rates(
     return enriched_charges
 
 
+def get_tax_accounts() -> QuerySet:
+    """
+    Return the tax expense accounts (federal, state, property).
+
+    Single source of truth for "which accounts are taxes" — shared by the
+    recommendations service, the tax forms, and bulk tax-charge creation.
+    """
+    return Account.objects.filter(
+        special_type__in=[
+            Account.SpecialType.FEDERAL_TAXES,
+            Account.SpecialType.STATE_TAXES,
+            Account.SpecialType.PROPERTY_TAXES,
+        ]
+    )
+
+
 def get_tax_account_recommendations(
     taxable_income: Decimal,
 ) -> List[TaxAccountRecommendation]:
@@ -170,13 +186,7 @@ def get_tax_account_recommendations(
     Returns:
         List of TaxAccountRecommendation objects.
     """
-    tax_accounts = Account.objects.filter(
-        special_type__in=[
-            Account.SpecialType.FEDERAL_TAXES,
-            Account.SpecialType.STATE_TAXES,
-            Account.SpecialType.PROPERTY_TAXES,
-        ]
-    )
+    tax_accounts = get_tax_accounts()
 
     recommendations: List[TaxAccountRecommendation] = []
 

--- a/api/views/tax_views.py
+++ b/api/views/tax_views.py
@@ -28,33 +28,14 @@ def _parse_date(value):
     return date.fromisoformat(str(value))
 
 
-def _render_updated_content(post_data) -> str:
+def _build_table_and_form(tax_charges, end_date: date):
     """
-    Re-render the taxes table + form for an HTMX update.
+    Build the tax table + form HTML for a set of charges and the month-end date.
 
-    Honors the submitted filter form (date range / tax type) so the refreshed
-    content matches the user's current filter, falling back to the default
-    six-month window when the filter form is absent or invalid.
+    Returns a (table_html, form_html) tuple. Shared by every taxes view so the
+    enrich → taxable-income → recommendations → render pipeline lives in one
+    place.
     """
-    filter_form = TaxChargeFilterForm(post_data)
-    if filter_form.is_valid():
-        date_from = _parse_date(filter_form.cleaned_data["date_from"])
-        date_to = _parse_date(filter_form.cleaned_data["date_to"])
-        tax_charges = tax_services.get_filtered_tax_charges(
-            date_from=date_from,
-            date_to=date_to,
-            tax_type=filter_form.cleaned_data.get("tax_type"),
-        )
-        end_date = date_to
-    else:
-        # Fallback to default date range
-        initial_end_date = utils.get_last_day_of_last_month()
-        six_months_ago = utils.get_last_days_of_month_tuples()[5][0]
-        tax_charges = tax_services.get_filtered_tax_charges(
-            date_from=six_months_ago, date_to=initial_end_date
-        )
-        end_date = initial_end_date
-
     enriched = tax_services.enrich_tax_charges_with_rates(tax_charges)
     taxable_income = tax_services.get_taxable_income(end_date)
     recommendations = tax_services.get_tax_account_recommendations(
@@ -65,6 +46,35 @@ def _render_updated_content(post_data) -> str:
     form_html = tax_helpers.render_tax_form(
         None, taxable_income.amount, recommendations, end_date
     )
+    return table_html, form_html
+
+
+def _render_updated_content(data) -> str:
+    """
+    Re-render the taxes table + form for an HTMX update.
+
+    Honors the submitted filter form (date range / tax type) so the refreshed
+    content matches the user's current filter, falling back to the default
+    six-month window when the filter form is absent or invalid.
+    """
+    filter_form = TaxChargeFilterForm(data)
+    if filter_form.is_valid():
+        date_from = _parse_date(filter_form.cleaned_data["date_from"])
+        end_date = _parse_date(filter_form.cleaned_data["date_to"])
+        tax_charges = tax_services.get_filtered_tax_charges(
+            date_from=date_from,
+            date_to=end_date,
+            tax_type=filter_form.cleaned_data.get("tax_type"),
+        )
+    else:
+        # Fallback to default date range
+        end_date = utils.get_last_day_of_last_month()
+        six_months_ago = utils.get_last_days_of_month_tuples()[5][0]
+        tax_charges = tax_services.get_filtered_tax_charges(
+            date_from=six_months_ago, date_to=end_date
+        )
+
+    table_html, form_html = _build_table_and_form(tax_charges, end_date)
     return tax_helpers.render_taxes_content(table_html, form_html)
 
 
@@ -75,29 +85,7 @@ class TaxChargeTableView(LoginRequiredMixin, View):
     redirect_field_name = "next"
 
     def get(self, request, *args, **kwargs):
-        form = TaxChargeFilterForm(request.GET)
-        if form.is_valid():
-            date_from = _parse_date(form.cleaned_data["date_from"])
-            date_to = _parse_date(form.cleaned_data["date_to"])
-
-            tax_charges = tax_services.get_filtered_tax_charges(
-                date_from=date_from,
-                date_to=date_to,
-                tax_type=form.cleaned_data.get("tax_type"),
-            )
-            enriched = tax_services.enrich_tax_charges_with_rates(tax_charges)
-            table_html = tax_helpers.render_tax_table(enriched)
-
-            taxable_income = tax_services.get_taxable_income(date_to)
-            recommendations = tax_services.get_tax_account_recommendations(
-                taxable_income.amount
-            )
-            form_html = tax_helpers.render_tax_form(
-                None, taxable_income.amount, recommendations, date_to
-            )
-
-            html = tax_helpers.render_taxes_content(table_html, form_html)
-            return HttpResponse(html)
+        return HttpResponse(_render_updated_content(request.GET))
 
 
 class TaxChargeFormView(LoginRequiredMixin, View):
@@ -136,17 +124,8 @@ class TaxesView(LoginRequiredMixin, View):
         tax_charges = tax_services.get_filtered_tax_charges(
             date_from=six_months_ago, date_to=initial_end_date
         )
-        enriched = tax_services.enrich_tax_charges_with_rates(tax_charges)
 
-        taxable_income = tax_services.get_taxable_income(initial_end_date)
-        recommendations = tax_services.get_tax_account_recommendations(
-            taxable_income.amount
-        )
-
-        table_html = tax_helpers.render_tax_table(enriched)
-        form_html = tax_helpers.render_tax_form(
-            None, taxable_income.amount, recommendations, initial_end_date
-        )
+        table_html, form_html = _build_table_and_form(tax_charges, initial_end_date)
         filter_html = tax_helpers.render_tax_filter_form()
 
         html = tax_helpers.render_taxes_page(table_html, form_html, filter_html)


### PR DESCRIPTION
## Summary

Two reuse/simplification cleanups on the taxes code, following up on the Autofill PR (#366):

1. **Deduplicate the taxes render pipeline.** The sequence `enrich_tax_charges_with_rates → get_taxable_income → get_tax_account_recommendations → render_tax_table → render_tax_form` was written out three times (`_render_updated_content`, `TaxChargeTableView.get`, `TaxesView.get`). Extracted a shared `_build_table_and_form(tax_charges, end_date)` helper; `TaxChargeTableView.get` collapses to a one-liner delegating to `_render_updated_content(request.GET)`.

2. **Single source of truth for tax accounts.** The `special_type__in=[FEDERAL_TAXES, STATE_TAXES, PROPERTY_TAXES]` filter was duplicated in four places (`tax_services`, `TaxChargeFilterForm`, `TaxChargeForm`, and `TaxChargeFactory`). Added a `get_tax_accounts()` service helper that all four now call — adding a new tax type is a one-line edit instead of four.

## Notes

- No behavior change intended. Minor bonus: `TaxChargeTableView.get` now gracefully falls back to the default six-month window on an invalid filter instead of returning an empty response.
- Import direction verified clean (`tax_services` only depends on `models`/`statement`), so `forms`/`factories` importing `get_tax_accounts` introduces no circular import.

## Testing

- `manage.py check`: no issues.
- `api.tests.services` + `api.tests.models`: 227/227 pass (includes `test_tax_services` 23/23).

🤖 Generated with [Claude Code](https://claude.com/claude-code)