### PR TITLE
Add user-facing Settings page with Account CRUD

### DIFF
--- a/api/forms.py
+++ b/api/forms.py
@@ -15,6 +15,7 @@ from api.services.tax_services import get_tax_accounts
 from api.models import (
     Account,
     Amortization,
+    CSVProfile,
     Entity,
     JournalEntry,
     JournalEntryItem,
@@ -625,3 +626,49 @@ class WalletForm(forms.ModelForm):
             instance.save()
 
         return instance
+
+
+class AccountForm(forms.ModelForm):
+    """User-facing form for creating/editing accounts via the Settings page.
+
+    Exposes a curated subset of fields. System-managed fields (special_type,
+    tax_payable_account, tax_rate, tax_amount) are intentionally hidden so users
+    can't corrupt tax/statement behavior.
+    """
+
+    entity = forms.ModelChoiceField(
+        queryset=Entity.objects.all().order_by("name"),
+        required=False,
+    )
+    csv_profile = forms.ModelChoiceField(
+        queryset=CSVProfile.objects.all().order_by("name"),
+        required=False,
+    )
+
+    class Meta:
+        model = Account
+        fields = [
+            "name",
+            "type",
+            "sub_type",
+            "entity",
+            "csv_profile",
+            "is_closed",
+            "is_depreciation",
+        ]
+
+    def clean(self):
+        cleaned_data = super().clean()
+        account_type = cleaned_data.get("type")
+        sub_type = cleaned_data.get("sub_type")
+
+        # Validate that the chosen sub_type is valid for the chosen type.
+        if account_type and sub_type:
+            valid_sub_types = Account.SUBTYPE_TO_TYPE_MAP.get(account_type, [])
+            if sub_type not in valid_sub_types:
+                self.add_error(
+                    "sub_type",
+                    f"'{sub_type}' is not a valid sub-type for {account_type} accounts.",
+                )
+
+        return cleaned_data

--- a/api/services/account_services.py
+++ b/api/services/account_services.py
@@ -1,0 +1,96 @@
+"""
+Account service layer for business logic and database operations.
+
+All account-related business logic and database writes go through these service
+functions. Services are pure functions with no HTTP dependencies and return
+dataclass result objects.
+"""
+
+from dataclasses import dataclass
+from typing import Any, Dict, List, Optional, Tuple
+
+from django.db import transaction as db_transaction
+from django.db.models import ProtectedError, QuerySet
+
+from api.models import Account, CSVProfile, Entity
+
+
+@dataclass
+class AccountResult:
+    """Result of an account create/update/delete operation."""
+    success: bool
+    account: Optional[Account] = None
+    error: Optional[str] = None
+
+
+def get_accounts() -> List[Account]:
+    """Returns all accounts, open ones first, then alphabetical by name."""
+    return list(
+        Account.objects.select_related("entity").order_by("is_closed", "name")
+    )
+
+
+def get_account_form_options() -> Tuple[QuerySet, QuerySet]:
+    """Returns the (entities, csv_profiles) querysets used to populate the
+    account edit form's dropdowns."""
+    entities = Entity.objects.order_by("name")
+    csv_profiles = CSVProfile.objects.order_by("name")
+    return entities, csv_profiles
+
+
+ACCOUNT_FIELDS = (
+    "name",
+    "type",
+    "sub_type",
+    "entity",
+    "csv_profile",
+    "is_closed",
+    "is_depreciation",
+)
+
+
+@db_transaction.atomic
+def save_account(
+    cleaned_data: Dict[str, Any], instance: Optional[Account] = None
+) -> AccountResult:
+    """Creates or updates an account from validated form data.
+
+    The caller (view) validates the form and passes ``form.cleaned_data``;
+    ``instance`` is the account being edited (None to create). Returns an
+    AccountResult; on any DB error the transaction rolls back.
+    """
+    try:
+        account = instance or Account()
+        for field in ACCOUNT_FIELDS:
+            setattr(account, field, cleaned_data.get(field))
+        account.save()
+        return AccountResult(success=True, account=account)
+    except Exception as e:  # pragma: no cover - defensive
+        return AccountResult(success=False, error=str(e))
+
+
+def delete_account(account_id: int) -> AccountResult:
+    """Deletes an account, gracefully blocking when it is still referenced.
+
+    Accounts are PROTECT-referenced by transactions, journal entry items,
+    paystub values, amortizations, etc. Rather than 500ing on a ProtectedError,
+    we return a friendly message so the UI can display it inline.
+    """
+    try:
+        account = Account.objects.get(pk=account_id)
+    except Account.DoesNotExist:
+        return AccountResult(success=False, error="Account not found.")
+
+    try:
+        account.delete()
+        return AccountResult(success=True, account=account)
+    except ProtectedError:
+        return AccountResult(
+            success=False,
+            account=account,
+            error=(
+                f"Can't delete '{account.name}' — it's still used by other "
+                "records (transactions, journal entries, paystub values, etc.). "
+                "Close it instead to archive it."
+            ),
+        )

--- a/api/tests/e2e/test_settings_playwright.py
+++ b/api/tests/e2e/test_settings_playwright.py
@@ -1,0 +1,106 @@
+"""Playwright browser tests for the interactive Settings page.
+
+Exercises the client-side behaviors: live search + count, row-select highlight,
+the Type -> Sub-type dependent select, the New Account blank form, and create
+re-rendering the list via HTMX.
+
+Run:
+    uv run python manage.py test api.tests.e2e.test_settings_playwright
+"""
+import os
+
+os.environ["DJANGO_ALLOW_ASYNC_UNSAFE"] = "true"
+
+from django.contrib.auth.models import User
+from django.test import Client, LiveServerTestCase, tag
+from playwright.sync_api import sync_playwright
+
+from api.models import Account
+from api.tests.testing_factories import AccountFactory, EntityFactory
+
+
+@tag("e2e")
+class SettingsSmokeTest(LiveServerTestCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.playwright = sync_playwright().start()
+        cls.browser = cls.playwright.chromium.launch(headless=True)
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.browser.close()
+        cls.playwright.stop()
+        super().tearDownClass()
+
+    def setUp(self):
+        self.user = User.objects.create_user(username="testuser", password="testpass")
+        EntityFactory(name="Self")
+        AccountFactory(name="Ally Checking", type=Account.Type.ASSET, sub_type=Account.SubType.CASH)
+        AccountFactory(name="Dining", type=Account.Type.EXPENSE, sub_type=Account.SubType.OPERATING)
+        AccountFactory(name="Federal Taxes", type=Account.Type.EXPENSE, sub_type=Account.SubType.TAX)
+        self.context = self.browser.new_context()
+        client = Client()
+        client.force_login(self.user)
+        sid = client.cookies["sessionid"].value
+        self.context.add_cookies([{"name": "sessionid", "value": sid, "url": self.live_server_url}])
+        self.page = self.context.new_page()
+
+    def tearDown(self):
+        self.page.close()
+        self.context.close()
+
+    def goto_settings(self):
+        self.page.goto(self.live_server_url + "/settings/")
+        self.page.wait_for_load_state("networkidle")
+        self.page.wait_for_function("typeof Alpine !== 'undefined'")
+        self.page.wait_for_selector(".set-table")
+
+    def test_interactions(self):
+        self.goto_settings()
+
+        # Count label
+        count = self.page.inner_text(".set-count")
+        self.assertIn("3 accounts", count)
+
+        # Search filters live + updates count
+        self.page.fill(".set-search input", "ally")
+        self.page.wait_for_timeout(150)
+        self.assertIn("1 of 3", self.page.inner_text(".set-count"))
+        visible = self.page.eval_on_selector_all(
+            "tr.set-row",
+            "els => els.filter(e => e.offsetParent !== null).map(e => e.querySelector('.set-td-name').innerText)",
+        )
+        self.assertEqual(visible, ["Ally Checking"])
+
+        # Clear search, select a row -> form loads + row highlighted
+        self.page.fill(".set-search input", "")
+        with self.page.expect_response(lambda r: "/form/" in r.url):
+            self.page.click("tr.set-row:has-text('Federal Taxes')")
+        self.page.wait_for_selector(".set-form-header:has-text('Edit · Federal Taxes')")
+        selected_name = self.page.inner_text("tr.set-row.selected .set-td-name")
+        self.assertEqual(selected_name, "Federal Taxes")
+
+        # Type -> Sub-type dependency: switch Type to Income, sub-type options change
+        self.page.select_option("select[name='type']", "income")
+        self.page.wait_for_timeout(100)
+        sub_opts = self.page.eval_on_selector_all(
+            "select[name='sub_type'] option", "els => els.map(e => e.value)"
+        )
+        self.assertIn("salary", sub_opts)
+        self.assertNotIn("tax", sub_opts)
+
+        # New Account -> blank create form
+        with self.page.expect_response(lambda r: "new/form" in r.url):
+            self.page.click("button:has-text('New Account')")
+        self.page.wait_for_selector(".set-form-header:has-text('New account')")
+        self.assertEqual(self.page.input_value(".set-input[name='name']"), "")
+
+        # Create a new account -> appears in list, count grows
+        self.page.fill(".set-input[name='name']", "New Brokerage")
+        self.page.select_option("select[name='type']", "asset")
+        with self.page.expect_response(lambda r: r.request.method == "POST"):
+            self.page.click("button:has-text('Create')")
+        self.page.wait_for_selector("tr.set-row:has-text('New Brokerage')")
+        self.assertIn("4 accounts", self.page.inner_text(".set-count"))
+        self.assertTrue(Account.objects.filter(name="New Brokerage").exists())

--- a/api/tests/services/test_account_services.py
+++ b/api/tests/services/test_account_services.py
@@ -1,0 +1,95 @@
+"""Tests for the account service layer."""
+
+from django.test import TestCase
+
+from api.forms import AccountForm
+from api.models import Account
+from api.services import account_services
+from api.tests.testing_factories import AccountFactory, TransactionFactory
+
+
+class GetAccountsTest(TestCase):
+    def test_returns_all_accounts(self):
+        AccountFactory()
+        AccountFactory()
+        accounts = account_services.get_accounts()
+        self.assertEqual(len(accounts), 2)
+
+    def test_open_accounts_sorted_first_then_by_name(self):
+        AccountFactory(name="Zebra", is_closed=False)
+        AccountFactory(name="Apple", is_closed=True)
+        AccountFactory(name="Mango", is_closed=False)
+        names = [a.name for a in account_services.get_accounts()]
+        # Open (is_closed=False) first, alphabetical within each group.
+        self.assertEqual(names, ["Mango", "Zebra", "Apple"])
+
+
+class SaveAccountTest(TestCase):
+    def _valid_data(self, **overrides):
+        data = {
+            "name": "Checking",
+            "type": Account.Type.ASSET,
+            "sub_type": Account.SubType.CASH,
+            "entity": "",
+            "csv_profile": "",
+            "is_closed": False,
+            "is_depreciation": False,
+        }
+        data.update(overrides)
+        return data
+
+    def test_create_account(self):
+        form = AccountForm(self._valid_data())
+        self.assertTrue(form.is_valid())
+        result = account_services.save_account(form.cleaned_data)
+
+        self.assertTrue(result.success)
+        self.assertIsNotNone(result.account)
+        self.assertEqual(result.account.name, "Checking")
+        self.assertTrue(Account.objects.filter(name="Checking").exists())
+
+    def test_update_account(self):
+        account = AccountFactory(
+            name="Old Name", type=Account.Type.ASSET, sub_type=Account.SubType.CASH
+        )
+        form = AccountForm(self._valid_data(name="New Name"), instance=account)
+        self.assertTrue(form.is_valid())
+        result = account_services.save_account(form.cleaned_data, instance=account)
+
+        self.assertTrue(result.success)
+        account.refresh_from_db()
+        self.assertEqual(account.name, "New Name")
+
+    def test_invalid_subtype_rejected_by_form(self):
+        # SALARY is an income sub_type, not valid for an asset account. The form
+        # (not the service) is responsible for rejecting it.
+        form = AccountForm(
+            self._valid_data(type=Account.Type.ASSET, sub_type=Account.SubType.SALARY)
+        )
+        self.assertFalse(form.is_valid())
+        self.assertIn("sub_type", form.errors)
+
+
+class DeleteAccountTest(TestCase):
+    def test_delete_unused_account(self):
+        account = AccountFactory()
+        result = account_services.delete_account(account.id)
+
+        self.assertTrue(result.success)
+        self.assertFalse(Account.objects.filter(pk=account.id).exists())
+
+    def test_delete_blocked_when_referenced(self):
+        account = AccountFactory()
+        # Transaction.account is PROTECT, so this should block deletion.
+        TransactionFactory(account=account)
+
+        result = account_services.delete_account(account.id)
+
+        self.assertFalse(result.success)
+        self.assertIn("Can't delete", result.error)
+        self.assertTrue(Account.objects.filter(pk=account.id).exists())
+
+    def test_delete_missing_account(self):
+        result = account_services.delete_account(999999)
+        self.assertFalse(result.success)
+        self.assertEqual(result.error, "Account not found.")

--- a/api/tests/views/test_settings_views.py
+++ b/api/tests/views/test_settings_views.py
@@ -1,0 +1,125 @@
+"""Tests for the Settings page HTMX views."""
+
+from django.urls import reverse
+
+from api.models import Account
+from api.tests.test_helpers import HTMXViewTestCase
+from api.tests.testing_factories import AccountFactory, TransactionFactory
+
+
+class SettingsViewTest(HTMXViewTestCase):
+    def test_requires_login(self):
+        self.client.logout()
+        response = self.client.get(reverse("settings"))
+        self.assertEqual(response.status_code, 302)
+        self.assertIn("/login/", response.url)
+
+    def test_page_loads_and_lists_accounts(self):
+        AccountFactory(name="Listed Account")
+        response = self.client.get(reverse("settings"))
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, "Listed Account")
+        self.assertContains(response, "Settings")
+
+    def test_page_contains_flat_menu_sections(self):
+        response = self.client.get(reverse("settings"))
+        # The flat menu is client-rendered from this section list.
+        self.assertContains(response, "'Entities', 'Paystubs', 'Auto Tags', 'CSV Profiles'")
+
+    def test_new_account_form_view(self):
+        response = self.client.get(reverse("settings-account-new-form"))
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, "New account")
+        # No Delete button on a blank create form.
+        self.assertNotContains(response, 'value="delete"')
+
+    def test_create_equity_account(self):
+        data = {
+            "action": "save",
+            "name": "Retained Earnings",
+            "type": Account.Type.EQUITY,
+            "sub_type": Account.SubType.RETAINED_EARNINGS,
+            "entity": "",
+            "csv_profile": "",
+        }
+        response = self.client.post(reverse("settings"), data=data)
+        self.assertEqual(response.status_code, 200)
+        account = Account.objects.get(name="Retained Earnings")
+        self.assertEqual(account.type, Account.Type.EQUITY)
+        self.assertEqual(account.sub_type, Account.SubType.RETAINED_EARNINGS)
+
+    def test_account_form_view_loads_account(self):
+        account = AccountFactory(name="Editable Account")
+        response = self.client.get(
+            reverse("settings-account-form", args=[account.id])
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, "Editable Account")
+
+    def test_create_account(self):
+        data = {
+            "action": "save",
+            "name": "New Savings",
+            "type": Account.Type.ASSET,
+            "sub_type": Account.SubType.CASH,
+            "entity": "",
+            "csv_profile": "",
+        }
+        response = self.client.post(reverse("settings"), data=data)
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue(Account.objects.filter(name="New Savings").exists())
+        self.assertContains(response, "Account created.")
+
+    def test_update_account(self):
+        account = AccountFactory(
+            name="Before", type=Account.Type.ASSET, sub_type=Account.SubType.CASH
+        )
+        data = {
+            "action": "save",
+            "name": "After",
+            "type": Account.Type.ASSET,
+            "sub_type": Account.SubType.CASH,
+            "entity": "",
+            "csv_profile": "",
+        }
+        response = self.client.post(
+            reverse("settings-account", args=[account.id]), data=data
+        )
+        self.assertEqual(response.status_code, 200)
+        account.refresh_from_db()
+        self.assertEqual(account.name, "After")
+
+    def test_delete_unused_account(self):
+        account = AccountFactory()
+        response = self.client.post(
+            reverse("settings-account", args=[account.id]),
+            data={"action": "delete"},
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertFalse(Account.objects.filter(pk=account.id).exists())
+
+    def test_delete_protected_account_shows_message(self):
+        account = AccountFactory(name="Busy Account")
+        TransactionFactory(account=account)
+
+        response = self.client.post(
+            reverse("settings-account", args=[account.id]),
+            data={"action": "delete"},
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, "Can&#x27;t delete")
+        self.assertTrue(Account.objects.filter(pk=account.id).exists())
+
+    def test_invalid_subtype_shows_form_errors(self):
+        data = {
+            "action": "save",
+            "name": "Bad Account",
+            "type": Account.Type.ASSET,
+            "sub_type": Account.SubType.SALARY,  # income sub_type, invalid for asset
+            "entity": "",
+            "csv_profile": "",
+        }
+        response = self.client.post(reverse("settings"), data=data)
+        self.assertEqual(response.status_code, 200)
+        self.assertFalse(Account.objects.filter(name="Bad Account").exists())
+        self.assertContains(response, "not a valid sub-type")

--- a/api/views/settings_helpers.py
+++ b/api/views/settings_helpers.py
@@ -1,0 +1,115 @@
+"""
+Helper functions for rendering Settings page HTML.
+
+These pure functions take data and return HTML strings via render_to_string.
+They contain no database writes and no business logic.
+"""
+
+from typing import Any, Dict, List, Optional
+
+from django.db.models import QuerySet
+from django.template.loader import render_to_string
+
+from api.forms import AccountForm
+from api.models import Account
+
+
+def build_subtype_map() -> Dict[str, List[Dict[str, str]]]:
+    """Builds a {type_value: [{value, label}, ...]} map of valid sub-types per
+    account type, for the client-side Type -> Sub-type dependent select.
+
+    Reads only the model constant (no DB), so it stays a pure helper.
+    """
+    subtype_map: Dict[str, List[Dict[str, str]]] = {}
+    for type_value, _label in Account.Type.choices:
+        subtypes = Account.SUBTYPE_TO_TYPE_MAP.get(type_value, [])
+        subtype_map[type_value] = [
+            {"value": st.value, "label": str(st.label)} for st in subtypes
+        ]
+    return subtype_map
+
+
+def render_settings_content(
+    accounts: List[Account],
+    account_form_html: str,
+    selected_id: Optional[int] = None,
+) -> str:
+    """Combines the header + table + form into the swappable right-pane fragment."""
+    return render_to_string(
+        "api/content/settings-content.html",
+        {
+            "accounts": accounts,
+            "total": len(accounts),
+            "selected_id": selected_id,
+            "account_form": account_form_html,
+        },
+    )
+
+
+def _form_values(
+    account: Optional[Account], form: Optional[AccountForm]
+) -> Dict[str, Any]:
+    """Resolves the current field values to display: submitted data on a bound
+    (invalid) form, else the account being edited, else blank-create defaults."""
+    if form is not None and form.is_bound:
+        data = form.data
+        return {
+            "name": data.get("name", ""),
+            "type": data.get("type", "asset"),
+            "sub_type": data.get("sub_type", ""),
+            "entity": data.get("entity", ""),
+            "csv_profile": data.get("csv_profile", ""),
+            "is_closed": "is_closed" in data,
+            "is_depreciation": "is_depreciation" in data,
+        }
+    if account is not None:
+        return {
+            "name": account.name,
+            "type": account.type,
+            "sub_type": account.sub_type,
+            "entity": str(account.entity_id or ""),
+            "csv_profile": str(account.csv_profile_id or ""),
+            "is_closed": account.is_closed,
+            "is_depreciation": account.is_depreciation,
+        }
+    return {
+        "name": "",
+        "type": Account.Type.ASSET,
+        "sub_type": "",
+        "entity": "",
+        "csv_profile": "",
+        "is_closed": False,
+        "is_depreciation": False,
+    }
+
+
+def render_account_form(
+    entities: QuerySet,
+    csv_profiles: QuerySet,
+    account: Optional[Account] = None,
+    change: Optional[str] = None,
+    error: Optional[str] = None,
+    form: Optional[AccountForm] = None,
+) -> str:
+    """Renders the account add/edit form HTML.
+
+    Args:
+        entities: Entity queryset for the Entity dropdown.
+        csv_profiles: CSVProfile queryset for the CSV Profile dropdown.
+        account: Existing account being edited (None for the create form).
+        change: Type of change just performed ("create"/"update"/"delete").
+        error: A friendly error message to display inline (e.g. delete blocked).
+        form: A bound form carrying validation errors to redisplay.
+    """
+    context = {
+        "account": account,
+        "change": change,
+        "error": error,
+        "form": form,
+        "values": _form_values(account, form),
+        "type_choices": Account.Type.choices,
+        "subtype_map": build_subtype_map(),
+        "entities": entities,
+        "csv_profiles": csv_profiles,
+    }
+    return render_to_string("api/entry_forms/account-form.html", context)

--- a/api/views/settings_views.py
+++ b/api/views/settings_views.py
@@ -1,0 +1,136 @@
+"""
+Settings views for HTTP orchestration.
+
+Views parse requests, call services for business logic, and call helpers for
+rendering. They contain no database writes and no HTML building. The Settings
+page hosts user-facing CRUD for configuration models, starting with Account.
+"""
+
+from typing import Optional
+
+from django.contrib.auth.mixins import LoginRequiredMixin
+from django.http import HttpResponse
+from django.shortcuts import get_object_or_404
+from django.template.loader import render_to_string
+from django.views import View
+
+from api.forms import AccountForm
+from api.models import Account
+from api.services import account_services
+from api.views import settings_helpers
+from api.views.page_utils import render_full_page
+
+
+class SettingsView(LoginRequiredMixin, View):
+    login_url = "/login/"
+    redirect_field_name = "next"
+
+    view_template = "api/views/settings.html"
+
+    def _render_content(
+        self,
+        account: Optional[Account] = None,
+        change: Optional[str] = None,
+        error: Optional[str] = None,
+        form: Optional[AccountForm] = None,
+        selected_id: Optional[int] = None,
+    ) -> str:
+        """Builds the swappable right-pane fragment (header + table + form)."""
+        entities, csv_profiles = account_services.get_account_form_options()
+        account_form_html = settings_helpers.render_account_form(
+            entities=entities,
+            csv_profiles=csv_profiles,
+            account=account,
+            change=change,
+            error=error,
+            form=form,
+        )
+        accounts = account_services.get_accounts()
+        return settings_helpers.render_settings_content(
+            accounts=accounts,
+            account_form_html=account_form_html,
+            selected_id=selected_id,
+        )
+
+    def get(self, request):
+        content_html = self._render_content()
+        html = render_to_string(self.view_template, {"content": content_html})
+        return render_full_page(request, html)
+
+    def post(self, request, account_id=None):
+        action = request.POST.get("action")
+
+        if action == "clear":
+            return HttpResponse(self._render_content())
+
+        if action == "delete":
+            result = account_services.delete_account(account_id)
+            if result.success:
+                return HttpResponse(self._render_content(change="delete"))
+            # Re-render the still-existing account with the friendly error.
+            return HttpResponse(
+                self._render_content(
+                    account=result.account,
+                    error=result.error,
+                    selected_id=result.account.id if result.account else None,
+                )
+            )
+
+        # Create or update
+        if account_id:
+            account = get_object_or_404(Account, pk=account_id)
+            form = AccountForm(request.POST, instance=account)
+            change = "update"
+        else:
+            account = None
+            form = AccountForm(request.POST)
+            change = "create"
+
+        if not form.is_valid():
+            return HttpResponse(
+                self._render_content(
+                    account=account,
+                    form=form,
+                    selected_id=account.id if account else None,
+                )
+            )
+
+        result = account_services.save_account(form.cleaned_data, instance=account)
+        if not result.success:
+            return HttpResponse(
+                self._render_content(
+                    account=account,
+                    form=form,
+                    error=result.error,
+                    selected_id=account.id if account else None,
+                )
+            )
+
+        return HttpResponse(
+            self._render_content(
+                account=result.account,
+                change=change,
+                selected_id=result.account.id,
+            )
+        )
+
+
+class AccountFormView(LoginRequiredMixin, View):
+    """Loads an account (or a blank create form) into the edit form.
+
+    Used on table row clicks (existing account) and the New Account button
+    (no account_id -> blank form).
+    """
+
+    login_url = "/login/"
+    redirect_field_name = "next"
+
+    def get(self, request, account_id=None):
+        account = get_object_or_404(Account, pk=account_id) if account_id else None
+        entities, csv_profiles = account_services.get_account_form_options()
+        form_html = settings_helpers.render_account_form(
+            entities=entities,
+            csv_profiles=csv_profiles,
+            account=account,
+        )
+        return HttpResponse(form_html)

--- a/ledger/templates/api/components/nav.html
+++ b/ledger/templates/api/components/nav.html
@@ -33,6 +33,9 @@
                 <li class="nav-item {% if request.resolver_match.url_name == 'search' %}active{% endif %}">
                     <a class="nav-link" href="{% url 'search' %}">Search</a>
                 </li>
+                <li class="nav-item {% if request.resolver_match.url_name == 'settings' %}active{% endif %}">
+                    <a class="nav-link" href="{% url 'settings' %}">Settings</a>
+                </li>
                 <!-- Dropdown Menu for Financial Statements -->
                 <li class="nav-item dropdown">
                     <a class="nav-link dropdown-toggle" href="#" id="navbarDropdownMenuLink" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false" hx-boost="false">

--- a/ledger/templates/api/content/settings-content.html
+++ b/ledger/templates/api/content/settings-content.html
@@ -1,0 +1,78 @@
+<div x-data="{
+        q: '',
+        selectedId: {{ selected_id|default:'null' }},
+        total: {{ total }},
+        matches(el) { return !this.q.trim() || el.dataset.search.includes(this.q.toLowerCase()); },
+        visible() {
+          if (!this.q.trim()) return this.total;
+          const needle = this.q.toLowerCase();
+          return Array.from(this.$root.querySelectorAll('tr[data-search]'))
+            .filter(tr => tr.dataset.search.includes(needle)).length;
+        },
+        countLabel() {
+          return this.q.trim() ? (this.visible() + ' of ' + this.total) : (this.total + ' accounts');
+        }
+     }">
+
+  <div class="set-head">
+    <div class="set-head-left">
+      <h2 class="set-h2">Accounts</h2>
+      <span class="set-count" x-text="countLabel()"></span>
+    </div>
+    <div class="set-head-right">
+      <div class="set-search">
+        <svg width="12" height="12" viewBox="0 0 16 16" fill="none" stroke="#adb5bd" stroke-width="1.6">
+          <circle cx="7" cy="7" r="4.5"></circle><line x1="10.6" y1="10.6" x2="14" y2="14"></line>
+        </svg>
+        <input x-model="q" placeholder="Search accounts" />
+      </div>
+      <button class="set-btn set-btn-primary"
+              @click="selectedId = null"
+              hx-get="{% url 'settings-account-new-form' %}"
+              hx-target="#account-form-div">New Account</button>
+    </div>
+  </div>
+
+  <div class="set-table-scroll">
+  <table class="set-table">
+    <thead>
+      <tr>
+        <th>Name</th>
+        <th>Type</th>
+        <th>Sub-type</th>
+        <th>Default Entity</th>
+        <th class="center">Closed</th>
+      </tr>
+    </thead>
+    <tbody>
+      {% for account in accounts %}
+      <tr class="set-row"
+          data-search="{{ account.name|lower }} {{ account.get_type_display|lower }} {{ account.get_sub_type_display|lower }}"
+          :class="{ selected: selectedId === {{ account.id }} }"
+          x-show="matches($el)"
+          @click="selectedId = {{ account.id }}"
+          hx-get="{% url 'settings-account-form' account.id %}"
+          hx-target="#account-form-div">
+        <td class="set-td set-td-name">{{ account.name }}</td>
+        <td class="set-td set-td-type">{{ account.get_type_display }}</td>
+        <td class="set-td set-td-sub">{{ account.get_sub_type_display }}</td>
+        {% if account.entity %}
+        <td class="set-td set-td-entity">{{ account.entity.name }}</td>
+        {% else %}
+        <td class="set-td set-td-entity empty">—</td>
+        {% endif %}
+        <td class="set-td set-td-closed">{% if account.is_closed %}Yes{% else %}No{% endif %}</td>
+      </tr>
+      {% endfor %}
+    </tbody>
+  </table>
+  </div>
+
+  <div class="set-empty" x-show="visible() === 0" x-cloak>
+    No accounts match "<span x-text="q"></span>".
+  </div>
+
+  <div id="account-form-div">
+    {{ account_form }}
+  </div>
+</div>

--- a/ledger/templates/api/entry_forms/account-form.html
+++ b/ledger/templates/api/entry_forms/account-form.html
@@ -1,0 +1,103 @@
+{{ subtype_map|json_script:"subtype-map" }}
+<div class="set-form"
+     x-data="{
+        type: '{{ values.type }}',
+        subtype: '{{ values.sub_type }}',
+        map: JSON.parse(document.getElementById('subtype-map').textContent),
+        subtypeOptions() { return this.map[this.type] || []; },
+        subtypeValues() { return this.subtypeOptions().map(o => o.value); },
+        normalize() { if (!this.subtypeValues().includes(this.subtype)) this.subtype = this.subtypeValues()[0] || ''; },
+        init() { this.normalize(); }
+     }">
+
+  <div class="set-form-header">
+    {% if account %}Edit · {{ account.name }}{% else %}New account{% endif %}
+  </div>
+
+  {% if change == "create" %}
+    <div class="set-alert set-alert-success">Account created.</div>
+  {% elif change == "update" %}
+    <div class="set-alert set-alert-success">Account updated.</div>
+  {% elif change == "delete" %}
+    <div class="set-alert set-alert-success">Account deleted.</div>
+  {% endif %}
+  {% if error %}
+    <div class="set-alert set-alert-danger">{{ error }}</div>
+  {% endif %}
+  {% if form.non_field_errors %}
+    <div class="set-alert set-alert-danger">{{ form.non_field_errors }}</div>
+  {% endif %}
+
+  <form method="post"
+        {% if account %}hx-post="{% url 'settings-account' account.id %}"{% else %}hx-post="{% url 'settings' %}"{% endif %}
+        hx-target="#settings-content"
+        hx-swap="innerHTML">
+    {% csrf_token %}
+
+    <div class="set-grid-1">
+      <div>
+        <label class="set-label">Name</label>
+        <input class="set-input" name="name" value="{{ values.name }}" placeholder="Account name" />
+        {% for e in form.name.errors %}<div class="set-field-error">{{ e }}</div>{% endfor %}
+      </div>
+      <div>
+        <label class="set-label">Type</label>
+        <select class="set-select" name="type" x-model="type" @change="normalize()">
+          {% for value, label in type_choices %}<option value="{{ value }}">{{ label }}</option>{% endfor %}
+        </select>
+        {% for e in form.type.errors %}<div class="set-field-error">{{ e }}</div>{% endfor %}
+      </div>
+      <div>
+        <label class="set-label">Sub-type</label>
+        <select class="set-select" name="sub_type" x-model="subtype">
+          <template x-for="opt in subtypeOptions()" :key="opt.value">
+            <option :value="opt.value" x-text="opt.label"></option>
+          </template>
+        </select>
+        {% for e in form.sub_type.errors %}<div class="set-field-error">{{ e }}</div>{% endfor %}
+      </div>
+    </div>
+
+    <div class="set-grid-2">
+      <div>
+        <label class="set-label">Default Entity</label>
+        <select class="set-select" name="entity">
+          <option value="" {% if not values.entity %}selected{% endif %}>Select…</option>
+          {% for entity in entities %}
+          <option value="{{ entity.id }}" {% if values.entity == entity.id|stringformat:'s' %}selected{% endif %}>{{ entity.name }}</option>
+          {% endfor %}
+        </select>
+        {% for e in form.entity.errors %}<div class="set-field-error">{{ e }}</div>{% endfor %}
+      </div>
+      <div>
+        <label class="set-label">CSV Profile</label>
+        <select class="set-select" name="csv_profile">
+          <option value="" {% if not values.csv_profile %}selected{% endif %}>Select…</option>
+          {% for profile in csv_profiles %}
+          <option value="{{ profile.id }}" {% if values.csv_profile == profile.id|stringformat:'s' %}selected{% endif %}>{{ profile.name }}</option>
+          {% endfor %}
+        </select>
+        {% for e in form.csv_profile.errors %}<div class="set-field-error">{{ e }}</div>{% endfor %}
+      </div>
+      <div class="set-checks">
+        <label class="set-check">
+          <input type="checkbox" name="is_closed" {% if values.is_closed %}checked{% endif %} />Closed
+        </label>
+        <label class="set-check">
+          <input type="checkbox" name="is_depreciation" {% if values.is_depreciation %}checked{% endif %} />Depreciation
+        </label>
+      </div>
+    </div>
+
+    <div class="set-actions">
+      <button type="submit" name="action" value="save" class="set-btn set-btn-primary">{% if account %}Save{% else %}Create{% endif %}</button>
+      {% if account %}
+      <button type="submit" name="action" value="delete" class="set-btn set-btn-danger">Delete</button>
+      {% endif %}
+      <button type="button" class="set-btn set-btn-clear"
+              @click="selectedId = null"
+              hx-get="{% url 'settings-account-new-form' %}"
+              hx-target="#account-form-div">Clear</button>
+    </div>
+  </form>
+</div>

--- a/ledger/templates/api/views/settings.html
+++ b/ledger/templates/api/views/settings.html
@@ -1,0 +1,123 @@
+<style>
+  /* ---- Settings page (design: "Ledger Settings (Interactive)", Direction A) ---- */
+  .set-page { max-width: 1160px; margin: 0 auto; padding: 30px 24px 60px;
+              font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif; }
+  .set-layout { display: flex; gap: 38px; }
+
+  .set-menu { width: 160px; flex: none; }
+  .set-menu-title { font-size: 11px; font-weight: 600; letter-spacing: .07em; text-transform: uppercase;
+                    color: #aeb4ba; margin-bottom: 13px; padding-left: 11px; }
+  .set-menu-list { display: flex; flex-direction: column; }
+  .set-menu-item { font-size: 14px; color: #6c757d; font-weight: 400; padding: 7px 0 7px 11px;
+                   border-left: 2px solid transparent; cursor: pointer; }
+  .set-menu-item.active { color: #007bff; font-weight: 600; border-left-color: #007bff; }
+
+  .set-main { flex: 1; min-width: 0; }
+
+  .set-head { display: flex; align-items: center; justify-content: space-between; margin-bottom: 15px; }
+  .set-head-left { display: flex; align-items: baseline; gap: 9px; }
+  .set-h2 { margin: 0; font-size: 16px; font-weight: 600; color: #212529; }
+  .set-count { font-size: 12px; color: #9aa0a6; }
+  .set-head-right { display: flex; align-items: center; gap: 10px; }
+
+  .set-search { display: flex; align-items: center; gap: 7px; width: 230px; height: 30px;
+                border: 1px solid #ced4da; border-radius: 4px; padding: 0 9px; background: #fff; }
+  .set-search input { border: none; outline: none; font-size: 12px; color: #212529; background: transparent;
+                      width: 100%; font-family: inherit; }
+  .set-search input::placeholder { color: #aeb4ba; }
+
+  .set-btn { height: 30px; padding: 0 14px; border: none; border-radius: 4px; font-size: 12px;
+             font-weight: 500; cursor: pointer; font-family: inherit; }
+  .set-btn-primary { background: #007bff; color: #fff; }
+  .set-btn-danger { background: #dc3545; color: #fff; }
+  .set-btn-clear { background: #f1f3f5; color: #6c757d; border: 1px solid #e2e5e8; }
+
+  /* Fixed-height table area: the list scrolls internally so the edit form
+     below is always visible no matter how many accounts exist. */
+  .set-table-scroll { max-height: 340px; overflow-y: auto; }
+  .set-table { width: 100%; border-collapse: collapse; }
+  .set-table th { padding: 8px 12px; font-size: 11px; letter-spacing: .04em; text-transform: uppercase;
+                  color: #9aa0a6; font-weight: 600; border-bottom: 1px solid #e2e5e8; text-align: left;
+                  position: sticky; top: 0; background: #fff; z-index: 1; }
+  .set-table th.center { text-align: center; }
+  .set-row { cursor: pointer; border-bottom: 1px solid #f0f2f4; }
+  .set-row:hover { background: #f7f9fb; }
+  .set-row.selected { background: #f2f8ff; box-shadow: inset 2px 0 0 #007bff; }
+  .set-td { padding: 8px 12px; font-size: 12px; white-space: nowrap; }
+  .set-td-name { color: #212529; font-weight: 500; }
+  .set-row.selected .set-td-name { font-weight: 600; }
+  .set-td-type { color: #343a40; }
+  .set-td-sub { color: #6c757d; }
+  .set-td-entity { color: #495057; }
+  .set-td-entity.empty { color: #b6bcc2; }
+  .set-td-closed { color: #6c757d; text-align: center; }
+  .set-empty { padding: 22px 12px; font-size: 12px; color: #9aa0a6; text-align: center; }
+
+  .set-form { margin-top: 22px; padding-top: 18px; border-top: 1px solid #e9ecef; }
+  .set-form-header { font-size: 11px; font-weight: 600; letter-spacing: .05em; text-transform: uppercase;
+                     color: #9aa0a6; margin-bottom: 15px; }
+  .set-grid-1 { display: grid; grid-template-columns: 2fr 1fr 1fr; gap: 14px 18px; margin-bottom: 14px; }
+  .set-grid-2 { display: grid; grid-template-columns: 1fr 1fr 1fr; gap: 14px 18px; align-items: end; margin-bottom: 18px; }
+  .set-label { display: block; font-size: 11px; color: #6c757d; margin-bottom: 5px; }
+  .set-input, .set-select { height: 30px; border: 1px solid #ced4da; border-radius: 4px; padding: 0 9px;
+                            font-size: 12px; color: #212529; background: #fff; width: 100%;
+                            font-family: inherit; outline: none; }
+  .set-select { padding: 0 7px; cursor: pointer; }
+  .set-checks { display: flex; gap: 20px; padding-bottom: 7px; }
+  .set-check { display: inline-flex; align-items: center; gap: 7px; font-size: 12px; color: #212529; cursor: pointer; }
+  .set-check input { width: 14px; height: 14px; accent-color: #007bff; cursor: pointer; margin: 0; }
+  .set-actions { display: flex; gap: 9px; }
+  .set-field-error { font-size: 11px; color: #dc3545; margin-top: 4px; }
+  .set-alert { font-size: 12px; border-radius: 4px; padding: 8px 11px; margin-bottom: 14px; }
+  .set-alert-success { background: #e9f7ef; color: #1e7e44; }
+  .set-alert-danger { background: #fdecee; color: #b02a37; }
+
+  .set-stub { border: 1px dashed #d8dce0; border-radius: 8px; padding: 46px 24px; text-align: center; background: #fafbfc; }
+  .set-stub-title { font-size: 13px; color: #868e96; font-weight: 500; }
+  .set-stub-sub { font-size: 12px; color: #aeb4ba; margin-top: 4px; }
+</style>
+
+<div class="set-page"
+     x-data="{
+        section: 'Accounts',
+        sections: ['Accounts', 'Entities', 'Paystubs', 'Auto Tags', 'CSV Profiles'],
+        stubs: {
+          'Entities': 'Counterparties money moves to and from — banks, employers, landlords.',
+          'Paystubs': 'Saved paystub templates parsed via AWS Textract.',
+          'Auto Tags': 'Rules that auto-categorize incoming transactions.',
+          'CSV Profiles': 'Column mappings for each bank\'s CSV export format.'
+        }
+     }">
+  <div class="set-layout">
+
+    <!-- flat menu -->
+    <div class="set-menu">
+      <div class="set-menu-title">Settings</div>
+      <div class="set-menu-list">
+        <template x-for="s in sections" :key="s">
+          <span class="set-menu-item" :class="{ active: section === s }"
+                @click="section = s" x-text="s"></span>
+        </template>
+      </div>
+    </div>
+
+    <!-- main -->
+    <div class="set-main">
+      <!-- Accounts (functional) -->
+      <div x-show="section === 'Accounts'">
+        <div id="settings-content">{{ content }}</div>
+      </div>
+
+      <!-- Stub sections -->
+      <div x-show="section !== 'Accounts'" x-cloak>
+        <h2 class="set-h2" style="margin-bottom: 4px;" x-text="section"></h2>
+        <p style="margin: 0 0 26px; font-size: 12px; color: #9aa0a6;" x-text="stubs[section]"></p>
+        <div class="set-stub">
+          <div class="set-stub-title"><span x-text="section"></span> settings</div>
+          <div class="set-stub-sub">List + form for this section follows the same pattern as Accounts.</div>
+        </div>
+      </div>
+    </div>
+
+  </div>
+</div>

--- a/ledger/urls.py
+++ b/ledger/urls.py
@@ -27,6 +27,7 @@ from api.views.journal_entry_views import (
 )
 from api.views.reconciliation_views import ReconciliationTableView, ReconciliationView
 from api.views.search_views import SearchBulkUpdateView, SearchContentView, SearchView
+from api.views.settings_views import AccountFormView, SettingsView
 from api.views.statement_views import StatementDetailView, StatementView
 from api.views.tax_views import (
     ApplyTaxRecommendationView,
@@ -156,6 +157,23 @@ urlpatterns = [
         "tag/journal-entry-item/<int:journal_entry_item_id>/",
         UntagJournalEntryView.as_view(),
         name="untag-journal-entry",
+    ),
+    # Settings (user-facing CRUD for config models)
+    path("settings/", SettingsView.as_view(), name="settings"),
+    path(
+        "settings/accounts/new/form/",
+        AccountFormView.as_view(),
+        name="settings-account-new-form",
+    ),
+    path(
+        "settings/accounts/<int:account_id>/",
+        SettingsView.as_view(),
+        name="settings-account",
+    ),
+    path(
+        "settings/accounts/<int:account_id>/form/",
+        AccountFormView.as_view(),
+        name="settings-account-form",
     ),
     path("tag/", TagEntitiesView.as_view(), name="tag-entities"),
     path("tag/balances/", EntityGroupedBalancesView.as_view(), name="entity-balances"),


### PR DESCRIPTION
## Summary

Adds a **Settings** page (navbar → `/settings/`) so users can manage accounts themselves instead of relying on the Django Admin console. Implements the approved **"Ledger Settings (Interactive)"** design (Direction A): a minimalist flat-text left menu, a dense account list with live client-side search + count, and an inline create/edit form below.

This is the first section; Entities / Paystubs / Auto Tags / CSV Profiles appear as stub panels that mark the seam for future work.

## What it does

- **CRUD on Accounts** with a curated, user-safe field set: name, type, sub_type, **Default Entity**, CSV profile, Closed, Depreciation. System-managed fields (`special_type`, `tax_payable_account`, `tax_rate`, `tax_amount`) are intentionally hidden.
- **Live interactions**: client-side search + "M of N" count (Alpine), Type→Sub-type dependent select, row-click loads the form (HTMX), Save/Create/Delete/Clear.
- **Graceful delete blocking**: deleting an account still referenced by transactions/journal entries/paystub values catches `ProtectedError` and shows a friendly message instead of a 500; `is_closed` remains for archiving.
- **Sorting**: open accounts first, then alphabetical by name.
- **Fixed-height scrolling table** with sticky headers so the edit form stays visible regardless of list length.

## Architecture

Follows the project's layering (per `CLAUDE.md`), mirroring the transactions/journal-entry reference implementation:

- `AccountForm` — field + cross-field (sub_type↔type) validation
- `account_services` — cleaned-data writes, `delete_account` (ProtectedError handling), option reads
- `settings_helpers` — pure HTML rendering
- `settings_views` — HTTP orchestration (`render_full_page` for direct load / hx-boost)

No model or migration changes; Django Admin registrations are left in place until all sections reach parity.

## Testing

- Service tests: create/update, delete success, **graceful delete blocking**, open-first sort, form-level invalid-subtype rejection.
- HTMX view tests: page load + listing, flat menu, new-form route, create/update/delete, protected-delete message, **Equity** round-trip.
- Playwright e2e (`api/tests/e2e/test_settings_playwright.py`): live search + count, row-select highlight + form load, Type→Sub-type dependency, New Account, and create re-rendering the list.

All settings tests green; full model/service/view suite passes and `manage.py check` is clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)