### PR TITLE
Centralize frontend styling into one design system

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -170,3 +170,6 @@ cython_debug/
 #.idea/
 # Gmail OAuth refresh token (minted locally, never commit)
 .gmail_refresh_token
+
+# Collected static files (build artifact; STATIC_ROOT)
+staticfiles/

--- a/api/tests/e2e/test_settings_playwright.py
+++ b/api/tests/e2e/test_settings_playwright.py
@@ -54,31 +54,31 @@ class SettingsSmokeTest(LiveServerTestCase):
         self.page.goto(self.live_server_url + "/settings/")
         self.page.wait_for_load_state("networkidle")
         self.page.wait_for_function("typeof Alpine !== 'undefined'")
-        self.page.wait_for_selector(".set-table")
+        self.page.wait_for_selector(".table")
 
     def test_interactions(self):
         self.goto_settings()
 
         # Count label
-        count = self.page.inner_text(".set-count")
+        count = self.page.inner_text(".card-count")
         self.assertIn("3 accounts", count)
 
         # Search filters live + updates count
-        self.page.fill(".set-search input", "ally")
+        self.page.fill(".search input", "ally")
         self.page.wait_for_timeout(150)
-        self.assertIn("1 of 3", self.page.inner_text(".set-count"))
+        self.assertIn("1 of 3", self.page.inner_text(".card-count"))
         visible = self.page.eval_on_selector_all(
-            "tr.set-row",
-            "els => els.filter(e => e.offsetParent !== null).map(e => e.querySelector('.set-td-name').innerText)",
+            "tr.row",
+            "els => els.filter(e => e.offsetParent !== null).map(e => e.querySelector('.td-name').innerText)",
         )
         self.assertEqual(visible, ["Ally Checking"])
 
         # Clear search, select a row -> form loads + row highlighted
-        self.page.fill(".set-search input", "")
+        self.page.fill(".search input", "")
         with self.page.expect_response(lambda r: "/form/" in r.url):
-            self.page.click("tr.set-row:has-text('Federal Taxes')")
-        self.page.wait_for_selector(".set-form-header:has-text('Edit · Federal Taxes')")
-        selected_name = self.page.inner_text("tr.set-row.selected .set-td-name")
+            self.page.click("tr.row:has-text('Federal Taxes')")
+        self.page.wait_for_selector(".form-header:has-text('Edit · Federal Taxes')")
+        selected_name = self.page.inner_text("tr.row.selected .td-name")
         self.assertEqual(selected_name, "Federal Taxes")
 
         # Type -> Sub-type dependency: switch Type to Income, sub-type options change
@@ -93,14 +93,14 @@ class SettingsSmokeTest(LiveServerTestCase):
         # New Account -> blank create form
         with self.page.expect_response(lambda r: "new/form" in r.url):
             self.page.click("button:has-text('New Account')")
-        self.page.wait_for_selector(".set-form-header:has-text('New account')")
-        self.assertEqual(self.page.input_value(".set-input[name='name']"), "")
+        self.page.wait_for_selector(".form-header:has-text('New account')")
+        self.assertEqual(self.page.input_value(".input[name='name']"), "")
 
         # Create a new account -> appears in list, count grows
-        self.page.fill(".set-input[name='name']", "New Brokerage")
+        self.page.fill(".input[name='name']", "New Brokerage")
         self.page.select_option("select[name='type']", "asset")
         with self.page.expect_response(lambda r: r.request.method == "POST"):
             self.page.click("button:has-text('Create')")
-        self.page.wait_for_selector("tr.set-row:has-text('New Brokerage')")
-        self.assertIn("4 accounts", self.page.inner_text(".set-count"))
+        self.page.wait_for_selector("tr.row:has-text('New Brokerage')")
+        self.assertIn("4 accounts", self.page.inner_text(".card-count"))
         self.assertTrue(Account.objects.filter(name="New Brokerage").exists())

--- a/ledger/settings.py
+++ b/ledger/settings.py
@@ -231,17 +231,21 @@ STATIC_URL = "/static/"
 # This is where the central design system, ledger/static/css/app.css, lives.
 STATICFILES_DIRS = [os.path.join(BASE_DIR, "ledger/static")]
 
-STORAGES = {
-    # Enable WhiteNoise's GZip and Brotli compression of static assets:
-    # https://whitenoise.readthedocs.io/en/latest/django.html#add-compression-and-caching-support
-    "staticfiles": {
-        "BACKEND": "whitenoise.storage.CompressedManifestStaticFilesStorage",
-    },
-}
-
-# Don't store the original (un-hashed filename) version of static files, to reduce slug size:
-# https://whitenoise.readthedocs.io/en/latest/django.html#WHITENOISE_KEEP_ONLY_HASHED_FILES
-WHITENOISE_KEEP_ONLY_HASHED_FILES = True
+# Hashed + compressed static files (WhiteNoise's manifest storage) only on the
+# real Heroku app, where `collectstatic` runs at build time to produce the
+# manifest. Locally and in CI we use Django's default storage so {% static %}
+# resolves straight from the finders without requiring a collected manifest.
+if IS_HEROKU_APP:
+    STORAGES = {
+        # Enable WhiteNoise's GZip and Brotli compression of static assets:
+        # https://whitenoise.readthedocs.io/en/latest/django.html#add-compression-and-caching-support
+        "staticfiles": {
+            "BACKEND": "whitenoise.storage.CompressedManifestStaticFilesStorage",
+        },
+    }
+    # Don't store the original (un-hashed filename) version of static files, to reduce slug size:
+    # https://whitenoise.readthedocs.io/en/latest/django.html#WHITENOISE_KEEP_ONLY_HASHED_FILES
+    WHITENOISE_KEEP_ONLY_HASHED_FILES = True
 
 # Default primary key field type
 # https://docs.djangoproject.com/en/3.2/ref/settings/#default-auto-field

--- a/ledger/settings.py
+++ b/ledger/settings.py
@@ -227,6 +227,10 @@ USE_TZ = True
 
 STATIC_URL = "/static/"
 
+# Project-level static files (mirrors the TEMPLATE_DIR convention above).
+# This is where the central design system, ledger/static/css/app.css, lives.
+STATICFILES_DIRS = [os.path.join(BASE_DIR, "ledger/static")]
+
 STORAGES = {
     # Enable WhiteNoise's GZip and Brotli compression of static assets:
     # https://whitenoise.readthedocs.io/en/latest/django.html#add-compression-and-caching-support

--- a/ledger/static/css/app.css
+++ b/ledger/static/css/app.css
@@ -1,0 +1,600 @@
+/* =============================================================================
+   Ledger — central design system (single source of truth)
+
+   Inspired by the original Settings screen. Everything is token-driven and
+   mobile-first; the one breakpoint is 760px (see --bp-mobile note below).
+
+   Sections:
+     1. Design tokens (:root)
+     2. Base / reset
+     3. Layout (page, grid, filter bar)
+     4. Navigation
+     5. Cards & section headers
+     6. Buttons
+     7. Search box
+     8. Tables (+ mobile stacked list)
+     9. Forms & fields
+    10. Feedback (alerts, badges, busy, error tooltip)
+    11. KPI cards
+    12. Typeahead multi-select component
+    13. Utilities
+    14. Mobile reflow (max-width: 760px)
+   ============================================================================= */
+
+/* 1. ---- Design tokens --------------------------------------------------- */
+:root {
+  /* Brand / action */
+  --color-primary:        #007bff;
+  --color-primary-strong: #1c63d4;
+  --color-danger:         #dc3545;
+
+  /* Status pairs (fg / bg) */
+  --status-success-fg:    #1e7e44;  --status-success-bg:    #e9f7ef;
+  --status-info-fg:       #1c63d4;  --status-info-bg:       #eaf2ff;
+  --status-warning-fg:    #b76e00;  --status-warning-bg:    #fff4e5;
+  --status-danger-fg:     #b02a37;  --status-danger-bg:     #fdecee;
+  --status-neutral-fg:    #6c757d;  --status-neutral-bg:    #f1f3f5;
+
+  /* Text ramp (darkest -> faintest) */
+  --text-1:     #212529;
+  --text-2:     #343a40;
+  --text-3:     #495057;
+  --text-4:     #6c757d;
+  --text-muted: #9aa0a6;
+  --text-faint: #b6bcc2;
+
+  /* Surfaces & borders */
+  --surface:        #fff;
+  --surface-alt:    #f7f9fb;
+  --surface-stub:   #fafbfc;
+  --selected:       #f2f8ff;
+  --highlight:      #fcfcd5;
+  --border:         #e2e5e8;
+  --border-faint:   #f0f2f4;
+  --border-divider: #e9ecef;
+  --input-border:   #ced4da;
+
+  /* Spacing scale */
+  --space-1: 4px;
+  --space-2: 8px;
+  --space-3: 12px;
+  --space-4: 18px;
+  --space-5: 24px;
+  --space-6: 38px;
+
+  /* Radii */
+  --radius:      4px;
+  --radius-lg:   8px;
+  --radius-pill: 10px;
+
+  /* Focus ring (shared by inputs, selects, typeahead) */
+  --focus-border: #80bdff;
+  --focus-ring:   rgba(0,123,255,.25);
+
+  /* Typography */
+  --font: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif;
+  --fs-sm:   11px;
+  --fs-body: 12px;
+  --fs-md:   13px;
+  --fs-lg:   14px;
+  --fs-h2:   16px;
+
+  /* Controls */
+  --control-h: 30px;
+
+  /* Layout */
+  --page-max: 1160px;
+
+  /* Breakpoint reference only — CSS variables can't be used inside an
+     @media condition, so the literal 760px is repeated in section 15. */
+  --bp-mobile: 760px;
+}
+
+/* 2. ---- Base / reset ---------------------------------------------------- */
+* { box-sizing: border-box; }
+
+html { -webkit-text-size-adjust: 100%; }
+
+body {
+  margin: 0;
+  font-family: var(--font);
+  font-size: var(--fs-lg);
+  line-height: 1.5;
+  color: var(--text-1);
+  background: var(--surface);
+}
+
+a { color: var(--color-primary); text-decoration: none; }
+a:hover { text-decoration: underline; }
+
+h1, h2, h3, h4, h5 { font-family: var(--font); color: var(--text-1); }
+h2 { font-size: 22px; font-weight: 600; margin: 0 0 var(--space-4); }
+h3 { font-size: var(--fs-h2); font-weight: 600; margin: 0 0 var(--space-3); }
+h4, h5 { font-size: var(--fs-md); font-weight: 600; margin: 0 0 var(--space-2); }
+
+[x-cloak] { display: none !important; }
+
+/* 3. ---- Layout ---------------------------------------------------------- */
+.page {
+  max-width: var(--page-max);
+  margin: 0 auto;
+  padding: var(--space-5) var(--space-5) 60px;
+}
+.page-narrow { max-width: 720px; }
+
+/* Responsive grid — collapses to one column on mobile (section 15) */
+.grid { display: grid; gap: var(--space-4); }
+.grid-2 { grid-template-columns: repeat(2, 1fr); }
+.grid-3 { grid-template-columns: repeat(3, 1fr); }
+.grid-4 { grid-template-columns: repeat(4, 1fr); }
+/* For forms where the first field (e.g. a name) should be wider */
+.grid-wide-first { grid-template-columns: 2fr 1fr 1fr; }
+.grid-tight { gap: var(--space-3); }
+/* Wide main pane + narrower side pane (e.g. table + detail/paystubs) */
+.grid-main-side { grid-template-columns: 2fr 1fr; }
+/* Auto-flowing responsive columns (no breakpoint needed) */
+.grid-auto { grid-template-columns: repeat(auto-fit, minmax(190px, 1fr)); }
+.grid-end { align-items: end; }
+
+/* Filter bar — inline, fixed-width filter fields that don't stretch to fill.
+   Each direct child is a 200px cell that bottom-aligns in the row. A cell with
+   one field is a plain wrapper; a cell stacking several fields uses .filter-col
+   so they keep their vertical gap. Button cells take .fw-auto. */
+.filter-bar { display: flex; flex-wrap: wrap; align-items: flex-end; gap: var(--space-3) var(--space-4); margin-bottom: var(--space-4); }
+.filter-bar > * { width: 200px; }
+.filter-bar .field { margin-bottom: 0; }
+.filter-col { display: flex; flex-direction: column; gap: var(--space-3); }
+.fw-narrow { width: 130px !important; }
+.fw-date   { width: 150px !important; }
+.fw-wide   { width: 260px !important; }
+.fw-auto   { width: auto !important; }
+
+/* Constrained-width form column (e.g. upload forms, stacked single-column forms) */
+.form-narrow { max-width: 320px; }
+
+/* Two-pane layout (sidebar + main), e.g. Settings */
+.split { display: flex; gap: var(--space-6); }
+.split-side { width: 160px; flex: none; }
+.split-main { flex: 1; min-width: 0; }
+
+/* Vertical menu rail (e.g. Settings sections) — becomes horizontal tabs on mobile */
+.menu-title {
+  font-size: var(--fs-sm); font-weight: 600; letter-spacing: .07em; text-transform: uppercase;
+  color: var(--text-faint); margin-bottom: var(--space-3); padding-left: 11px;
+}
+.menu-list { display: flex; flex-direction: column; }
+.menu-item {
+  font-size: var(--fs-lg); color: var(--text-4); font-weight: 400;
+  padding: 7px 0 7px 11px; border-left: 2px solid transparent; cursor: pointer;
+}
+.menu-item.active { color: var(--color-primary); font-weight: 600; border-left-color: var(--color-primary); }
+
+/* 4. ---- Navigation ------------------------------------------------------ */
+.nav {
+  background: var(--surface);
+  border-bottom: 1px solid var(--border);
+  margin-bottom: var(--space-5);
+}
+.nav-inner {
+  max-width: var(--page-max);
+  margin: 0 auto;
+  display: flex;
+  align-items: center;
+  gap: var(--space-5);
+  padding: 0 var(--space-5);
+  min-height: 52px;
+}
+.nav-brand {
+  font-size: var(--fs-h2);
+  font-weight: 600;
+  color: var(--text-1);
+}
+.nav-brand:hover { text-decoration: none; }
+
+.nav-toggle {
+  display: none;
+  margin-left: auto;
+  background: none;
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  color: var(--text-3);
+  font-size: 18px;
+  line-height: 1;
+  padding: 5px 9px;
+  cursor: pointer;
+}
+
+.nav-links {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  align-items: center;
+  gap: var(--space-1);
+  flex-wrap: wrap;
+}
+.nav-link {
+  display: block;
+  font-size: var(--fs-md);
+  color: var(--text-4);
+  font-weight: 400;
+  padding: 7px 10px;
+  border-radius: var(--radius);
+  white-space: nowrap;
+}
+.nav-link:hover { color: var(--text-1); text-decoration: none; background: var(--surface-alt); }
+.nav-item.active .nav-link,
+.nav-link.active { color: var(--color-primary); font-weight: 600; }
+
+/* Financials dropdown */
+.nav-dropdown { position: relative; }
+.nav-dropdown-menu {
+  position: absolute;
+  top: calc(100% + 4px);
+  left: 0;
+  z-index: 1000;
+  min-width: 180px;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  box-shadow: 0 .5rem 1rem rgba(0,0,0,.12);
+  padding: var(--space-1) 0;
+}
+.nav-dropdown-item {
+  display: block;
+  padding: 7px 14px;
+  font-size: var(--fs-md);
+  color: var(--text-3);
+}
+.nav-dropdown-item:hover { background: var(--surface-alt); color: var(--text-1); text-decoration: none; }
+
+/* 5. ---- Cards & section headers ----------------------------------------- */
+.card {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  padding: var(--space-5);
+}
+.card + .card { margin-top: var(--space-4); }
+
+.card-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-3);
+  margin-bottom: var(--space-4);
+}
+.card-head-left { display: flex; align-items: baseline; gap: var(--space-2); }
+.card-head-right { display: flex; align-items: center; gap: var(--space-3); }
+.card-title { margin: 0; font-size: var(--fs-h2); font-weight: 600; color: var(--text-1); }
+.card-count { font-size: var(--fs-body); color: var(--text-muted); }
+.section-label {
+  font-size: var(--fs-sm); font-weight: 600; letter-spacing: .05em; text-transform: uppercase;
+  color: var(--text-muted); margin-bottom: var(--space-3);
+}
+
+/* 6. ---- Buttons --------------------------------------------------------- */
+.btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+  height: var(--control-h);
+  padding: 0 14px;
+  border: 1px solid transparent;
+  border-radius: var(--radius);
+  font-size: var(--fs-body);
+  font-weight: 500;
+  font-family: inherit;
+  cursor: pointer;
+  white-space: nowrap;
+}
+.btn:hover { text-decoration: none; }
+.btn-primary   { background: var(--color-primary); color: #fff; }
+.btn-danger    { background: var(--color-danger); color: #fff; }
+.btn-secondary { background: var(--surface); color: var(--text-3); border-color: var(--input-border); }
+.btn-ghost     { background: var(--status-neutral-bg); color: var(--text-4); border-color: var(--border); }
+.btn-warning   { background: var(--status-warning-bg); color: var(--status-warning-fg); border-color: var(--status-warning-fg); }
+.btn-sm  { height: 22px; padding: 0 8px; font-size: var(--fs-sm); }
+.btn:disabled, .btn[disabled] { opacity: .6; cursor: default; }
+
+/* Segmented radio control (replaces Bootstrap btn-group-toggle; no JS needed) */
+.segmented { display: inline-flex; border: 1px solid var(--input-border); border-radius: var(--radius); overflow: hidden; }
+.segmented label {
+  display: inline-flex; align-items: center; height: var(--control-h); padding: 0 14px;
+  font-size: var(--fs-body); color: var(--text-3); cursor: pointer; border-right: 1px solid var(--input-border);
+}
+.segmented label:last-child { border-right: none; }
+.segmented label:has(input:checked) { background: var(--color-primary); color: #fff; }
+.segmented input { position: absolute; opacity: 0; width: 0; height: 0; pointer-events: none; }
+
+/* 7. ---- Search box ------------------------------------------------------ */
+.search {
+  display: flex;
+  align-items: center;
+  gap: 7px;
+  width: 230px;
+  height: var(--control-h);
+  border: 1px solid var(--input-border);
+  border-radius: var(--radius);
+  padding: 0 9px;
+  background: var(--surface);
+}
+.search input {
+  border: none; outline: none; background: transparent;
+  width: 100%; font-family: inherit; font-size: var(--fs-body); color: var(--text-1);
+}
+.search input::placeholder { color: var(--text-faint); }
+.search svg { color: var(--text-faint); flex: none; }
+
+/* 8. ---- Tables ---------------------------------------------------------- */
+.table-scroll { max-height: 340px; overflow: auto; }
+.table-scroll-sm { max-height: 200px; }
+.table-scroll-lg { max-height: 480px; }
+.table { width: 100%; border-collapse: collapse; }
+.table th {
+  padding: var(--space-2) var(--space-3);
+  font-size: var(--fs-sm); letter-spacing: .04em; text-transform: uppercase;
+  color: var(--text-muted); font-weight: 600; text-align: left;
+  border-bottom: 1px solid var(--border);
+  position: sticky; top: 0; background: var(--surface); z-index: 1;
+}
+.table th.center, .table td.center { text-align: center; }
+.table th.right,  .table td.right  { text-align: right; }
+.table td {
+  padding: var(--space-2) var(--space-3);
+  font-size: var(--fs-body);
+  border-bottom: 1px solid var(--border-faint);
+  white-space: nowrap;
+}
+.table tbody tr:hover { background: var(--surface-alt); }
+
+/* Row selection — works for the .row convention AND the legacy jQuery
+   .clickable-row / .table-active highlight scripts. */
+.row { cursor: pointer; }
+.clickable-row { cursor: pointer; }
+.row.selected,
+.clickable-row.table-active,
+.table tbody tr.selected,
+.table tbody tr.table-active {
+  background: var(--selected);
+  box-shadow: inset 2px 0 0 var(--color-primary);
+}
+.td-name   { color: var(--text-1); font-weight: 500; }
+.td-strong { color: var(--text-1); font-weight: 600; }
+.td-2      { color: var(--text-2); }
+.td-3      { color: var(--text-3); }
+.td-muted  { color: var(--text-4); }
+.td-faint  { color: var(--text-faint); }
+.table-empty { padding: 22px var(--space-3); font-size: var(--fs-body); color: var(--text-muted); text-align: center; }
+
+/* Mobile stacked list (shown in place of a table on narrow screens) */
+.list { display: none; border-top: 1px solid var(--border); }
+.lrow { padding: 11px var(--space-3); cursor: pointer; border-bottom: 1px solid var(--border-faint); }
+.lrow.selected { background: var(--selected); box-shadow: inset 2px 0 0 var(--color-primary); }
+.lrow-top { display: flex; align-items: baseline; justify-content: space-between; gap: var(--space-3); }
+.lname {
+  font-size: var(--fs-md); color: var(--text-1); font-weight: 500;
+  min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
+}
+.lrow.selected .lname { font-weight: 600; }
+.lmeta-right { font-size: var(--fs-body); color: var(--text-3); white-space: nowrap; flex: none; }
+.lmeta { font-size: 11.5px; color: var(--text-muted); margin-top: 3px; }
+
+/* Loan amortization schedule — dense editable table */
+.loan-sched { table-layout: fixed; width: 100%; }
+.loan-sched td, .loan-sched th { white-space: normal; word-break: break-word; padding: 6px 5px; }
+.loan-sched .input { width: 100%; box-sizing: border-box; padding: 3px 5px; height: 26px; }
+.loan-sched .ls-bal { display: flex; align-items: center; gap: 4px; }
+.loan-sched .ls-bal .input { flex: 1; min-width: 0; }
+.loan-sched .ls-actions { display: flex; flex-direction: column; gap: 4px; }
+.loan-sched .ls-actions .btn { width: 100%; padding: 0 6px; height: 24px; font-size: var(--fs-sm); }
+
+/* 9. ---- Forms & fields -------------------------------------------------- */
+.form { margin-top: 22px; padding-top: var(--space-4); border-top: 1px solid var(--border-divider); }
+.form-header {
+  font-size: var(--fs-sm); font-weight: 600; letter-spacing: .05em; text-transform: uppercase;
+  color: var(--text-muted); margin-bottom: var(--space-4);
+}
+.field { margin-bottom: var(--space-3); }
+.label { display: block; font-size: var(--fs-sm); color: var(--text-4); margin-bottom: 5px; }
+.label-optional { color: var(--text-faint); }
+.input, .select, .textarea {
+  height: var(--control-h);
+  border: 1px solid var(--input-border);
+  border-radius: var(--radius);
+  padding: 0 9px;
+  font-size: var(--fs-body);
+  color: var(--text-1);
+  background: var(--surface);
+  width: 100%;
+  font-family: inherit;
+  outline: none;
+}
+.input:focus, .select:focus, .textarea:focus {
+  border-color: var(--focus-border); box-shadow: 0 0 0 .2rem var(--focus-ring);
+}
+.select { padding: 0 7px; cursor: pointer; }
+.is-invalid { border-color: var(--color-danger); }
+.textarea { height: auto; min-height: 64px; padding: 7px 9px; resize: vertical; }
+.file-input { font-size: var(--fs-body); color: var(--text-3); }
+
+.checks { display: flex; flex-wrap: wrap; gap: 20px; padding-bottom: 7px; }
+.check { display: inline-flex; align-items: center; gap: 7px; font-size: var(--fs-body); color: var(--text-1); cursor: pointer; }
+.check input { width: 14px; height: 14px; accent-color: var(--color-primary); cursor: pointer; margin: 0; }
+
+.actions { display: flex; gap: 9px; flex-wrap: wrap; }
+.field-error { font-size: var(--fs-sm); color: var(--color-danger); margin-top: var(--space-1); }
+
+/* Currency / prefixed input (replaces Bootstrap input-group) */
+.field-currency { display: flex; align-items: stretch; }
+.field-currency .prefix {
+  display: inline-flex; align-items: center;
+  padding: 0 9px;
+  border: 1px solid var(--input-border);
+  border-right: none;
+  border-radius: var(--radius) 0 0 var(--radius);
+  background: var(--status-neutral-bg);
+  color: var(--text-4);
+  font-size: var(--fs-body);
+}
+.field-currency .input { border-radius: 0 var(--radius) var(--radius) 0; }
+
+/* 10. ---- Feedback ------------------------------------------------------- */
+.alert { font-size: var(--fs-body); border-radius: var(--radius); padding: var(--space-2) 11px; margin-bottom: var(--space-4); }
+.alert-success { background: var(--status-success-bg); color: var(--status-success-fg); }
+.alert-danger  { background: var(--status-danger-bg);  color: var(--status-danger-fg); }
+.alert-info    { background: var(--status-info-bg);    color: var(--status-info-fg); }
+.alert-warning { background: var(--status-warning-bg); color: var(--status-warning-fg); }
+
+.badge {
+  display: inline-block; font-size: var(--fs-sm); font-weight: 600; line-height: 1;
+  padding: 4px 8px; border-radius: var(--radius-pill); white-space: nowrap;
+}
+.badge-matched    { background: var(--status-success-bg); color: var(--status-success-fg); }
+.badge-parsed     { background: var(--status-info-bg);    color: var(--status-info-fg); }
+.badge-unresolved { background: var(--status-warning-bg); color: var(--status-warning-fg); }
+.badge-failed     { background: var(--status-danger-bg);  color: var(--status-danger-fg); }
+.badge-pending    { background: var(--status-neutral-bg); color: var(--status-neutral-fg); }
+
+/* Per-request busy indicator (htmx adds .htmx-request to the indicator target) */
+.busy { display: none; font-size: 11.5px; color: var(--color-primary-strong); white-space: nowrap; }
+.busy.htmx-request { display: inline; }
+
+/* Compact status line: badge + short error + retry on one row */
+.status-line { display: inline-flex; align-items: center; gap: var(--space-2); white-space: nowrap; }
+.err { position: relative; }
+.err-short { font-size: var(--fs-sm); color: var(--status-danger-fg); cursor: help; border-bottom: 1px dotted #e0a3a8; }
+.err-tip {
+  display: none; position: absolute; top: calc(100% + 5px); left: 0; z-index: 30;
+  width: max-content; max-width: 320px; white-space: normal; font-size: var(--fs-sm);
+  line-height: 1.45; color: #fff; background: var(--text-1); padding: 7px 9px;
+  border-radius: 5px; box-shadow: 0 4px 14px rgba(0,0,0,.20);
+}
+.err:hover .err-tip { display: block; }
+
+/* Empty / stub states */
+.stub { border: 1px dashed #d8dce0; border-radius: var(--radius-lg); padding: 46px var(--space-5); text-align: center; background: var(--surface-stub); }
+.stub-title { font-size: var(--fs-md); color: #868e96; font-weight: 500; }
+.stub-sub { font-size: var(--fs-body); color: var(--text-faint); margin-top: var(--space-1); }
+
+/* 11. ---- KPI cards ------------------------------------------------------ */
+/* Fixed-width cards that sit left-aligned and wrap, rather than stretching. */
+.kpi-row { display: flex; flex-wrap: wrap; gap: var(--space-3); margin-bottom: var(--space-4); }
+.kpi {
+  width: 160px;
+  border: 1px solid var(--border); border-radius: var(--radius-lg);
+  padding: var(--space-3) var(--space-4); text-align: center; background: var(--surface);
+}
+.kpi-value { font-size: 20px; font-weight: 600; color: var(--text-1); }
+.kpi-label { font-size: var(--fs-sm); letter-spacing: .04em; text-transform: uppercase; color: var(--text-muted); margin-top: var(--space-1); }
+
+/* 12. ---- Typeahead multi-select (markup unchanged; styling tokenized) --- */
+.ta-field { position: relative; }
+.ta-label { color: var(--text-1); cursor: pointer; user-select: none; font-size: var(--fs-sm); font-weight: 500; }
+.ta-badge { background: var(--color-primary); color: #fff; font-size: .62rem; font-weight: 600; line-height: 1;
+            padding: 2px 6px; border-radius: .7rem; margin-left: 5px; vertical-align: middle; }
+.ta-anchor { position: relative; }
+.ta-trigger { display: flex; align-items: center; justify-content: space-between; gap: 6px; width: 100%;
+              text-align: left; background: var(--surface); border: 1px solid var(--input-border); border-radius: var(--radius);
+              padding: 0 9px; min-height: var(--control-h); font-size: var(--fs-body); color: var(--text-1); cursor: pointer; }
+.ta-trigger.is-empty .ta-trigger-text { color: var(--text-4); }
+.ta-trigger:focus { border-color: var(--focus-border); box-shadow: 0 0 0 .2rem var(--focus-ring); outline: 0; }
+.ta-trigger-text { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.ta-caret { color: var(--text-4); font-size: .7rem; }
+.ta-popover { position: absolute; top: 100%; left: 0; right: 0; z-index: 1000; margin-top: 2px;
+              background: var(--surface); border: 1px solid rgba(0,0,0,.15); border-radius: var(--radius);
+              padding: .45rem; min-width: 210px; box-shadow: 0 .5rem 1rem rgba(0,0,0,.15); }
+.ta-search { width: 100%; border: 1px solid var(--border-divider); border-radius: .2rem; font-size: var(--fs-body);
+             padding: .28rem .4rem; margin-bottom: .4rem; }
+.ta-search:focus { outline: 0; border-color: var(--focus-border); box-shadow: 0 0 0 .15rem rgba(0,123,255,.2); }
+.ta-popover-list { max-height: 220px; overflow: auto; }
+.ta-check { display: flex; align-items: center; gap: 8px; font-size: var(--fs-body); padding: .22rem .25rem;
+            margin: 0; cursor: pointer; font-weight: 400; border-radius: .15rem; }
+.ta-check:hover { background: var(--status-neutral-bg); }
+.ta-check--on { background: #f1f6ff; }
+.ta-check--on:hover { background: #e7f1ff; }
+.ta-pinned { border-bottom: 1px solid var(--border-divider); padding-bottom: .2rem; margin-bottom: .25rem; }
+.ta-section-label { font-size: .64rem; text-transform: uppercase; letter-spacing: .05em;
+                    color: var(--text-4); font-weight: 600; padding: .15rem .25rem; }
+.ta-mark { font-weight: 700; }
+.ta-empty { padding: .45rem .55rem; font-size: var(--fs-sm); color: var(--text-4); }
+.ta-toolbar { display: flex; align-items: center; gap: 9px; padding: .4rem .35rem .15rem;
+              border-top: 1px solid var(--border-divider); margin-top: .35rem; }
+.ta-link { border: 0; background: transparent; color: var(--color-primary); font-size: var(--fs-sm); padding: 0; cursor: pointer; }
+.ta-link:hover { text-decoration: underline; }
+.ta-toolbar-sep { color: var(--input-border); font-size: var(--fs-sm); }
+
+/* 13. ---- Utilities ------------------------------------------------------ */
+.muted, .text-muted { color: var(--text-muted); }
+.faint { color: var(--text-faint); }
+.text-secondary { color: var(--text-4); }
+.text-primary { color: var(--color-primary); }
+.text-success { color: var(--status-success-fg); }
+.text-danger  { color: var(--color-danger); }
+.bg-light { background: var(--surface-alt); }
+.text-center { text-align: center; }
+.nowrap { white-space: nowrap; }
+.truncate { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.highlight-yellow { background-color: var(--highlight); }
+.small { font-size: var(--fs-sm); }
+.fs-body { font-size: var(--fs-body); }
+
+/* Small flex helpers (token-driven; keeps micro-layouts off inline styles) */
+.flex { display: flex; }
+.flex-between { display: flex; align-items: center; justify-content: space-between; }
+.items-baseline { align-items: baseline; }
+.justify-end { justify-content: flex-end; }
+.gap-2 { gap: var(--space-2); }
+.gap-3 { gap: var(--space-3); }
+.sticky-pane { position: sticky; top: 1rem; }
+.cell-clip { max-width: 250px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+
+.mt-0 { margin-top: 0; }   .mb-0 { margin-bottom: 0; }
+.mt-2 { margin-top: var(--space-2); } .mb-2 { margin-bottom: var(--space-2); }
+.mt-3 { margin-top: var(--space-3); } .mb-3 { margin-bottom: var(--space-3); }
+.mt-4 { margin-top: var(--space-4); } .mb-4 { margin-bottom: var(--space-4); }
+
+/* 14. ---- Mobile reflow (breakpoint: 760px) ------------------------------
+   Single-column everywhere; nav collapses to a toggle panel; multi-column
+   grids stack; tables can switch to the stacked .list. */
+@media (max-width: 760px) {
+  .page { padding: var(--space-4) var(--space-3) 48px; }
+
+  /* Nav */
+  .nav-toggle { display: inline-block; }
+  .nav-inner { flex-wrap: wrap; padding: var(--space-2) var(--space-3); }
+  .nav-links {
+    display: none;
+    flex-basis: 100%;
+    flex-direction: column;
+    align-items: stretch;
+    gap: 0;
+    padding-bottom: var(--space-2);
+  }
+  .nav-links.open { display: flex; }
+  .nav-link { padding: 10px 6px; border-bottom: 1px solid var(--border-faint); }
+  .nav-dropdown-menu { position: static; box-shadow: none; border: none; padding-left: var(--space-3); }
+
+  /* Layout */
+  .split { flex-direction: column; gap: var(--space-4); }
+  .split-side { width: auto; }
+  .grid-2, .grid-3, .grid-4, .grid-wide-first, .grid-main-side { grid-template-columns: 1fr; }
+
+  /* Filter bar + KPI cards stack full-width on mobile */
+  .filter-bar > * { width: 100% !important; }
+  .kpi { width: 100%; }
+
+  /* Menu rail -> horizontal scrollable tab strip */
+  .menu-title { display: none; }
+  .menu-list { flex-direction: row; overflow-x: auto; gap: 2px; border-bottom: 1px solid var(--border-divider); }
+  .menu-item { padding: 9px 13px; border-left: none; border-bottom: 2px solid transparent; white-space: nowrap; }
+  .menu-item.active { border-left-color: transparent; border-bottom-color: var(--color-primary); }
+
+  /* Tables -> stacked lists where provided */
+  .table-scroll.has-list { display: none; }
+  .has-list + .list, .list.show-mobile { display: block; }
+
+  /* Cards a touch tighter */
+  .card { padding: var(--space-4); }
+}

--- a/ledger/templates/api/base.html
+++ b/ledger/templates/api/base.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+{% load static %}<!DOCTYPE html>
 <html lang="en">
 
 <head>
@@ -6,131 +6,18 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
 
 
-    <!-- Include jQuery -->
+    <!-- Include jQuery (independent of the removed Bootstrap; powers behavior scripts) -->
     <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.5.1/jquery.min.js"></script>
     <!-- htmx -->
     <script src="https://unpkg.com/htmx.org"></script>
 
-    <!-- Bootstrap -->
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.14.7/umd/popper.min.js"></script>
-    <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.5.0/js/bootstrap.min.js"></script>
-    <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.5.0/css/bootstrap.min.css">
+    <!-- Bootstrap Icons (icon font only; framework removed in favor of app.css) -->
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.13.1/font/bootstrap-icons.min.css">
 
+    <!-- Central design system: the single source of truth for all styling -->
+    <link rel="stylesheet" href="{% static 'css/app.css' %}">
+
     <script src="https://cdn.jsdelivr.net/npm/alpinejs@3.x.x/dist/cdn.min.js" defer></script>
-
-
-    <style>
-
-        .form-sm .form-control {
-            padding: .3rem; /* smaller padding */
-            font-size: 0.75rem; /* smaller font-size */
-            /* Match height to the reduced padding (Bootstrap's default height assumes
-               .75rem padding). This is the same formula .ta-trigger uses, so date
-               inputs, selects, text inputs and typeahead triggers are all the same
-               height and every filter column lines up row-for-row. */
-            height: calc(1.5em + .6rem + 2px);
-        }
-        .form-sm .input-group-text {
-            padding: .3rem .5rem; /* smaller padding */
-            font-size: 0.75rem; /* smaller font-size */
-        }
-        .form-sm .row {
-            margin-bottom: .5rem; /* less space between rows */
-        }
-        .form-sm h3 {
-            font-size: 1rem; /* smaller heading */
-        }
-        .form-sm .btn {
-            padding: .25rem .5rem; /* smaller button padding */
-            font-size: 0.75rem; /* smaller font-size */
-        }
-
-        .input-group-sm .input-group-prepend .input-group-text {
-            padding: 2px 4px; /* Match the padding to the input field */
-            font-size: 0.8em; /* Match the font size to the input field */
-            /* You may need to adjust the height if it's not automatically aligning */
-            height: calc(1.7rem + 1px); /* This is Bootstrap's default height for small form controls, adjust the calc() as necessary */
-        }
-
-        .table-sm th, .table-sm td {
-            padding: .3rem; /* smaller padding */
-            white-space: nowrap; /* prevents wrapping */
-            font-size: 0.75rem; /* smaller font-size */
-        }
-
-        .highlight-yellow {
-            background-color: #fcfcd5; /* Dull yellow color */
-        }
-
-        /* Style to make the table container fixed and scrollable */
-        .fixed-table-container {
-            position: fixed;
-            top: 120px; /* Adjust as needed */
-            bottom: 20px; /* Adjust as needed */
-            width: 400px; /* Adjust as needed */
-            max-height: 70vh; /* Adjust as needed */
-            overflow-y: auto;
-        }
-        .fixed-header {
-            position: sticky;
-            top: 0;
-            background: white;
-            z-index: 1;
-        }
-        .transaction-column {
-            max-width: 250px; /* Adjust as necessary */
-            white-space: nowrap;
-            overflow: hidden;
-            text-overflow: ellipsis;
-        }
-
-        /* --- Typeahead multi-select (Option B: count + checkbox menu) --- */
-        [x-cloak] { display: none !important; }
-        .ta-field { position: relative; }
-        /* Field labels across all compact forms (the direct-child selector excludes
-           the in-popover checkbox labels, .ta-check, which style themselves) */
-        .form-sm .form-group > label { font-size: .75rem; font-weight: 500; margin-bottom: 3px; }
-        /* Vertical gap between fields stacked in the same column. Owned here once
-           (not via per-field mb-* utilities) so every column lines up row-for-row.
-           .ta-field is also a .form-group, so typeaheads participate automatically. */
-        .form-sm .form-group + .form-group { margin-top: .25rem; }
-        .ta-label { color: #212529; cursor: pointer; user-select: none; }
-        .ta-badge { background: #007bff; color: #fff; font-size: .62rem; font-weight: 600; line-height: 1;
-                    padding: 2px 6px; border-radius: .7rem; margin-left: 5px; vertical-align: middle; }
-        .ta-anchor { position: relative; }
-        .ta-trigger { display: flex; align-items: center; justify-content: space-between; gap: 6px; width: 100%;
-                      text-align: left; background: #fff; border: 1px solid #dee2e6; border-radius: .25rem;
-                      padding: .3rem .5rem; font-size: .75rem; color: #212529; cursor: pointer;
-                      min-height: calc(1.5em + .6rem + 2px); }
-        .ta-trigger.is-empty .ta-trigger-text { color: #6c757d; }
-        .ta-trigger:focus { border-color: #80bdff; box-shadow: 0 0 0 .2rem rgba(0,123,255,.25); outline: 0; }
-        .ta-trigger-text { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
-        .ta-caret { color: #6c757d; font-size: .7rem; }
-        .ta-popover { position: absolute; top: 100%; left: 0; right: 0; z-index: 1000; margin-top: 2px;
-                      background: #fff; border: 1px solid rgba(0,0,0,.15); border-radius: .25rem;
-                      padding: .45rem; min-width: 210px; box-shadow: 0 .5rem 1rem rgba(0,0,0,.15); }
-        .ta-search { width: 100%; border: 1px solid #dee2e6; border-radius: .2rem; font-size: .75rem;
-                     padding: .28rem .4rem; margin-bottom: .4rem; }
-        .ta-search:focus { outline: 0; border-color: #80bdff; box-shadow: 0 0 0 .15rem rgba(0,123,255,.2); }
-        .ta-popover-list { max-height: 220px; overflow: auto; }
-        .ta-check { display: flex; align-items: center; gap: 8px; font-size: .75rem; padding: .22rem .25rem;
-                    margin: 0; cursor: pointer; font-weight: 400; border-radius: .15rem; }
-        .ta-check:hover { background: #f1f3f5; }
-        .ta-check--on { background: #f1f6ff; }
-        .ta-check--on:hover { background: #e7f1ff; }
-        .ta-pinned { border-bottom: 1px solid #e9ecef; padding-bottom: .2rem; margin-bottom: .25rem; }
-        .ta-section-label { font-size: .64rem; text-transform: uppercase; letter-spacing: .05em;
-                            color: #6c757d; font-weight: 600; padding: .15rem .25rem; }
-        .ta-mark { font-weight: 700; }
-        .ta-empty { padding: .45rem .55rem; font-size: .72rem; color: #6c757d; }
-        .ta-toolbar { display: flex; align-items: center; gap: 9px; padding: .4rem .35rem .15rem;
-                      border-top: 1px solid #e9ecef; margin-top: .35rem; }
-        .ta-link { border: 0; background: transparent; color: #007bff; font-size: .72rem; padding: 0; cursor: pointer; }
-        .ta-link:hover { text-decoration: underline; }
-        .ta-toolbar-sep { color: #ced4da; font-size: .72rem; }
-
-    </style>
 
     <!-- Typeahead multi-select Alpine component (Option B). Registered once,
          before Alpine inits, so it is available to htmx-swapped filter forms. -->
@@ -195,6 +82,25 @@
                     + this.escapeHtml(label.slice(i + q.length));
             },
         }));
+
+        // Live search + selection state shared by the Settings list fragments
+        // (Accounts, Loans, Bill Rules). Rows carry data-search; the desktop
+        // <tr data-search> set drives the visible count.
+        Alpine.data('searchList', (total, noun, selectedId = null) => ({
+            q: '',
+            selectedId: selectedId,
+            total: total,
+            matches(el) { return !this.q.trim() || el.dataset.search.includes(this.q.toLowerCase()); },
+            visible() {
+                if (!this.q.trim()) return this.total;
+                const needle = this.q.toLowerCase();
+                return Array.from(this.$root.querySelectorAll('tr[data-search]'))
+                    .filter(tr => tr.dataset.search.includes(needle)).length;
+            },
+            countLabel() {
+                return this.q.trim() ? (this.visible() + ' of ' + this.total) : (this.total + ' ' + noun);
+            },
+        }));
     });
     </script>
 
@@ -205,7 +111,7 @@
 <body>
 
     {% include "api/components/nav.html" %}
-    <div id="container" class="container">
+    <div id="container" class="page">
         {% block content %}{% endblock %}
     </div>
 

--- a/ledger/templates/api/components/nav.html
+++ b/ledger/templates/api/components/nav.html
@@ -1,54 +1,56 @@
-<nav class="navbar navbar-expand-lg navbar-light bg-light mb-3">
-    <div class="container">
-        <a class="navbar-brand" href="/">Ledger</a>
-        <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarNav" aria-controls="navbarNav" aria-expanded="false" aria-label="Toggle navigation">
-            <span class="navbar-toggler-icon"></span>
+<nav class="nav" x-data="{ menu: false, fin: false }">
+    <div class="nav-inner">
+        <a class="nav-brand" href="/">Ledger</a>
+
+        <button class="nav-toggle" type="button" @click="menu = !menu"
+                aria-label="Toggle navigation">
+            <i class="bi bi-list"></i>
         </button>
-        <div class="collapse navbar-collapse" id="navbarNav">
-            <ul class="navbar-nav" hx-boost="true" hx-target="#container" hx-select="#container" hx-swap="outerHTML show:window:top">
-                <li class="nav-item {% if request.resolver_match.url_name == 'journal-entries' %}active{% endif %}">
-                    <a class="nav-link" href="{% url 'journal-entries' %}">Entries</a>
-                </li>
-                <li class="nav-item {% if request.resolver_match.url_name == 'link-transactions' %}active{% endif %}">
-                    <a class="nav-link" href="{% url 'link-transactions' %}">Links</a>
-                </li>
-                <li class="nav-item {% if request.resolver_match.url_name == 'transactions' %}active{% endif %}">
-                    <a class="nav-link" href="{% url 'transactions' %}">Transactions</a>
-                </li>
-                <li class="nav-item {% if request.resolver_match.url_name == 'taxes' %}active{% endif %}">
-                    <a class="nav-link" href="{% url 'taxes' %}">Taxes</a>
-                </li>
-                <li class="nav-item {% if request.resolver_match.url_name == 'reconciliation' %}active{% endif %}">
-                    <a class="nav-link" href="{% url 'reconciliation' %}">Reconciliations</a>
-                </li>
-                <li class="nav-item {% if request.resolver_match.url_name == 'amortization' %}active{% endif %}">
-                    <a class="nav-link" href="{% url 'amortization' %}">Amortizations</a>
-                </li>
-                <li class="nav-item {% if request.resolver_match.url_name == 'tag-entities' %}active{% endif %}">
-                    <a class="nav-link" href="{% url 'tag-entities' %}">Balances</a>
-                </li>
-                <li class="nav-item {% if request.resolver_match.url_name == 'upload-transactions' %}active{% endif %}">
-                    <a class="nav-link" href="{% url 'upload-transactions' %}">Upload/Download</a>
-                </li>
-                <li class="nav-item {% if request.resolver_match.url_name == 'search' %}active{% endif %}">
-                    <a class="nav-link" href="{% url 'search' %}">Search</a>
-                </li>
-                <li class="nav-item {% if request.resolver_match.url_name == 'settings' %}active{% endif %}">
-                    <a class="nav-link" href="{% url 'settings' %}">Settings</a>
-                </li>
-                <!-- Dropdown Menu for Financial Statements -->
-                <li class="nav-item dropdown">
-                    <a class="nav-link dropdown-toggle" href="#" id="navbarDropdownMenuLink" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false" hx-boost="false">
-                        Financials
-                    </a>
-                    <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-                        <!-- hx-include to maintain filters between statements -->
-                        <a class="dropdown-item" href="{% url 'statements' 'income' %}" hx-include="#statement-form">Income Statement</a>
-                        <a class="dropdown-item" href="{% url 'statements' 'balance' %}" hx-include="#statement-form">Balance Sheet</a>
-                        <a class="dropdown-item" href="{% url 'statements' 'cash' %}" hx-include="#statement-form">Cash Flow</a>
-                    </div>
-                </li>
-            </ul>
-        </div>
+
+        <ul class="nav-links" :class="{ open: menu }"
+            hx-boost="true" hx-target="#container" hx-select="#container" hx-swap="outerHTML show:window:top">
+            <li class="nav-item {% if request.resolver_match.url_name == 'journal-entries' %}active{% endif %}">
+                <a class="nav-link" href="{% url 'journal-entries' %}">Entries</a>
+            </li>
+            <li class="nav-item {% if request.resolver_match.url_name == 'link-transactions' %}active{% endif %}">
+                <a class="nav-link" href="{% url 'link-transactions' %}">Links</a>
+            </li>
+            <li class="nav-item {% if request.resolver_match.url_name == 'transactions' %}active{% endif %}">
+                <a class="nav-link" href="{% url 'transactions' %}">Transactions</a>
+            </li>
+            <li class="nav-item {% if request.resolver_match.url_name == 'taxes' %}active{% endif %}">
+                <a class="nav-link" href="{% url 'taxes' %}">Taxes</a>
+            </li>
+            <li class="nav-item {% if request.resolver_match.url_name == 'reconciliation' %}active{% endif %}">
+                <a class="nav-link" href="{% url 'reconciliation' %}">Reconciliations</a>
+            </li>
+            <li class="nav-item {% if request.resolver_match.url_name == 'amortization' %}active{% endif %}">
+                <a class="nav-link" href="{% url 'amortization' %}">Amortizations</a>
+            </li>
+            <li class="nav-item {% if request.resolver_match.url_name == 'tag-entities' %}active{% endif %}">
+                <a class="nav-link" href="{% url 'tag-entities' %}">Balances</a>
+            </li>
+            <li class="nav-item {% if request.resolver_match.url_name == 'upload-transactions' %}active{% endif %}">
+                <a class="nav-link" href="{% url 'upload-transactions' %}">Upload/Download</a>
+            </li>
+            <li class="nav-item {% if request.resolver_match.url_name == 'search' %}active{% endif %}">
+                <a class="nav-link" href="{% url 'search' %}">Search</a>
+            </li>
+            <li class="nav-item {% if request.resolver_match.url_name == 'settings' %}active{% endif %}">
+                <a class="nav-link" href="{% url 'settings' %}">Settings</a>
+            </li>
+
+            <!-- Financials dropdown (Alpine-driven; hx-boost disabled on the toggle) -->
+            <li class="nav-item nav-dropdown" @click.outside="fin = false">
+                <a class="nav-link" href="#" role="button" hx-boost="false"
+                   @click.prevent="fin = !fin">Financials ▾</a>
+                <div class="nav-dropdown-menu" x-show="fin" x-cloak @click="fin = false">
+                    <!-- hx-include keeps the active statement filters between statements -->
+                    <a class="nav-dropdown-item" href="{% url 'statements' 'income' %}" hx-include="#statement-form">Income Statement</a>
+                    <a class="nav-dropdown-item" href="{% url 'statements' 'balance' %}" hx-include="#statement-form">Balance Sheet</a>
+                    <a class="nav-dropdown-item" href="{% url 'statements' 'cash' %}" hx-include="#statement-form">Cash Flow</a>
+                </div>
+            </li>
+        </ul>
     </div>
 </nav>

--- a/ledger/templates/api/components/search-box.html
+++ b/ledger/templates/api/components/search-box.html
@@ -1,0 +1,10 @@
+{% comment %}
+Search box for the Settings list fragments. Rendered inside an x-data scope
+that exposes `q` (the live query). Pass `placeholder`.
+{% endcomment %}
+<div class="search">
+  <svg width="12" height="12" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.6">
+    <circle cx="7" cy="7" r="4.5"></circle><line x1="10.6" y1="10.6" x2="14" y2="14"></line>
+  </svg>
+  <input x-model="q" placeholder="{{ placeholder }}" />
+</div>

--- a/ledger/templates/api/components/transaction-success.html
+++ b/ledger/templates/api/components/transaction-success.html
@@ -1,34 +1,22 @@
 {% load humanize %}
-<div class="row">
-    <div class="col-md-6">
-        {% if change == "create" %}
-        <div class="alert alert-success" role="alert">
-            <small>Added transaction</small>
-        </div>
-        {% elif change == "update" %}
-        <div class="alert alert-success" role="alert">
-            <small>Updated transaction</small>
-        </div>
-        {% elif change == "delete" %}
-        <div class="alert alert-danger" role="alert">
-            <small>Deleted transaction</small>
-        </div>
-        {% endif %}
+{% if change == "create" %}
+<div class="alert alert-success" role="alert"><small>Added transaction</small></div>
+{% elif change == "update" %}
+<div class="alert alert-success" role="alert"><small>Updated transaction</small></div>
+{% elif change == "delete" %}
+<div class="alert alert-danger" role="alert"><small>Deleted transaction</small></div>
+{% endif %}
 
-        <div class="card">
-            <div class="card-body">
-                <p class="card-text small" style="margin-bottom: 10px;"><strong>Date:</strong> {{ created_transaction.date }}</p>
-                <p class="card-text small" style="margin-bottom: 10px;">
-                    <strong>Amount:</strong>
-                    {% if transaction.amount < 0 %}
-                        -${{ created_transaction.amount|floatformat:2|intcomma|cut:"-" }}
-                    {% else %}
-                        ${{ created_transaction.amount|floatformat:2|intcomma }}
-                    {% endif %}
-                </p>
-                <p class="card-text small" style="margin-bottom: 10px;"><strong>Description:</strong> {{ created_transaction.description }}</p>
-                <p class="card-text small" style="margin-bottom: 10px;"><strong>Account:</strong> {{ created_transaction.account }}</p>
-            </div>
-        </div>
-    </div>
+<div class="card">
+    <p class="small mb-2"><strong>Date:</strong> {{ created_transaction.date }}</p>
+    <p class="small mb-2">
+        <strong>Amount:</strong>
+        {% if transaction.amount < 0 %}
+            -${{ created_transaction.amount|floatformat:2|intcomma|cut:"-" }}
+        {% else %}
+            ${{ created_transaction.amount|floatformat:2|intcomma }}
+        {% endif %}
+    </p>
+    <p class="small mb-2"><strong>Description:</strong> {{ created_transaction.description }}</p>
+    <p class="small mb-0"><strong>Account:</strong> {{ created_transaction.account }}</p>
 </div>

--- a/ledger/templates/api/components/typeahead-multiselect.html
+++ b/ledger/templates/api/components/typeahead-multiselect.html
@@ -14,7 +14,7 @@ Params:
   label      - visible label / empty-state placeholder
   all_label  - section header for unselected options (default "All")
 {% endcomment %}
-<div class="form-group ta-field"
+<div class="field ta-field"
      x-data="typeaheadMultiselect()"
      @click.outside="closeMenu()"
      @keydown.escape="closeMenu()">

--- a/ledger/templates/api/content/balance-sheet-content.html
+++ b/ledger/templates/api/content/balance-sheet-content.html
@@ -1,118 +1,108 @@
 {% load humanize %}
 {% load math_filters %}
-<div class="row">
-    <div class="col">
-        {{ filter_form }}
+{{ filter_form }}
+
+{% if unbalanced_entries %}
+<div class="page-narrow">
+    <div class="alert alert-danger small mb-2" role="alert">
+    ⚠️ <strong>{{ unbalanced_entries|length }}</strong> unbalanced journal entr{{ unbalanced_entries|length|pluralize:"y,ies" }} detected.
+    </div>
+    <table class="table mb-4">
+        <thead>
+        <tr>
+            <th scope="col">ID</th>
+            <th scope="col">Description</th>
+            <th scope="col" class="right">Debits</th>
+            <th scope="col" class="right">Credits</th>
+        </tr>
+        </thead>
+        <tbody>
+        {% for entry in unbalanced_entries %}
+            <tr>
+            <td>{{ entry.id }}</td>
+            <td class="td-name">{{ entry.transaction.description }}</td>
+            <td class="right">${{ entry.total_debits|default:0|floatformat:2 }}</td>
+            <td class="right">${{ entry.total_credits|default:0|floatformat:2 }}</td>
+            </tr>
+        {% endfor %}
+        </tbody>
+    </table>
+</div>
+{% endif %}
+
+<div class="kpi-row">
+    <div class="kpi">
+        <div class="kpi-value">{{ cash_percent_assets|multiply:100|floatformat:1 }}%</div>
+        <div class="kpi-label">Cash % Assets</div>
+    </div>
+    <div class="kpi">
+        <div class="kpi-value">{{ liquid_percent_assets|multiply:100|floatformat:1 }}%</div>
+        <div class="kpi-label">% Liquid</div>
+    </div>
+    <div class="kpi">
+        <div class="kpi-value">{{ debt_to_equity_ratio|floatformat:2 }}x</div>
+        <div class="kpi-label">Debt to Equity</div>
     </div>
 </div>
-<div class="container-fluid">
-    {% if unbalanced_entries %}
 
-    <div class="row">
-        <div class="col-md-4">
-            <div class="alert alert-danger py-1 px-2 small mb-2" role="alert">
-            ⚠️ <strong>{{ unbalanced_entries|length }}</strong> unbalanced journal entr{{ unbalanced_entries|length|pluralize:"y,ies" }} detected.
-            </div>
-            <table class="table table-sm table-striped align-middle mb-4">
-                <thead class="table-light">
+<div class="grid grid-3">
+    <div>
+        <h4>Assets: ${{ summary.asset.total|floatformat:"0"|intcomma }}</h4>
+        {% for account in summary.asset.balances %}
+        <table class="table mb-3">
+            <tbody>
                 <tr>
-                    <th scope="col">ID</th>
-                    <th scope="col">Description</th>
-                    <th scope="col" class="text-end">Debits</th>
-                    <th scope="col" class="text-end">Credits</th>
+                    <td class="td-strong">{{ account.name }}</td>
+                    <td class="right td-strong">${{ account.total|floatformat:"0"|intcomma }}</td>
                 </tr>
-                </thead>
-                <tbody>
-                {% for entry in unbalanced_entries %}
-                    <tr>
-                    <td>{{ entry.id }}</td>
-                    <td>{{ entry.transaction.description }}</td>
-                    <td class="text-end">${{ entry.total_debits|default:0|floatformat:2 }}</td>
-                    <td class="text-end">${{ entry.total_credits|default:0|floatformat:2 }}</td>
-                    </tr>
+                {% for balance in account.balances %}
+                <tr>
+                    <td class="td-name">{{ balance.account }}</td>
+                    <td class="right">${{ balance.amount|floatformat:"0"|intcomma }}</td>
+                </tr>
                 {% endfor %}
-                </tbody>
-            </table>
-        </div>
+            </tbody>
+        </table>
+        {% endfor %}
     </div>
-    {% endif %}
-    <div class="row">
-        <div class="col-md-12">
-            <div class="row text-center">
-                <div class="col-md-2">
-                    <h5 class="font-weight-bold">{{ cash_percent_assets|multiply:100|floatformat:1 }}%</h5>
-                    <p class="text-secondary">Cash % Assets</p>
-                </div>
-                <div class="col-md-2">
-                    <h5 class="font-weight-bold">{{ liquid_percent_assets|multiply:100|floatformat:1 }}%</h5>
-                    <p class="text-secondary">% Liquid</p>
-                </div>
-                <div class="col-md-2">
-                    <h5 class="font-weight-bold">{{ debt_to_equity_ratio|floatformat:2 }}x</h5>
-                    <p class="text-secondary">Debt to Equity</p>
-                </div>
-            </div>
-        </div>
+
+    <div>
+        <h4>Liabilities: ${{ summary.liability.total|floatformat:"0"|intcomma }}</h4>
+        {% for account in summary.liability.balances %}
+        <table class="table mb-3">
+            <tbody>
+                <tr>
+                    <td class="td-strong">{{ account.name }}</td>
+                    <td class="right td-strong">${{ account.total|floatformat:"0"|intcomma }}</td>
+                </tr>
+                {% for balance in account.balances %}
+                <tr>
+                    <td class="td-name">{{ balance.account }}</td>
+                    <td class="right">${{ balance.amount|floatformat:"0"|intcomma }}</td>
+                </tr>
+                {% endfor %}
+            </tbody>
+        </table>
+        {% endfor %}
     </div>
-    <div class="row">
-        <div class="col-md-4">
-            <h4>Assets: ${{ summary.asset.total|floatformat:"0"|intcomma }}</h4>
-            {% for account in summary.asset.balances %}
-            <table class="table table-hover table-sm">
-                <tbody>
-                    <tr>
-                        <td class="col-8"><strong>{{ account.name }}</strong></td>
-                        <td class="col-4"><strong>${{ account.total|floatformat:"0"|intcomma }}</strong></td>
-                    </tr>
-                    {% for balance in account.balances %}
-                    <tr>
-                        <td class="col-8">{{ balance.account }}</td>
-                        <td class="col-4">${{ balance.amount|floatformat:"0"|intcomma }}</td>
-                    </tr>
-                    {% endfor %}
-                </tbody>
-            </table>
-            {% endfor %}
-        </div>
 
-        <div class="col-md-4">
-            <h4>Liabilities: ${{ summary.liability.total|floatformat:"0"|intcomma }}</h4>
-            {% for account in summary.liability.balances %}
-            <table class="table table-hover table-sm">
-                <tbody>
-                    <tr>
-                        <td class="col-8"><strong>{{ account.name }}</strong></td>
-                        <td class="col-4"><strong>${{ account.total|floatformat:"0"|intcomma }}</strong></td>
-                    </tr>
-                    {% for balance in account.balances %}
-                    <tr>
-                        <td class="col-8">{{ balance.account }}</td>
-                        <td class="col-4">${{ balance.amount|floatformat:"0"|intcomma }}</td>
-                    </tr>
-                    {% endfor %}
-                </tbody>
-            </table>
-            {% endfor %}
-        </div>
-
-        <div class="col-md-4">
-            <h4>Equity: ${{ summary.equity.total|floatformat:"0"|intcomma }}</h4>
-            {% for account in summary.equity.balances %}
-            <table class="table table-hover table-sm">
-                <tbody>
-                    <tr>
-                        <td class="col-8"><strong>{{ account.name }}</strong></td>
-                        <td class="col-4"><strong>${{ account.total|floatformat:"0"|intcomma }}</strong></td>
-                    </tr>
-                    {% for balance in account.balances %}
-                    <tr>
-                        <td class="col-8">{{ balance.account }}</td>
-                        <td class="col-4">${{ balance.amount|floatformat:"0"|intcomma }}</td>
-                    </tr>
-                    {% endfor %}
-                </tbody>
-            </table>
-            {% endfor %}
-        </div>
+    <div>
+        <h4>Equity: ${{ summary.equity.total|floatformat:"0"|intcomma }}</h4>
+        {% for account in summary.equity.balances %}
+        <table class="table mb-3">
+            <tbody>
+                <tr>
+                    <td class="td-strong">{{ account.name }}</td>
+                    <td class="right td-strong">${{ account.total|floatformat:"0"|intcomma }}</td>
+                </tr>
+                {% for balance in account.balances %}
+                <tr>
+                    <td class="td-name">{{ balance.account }}</td>
+                    <td class="right">${{ balance.amount|floatformat:"0"|intcomma }}</td>
+                </tr>
+                {% endfor %}
+            </tbody>
+        </table>
+        {% endfor %}
     </div>
 </div>

--- a/ledger/templates/api/content/bill-rules-content.html
+++ b/ledger/templates/api/content/bill-rules-content.html
@@ -1,40 +1,21 @@
-<div x-data="{
-        q: '',
-        selectedId: {{ selected_id|default:'null' }},
-        total: {{ total }},
-        matches(el) { return !this.q.trim() || el.dataset.search.includes(this.q.toLowerCase()); },
-        visible() {
-          if (!this.q.trim()) return this.total;
-          const needle = this.q.toLowerCase();
-          return Array.from(this.$root.querySelectorAll('tr[data-search]'))
-            .filter(tr => tr.dataset.search.includes(needle)).length;
-        },
-        countLabel() {
-          return this.q.trim() ? (this.visible() + ' of ' + this.total) : (this.total + ' rules');
-        }
-     }">
+<div x-data="searchList({{ total }}, 'rules', {{ selected_id|default:'null' }})">
 
-  <div class="set-head">
-    <div class="set-head-left">
-      <h2 class="set-h2">Bill Rules</h2>
-      <span class="set-count" x-text="countLabel()"></span>
+  <div class="card-head">
+    <div class="card-head-left">
+      <h2 class="card-title">Bill Rules</h2>
+      <span class="card-count" x-text="countLabel()"></span>
     </div>
-    <div class="set-head-right">
-      <div class="set-search">
-        <svg width="12" height="12" viewBox="0 0 16 16" fill="none" stroke="#adb5bd" stroke-width="1.6">
-          <circle cx="7" cy="7" r="4.5"></circle><line x1="10.6" y1="10.6" x2="14" y2="14"></line>
-        </svg>
-        <input x-model="q" placeholder="Search rules" />
-      </div>
-      <button class="set-btn set-btn-primary"
+    <div class="card-head-right">
+      {% include "api/components/search-box.html" with placeholder="Search rules" %}
+      <button class="btn btn-primary"
               @click="selectedId = null"
               hx-get="{% url 'settings-bill-rule-new-form' %}"
               hx-target="#bill-rule-form-div">New Rule</button>
     </div>
   </div>
 
-  <div class="set-table-scroll">
-  <table class="set-table">
+  <div class="table-scroll has-list">
+  <table class="table">
     <thead>
       <tr>
         <th>From</th>
@@ -46,43 +27,43 @@
     </thead>
     <tbody>
       {% for rule in rules %}
-      <tr class="set-row"
+      <tr class="row"
           data-search="{{ rule.from_address|lower }} {{ rule.subject|lower }} {{ rule.account_number|lower }} {{ rule.account.name|lower }} {{ rule.transaction_description_match|lower }}"
           :class="{ selected: selectedId === {{ rule.id }} }"
           x-show="matches($el)"
           @click="selectedId = {{ rule.id }}"
           hx-get="{% url 'settings-bill-rule-form' rule.id %}"
           hx-target="#bill-rule-form-div">
-        <td class="set-td set-td-name">{{ rule.from_address }}</td>
-        <td class="set-td set-td-sub">{{ rule.subject }}</td>
-        <td class="set-td set-td-type">{{ rule.account_number }}</td>
-        <td class="set-td set-td-entity">{{ rule.account.name }}</td>
-        <td class="set-td set-td-sub">{{ rule.transaction_description_match }}</td>
+        <td class="td-name">{{ rule.from_address }}</td>
+        <td class="td-muted">{{ rule.subject }}</td>
+        <td class="td-2">{{ rule.account_number }}</td>
+        <td class="td-3">{{ rule.account.name }}</td>
+        <td class="td-muted">{{ rule.transaction_description_match }}</td>
       </tr>
       {% endfor %}
     </tbody>
   </table>
   </div>
 
-  <div class="set-list">
+  <div class="list">
     {% for rule in rules %}
-    <div class="set-mrow"
+    <div class="lrow"
          data-search="{{ rule.from_address|lower }} {{ rule.subject|lower }} {{ rule.account_number|lower }} {{ rule.account.name|lower }} {{ rule.transaction_description_match|lower }}"
          :class="{ selected: selectedId === {{ rule.id }} }"
          x-show="matches($el)"
          @click="selectedId = {{ rule.id }}"
          hx-get="{% url 'settings-bill-rule-form' rule.id %}"
          hx-target="#bill-rule-form-div">
-      <div class="set-mrow-top">
-        <span class="set-mname">{{ rule.account.name }}</span>
-        <span class="set-mtype">{{ rule.account_number }}</span>
+      <div class="lrow-top">
+        <span class="lname">{{ rule.account.name }}</span>
+        <span class="lmeta-right">{{ rule.account_number }}</span>
       </div>
-      <div class="set-mmeta">{{ rule.from_address }} · {{ rule.transaction_description_match }}</div>
+      <div class="lmeta">{{ rule.from_address }} · {{ rule.transaction_description_match }}</div>
     </div>
     {% endfor %}
   </div>
 
-  <div class="set-empty" x-show="visible() === 0" x-cloak>
+  <div class="table-empty" x-show="visible() === 0" x-cloak>
     No rules match "<span x-text="q"></span>".
   </div>
 

--- a/ledger/templates/api/content/bills-content.html
+++ b/ledger/templates/api/content/bills-content.html
@@ -12,13 +12,13 @@
         }
      }">
 
-  <div class="set-head">
-    <div class="set-head-left">
-      <h2 class="set-h2">Utility Bills</h2>
-      <span class="set-count" x-text="countLabel()"></span>
+  <div class="card-head">
+    <div class="card-head-left">
+      <h2 class="card-title">Utility Bills</h2>
+      <span class="card-count" x-text="countLabel()"></span>
     </div>
-    <div class="set-head-right">
-      <select class="set-select" style="width: 150px;" x-model="status">
+    <div class="card-head-right">
+      <select class="select" style="width: 150px;" x-model="status">
         <option value="">All statuses</option>
         <option value="parsed">Parsed</option>
         <option value="matched">Matched</option>
@@ -26,8 +26,8 @@
         <option value="failed">Failed</option>
         <option value="pending">Pending</option>
       </select>
-      <span id="bills-poll-busy" class="set-busy">⚙️ Polling…</span>
-      <button class="set-btn set-btn-primary"
+      <span id="bills-poll-busy" class="busy">⚙️ Polling…</span>
+      <button class="btn btn-primary"
               hx-post="{% url 'settings-bills' %}"
               hx-vals='{"action": "poll"}'
               hx-target="#bills-content"
@@ -38,11 +38,11 @@
   </div>
 
   {% if message %}
-  <div class="set-alert set-alert-success">{{ message }}</div>
+  <div class="alert alert-success">{{ message }}</div>
   {% endif %}
 
-  <div class="set-bills-table">
-  <table class="set-table">
+  <div class="table-scroll">
+  <table class="table">
     <thead>
       <tr>
         <th>Received</th>
@@ -57,33 +57,33 @@
     <tbody>
       {% for bill in bills %}
       <tr data-status="{{ bill.status }}" x-show="matches($el)">
-        <td class="set-td set-td-sub">{{ bill.received_at|default:bill.created_at|date:"M j, Y" }}</td>
-        <td class="set-td set-td-name">{{ bill.vendor|default:"—" }}</td>
-        <td class="set-td set-td-type">{{ bill.account_number|default:"—" }}</td>
-        <td class="set-td set-td-type">{% if bill.amount is not None %}${{ bill.amount }}{% else %}—{% endif %}</td>
-        <td class="set-td set-td-status">
-          <span class="set-status-line">
-            <span class="set-badge set-badge-{{ bill.status }}">{{ bill.get_status_display }}</span>
+        <td class="td-muted">{{ bill.received_at|default:bill.created_at|date:"M j, Y" }}</td>
+        <td class="td-name">{{ bill.vendor|default:"—" }}</td>
+        <td class="td-2">{{ bill.account_number|default:"—" }}</td>
+        <td class="td-2">{% if bill.amount is not None %}${{ bill.amount }}{% else %}—{% endif %}</td>
+        <td>
+          <span class="status-line">
+            <span class="badge badge-{{ bill.status }}">{{ bill.get_status_display }}</span>
             {% if bill.status == failed_status %}
             {% if bill.short_error %}
-            <span class="set-err">
-              <span class="set-err-short">{{ bill.short_error }}</span>
-              <span class="set-err-tip">{{ bill.error_message }}</span>
+            <span class="err">
+              <span class="err-short">{{ bill.short_error }}</span>
+              <span class="err-tip">{{ bill.error_message }}</span>
             </span>
             {% endif %}
-            <button class="set-btn set-btn-clear set-btn-retry"
+            <button class="btn btn-ghost btn-sm"
                     hx-post="{% url 'settings-bills' %}"
                     hx-vals='{"action": "retry", "bill_id": "{{ bill.id }}"}'
                     hx-target="#bills-content"
                     hx-swap="innerHTML"
                     hx-indicator="#bill-retry-busy-{{ bill.id }}"
                     hx-disabled-elt="this">↻ Retry</button>
-            <span id="bill-retry-busy-{{ bill.id }}" class="set-busy">⚙️ Reparsing…</span>
+            <span id="bill-retry-busy-{{ bill.id }}" class="busy">⚙️ Reparsing…</span>
             {% endif %}
           </span>
         </td>
-        <td class="set-td set-td-entity{% if not bill.account %} empty{% endif %}">{{ bill.account.name|default:"—" }}</td>
-        <td class="set-td set-td-sub">{% if bill.matched_transaction %}{{ bill.matched_transaction.description|truncatechars:28 }}{% else %}—{% endif %}</td>
+        <td class="{% if not bill.account %}td-faint{% else %}td-3{% endif %}">{{ bill.account.name|default:"—" }}</td>
+        <td class="td-muted">{% if bill.matched_transaction %}{{ bill.matched_transaction.description|truncatechars:28 }}{% else %}—{% endif %}</td>
       </tr>
       {% endfor %}
     </tbody>
@@ -91,9 +91,9 @@
   </div>
 
   {% if not bills %}
-  <div class="set-empty">No bills ingested yet. Configure a rule, then "Poll now".</div>
+  <div class="table-empty">No bills ingested yet. Configure a rule, then "Poll now".</div>
   {% endif %}
-  <div class="set-empty" x-show="total !== 0 && visible() === 0" x-cloak>
+  <div class="table-empty" x-show="total !== 0 && visible() === 0" x-cloak>
     No bills with that status.
   </div>
 </div>

--- a/ledger/templates/api/content/cash-flow-content.html
+++ b/ledger/templates/api/content/cash-flow-content.html
@@ -1,87 +1,78 @@
 {% load humanize %}
-<div class="row">
-    <div class="col">
-        {{ filter_form }}
+{{ filter_form }}
+
+{% if cash_flow_discrepancy %}
+<div class="page-narrow">
+    <div class="alert alert-danger small mb-2" role="alert">
+    ⚠️ Cash flow discrepancy: ${{ cash_flow_discrepancy|default:0|floatformat:2 }}
     </div>
 </div>
-<div class="container-fluid">
-    {% if cash_flow_discrepancy %}
-    <div class="row">
-        <div class="col-md-4">
-            <div class="alert alert-danger py-1 px-2 small mb-2" role="alert">
-            ⚠️ Cash flow discrepancy: ${{ cash_flow_discrepancy|default:0|floatformat:2 }}
-            </div>
-        </div>
-    </div>
-    {% endif %}
-    <div class="row">
-        <div class="col-md-12">
-            <div class="row text-center">
-                <div class="col-md-2">
-                    <h5 class="font-weight-bold">${{ net_cash_flow|floatformat:0|intcomma }}</h5>
-                    <p class="text-secondary">Cash Balance Change</p>
-                </div>
-                <div class="col-md-2">
-                    <h5 class="font-weight-bold">${{ levered_cash_flow|floatformat:0|intcomma }}</h5>
-                    <p class="text-secondary">Levered Cash Flow</p>
-                </div>
-                <div class="col-md-2">
-                    <h5 class="font-weight-bold">${{ levered_cash_flow_post_retirement|floatformat:0|intcomma }}</h5>
-                    <p class="text-secondary">Levered Cash Flow, post-Retirement</p>
-                </div>
-            </div>
-        </div>
-    </div>
-    <div class="row">
-        <div class="col-md-4">
-            <table class="table table-hover table-sm">
-                <tbody>
-                    <tr>
-                        <td class="col-8"><strong>Cash from Operations</strong></td>
-                        <td class="col-4"><strong>${{ cash_from_operations|floatformat:"0"|intcomma }}</strong></td>
-                    </tr>
-                    {% for balance in operations_flows %}
-                    <tr>
-                        <td class="col-8">{{ balance.account }}</td>
-                        <td class="col-4">${{ balance.amount|floatformat:"0"|intcomma }}</td>
-                    </tr>
-                    {% endfor %}
-                </tbody>
-            </table>
-        </div>
+{% endif %}
 
-        <div class="col-md-4">
-            <table class="table table-hover table-sm">
-                <tbody>
-                    <tr>
-                        <td class="col-8"><strong>Cash from Financing</strong></td>
-                        <td class="col-4"><strong>${{ cash_from_financing|floatformat:"0"|intcomma }}</strong></td>
-                    </tr>
-                    {% for balance in financing_flows %}
-                    <tr>
-                        <td class="col-8">{{ balance.account }}</td>
-                        <td class="col-4">${{ balance.amount|floatformat:"0"|intcomma }}</td>
-                    </tr>
-                    {% endfor %}
-                </tbody>
-            </table>
-        </div>
+<div class="kpi-row">
+    <div class="kpi">
+        <div class="kpi-value">${{ net_cash_flow|floatformat:0|intcomma }}</div>
+        <div class="kpi-label">Cash Balance Change</div>
+    </div>
+    <div class="kpi">
+        <div class="kpi-value">${{ levered_cash_flow|floatformat:0|intcomma }}</div>
+        <div class="kpi-label">Levered Cash Flow</div>
+    </div>
+    <div class="kpi">
+        <div class="kpi-value">${{ levered_cash_flow_post_retirement|floatformat:0|intcomma }}</div>
+        <div class="kpi-label">Levered CF, post-Retirement</div>
+    </div>
+</div>
 
-        <div class="col-md-4">
-            <table class="table table-hover table-sm">
-                <tbody>
-                    <tr>
-                        <td class="col-8"><strong>Cash from Investing</strong></td>
-                        <td class="col-4"><strong>${{ cash_from_investing|floatformat:"0"|intcomma }}</strong></td>
-                    </tr>
-                    {% for balance in investing_flows %}
-                    <tr>
-                        <td class="col-8">{{ balance.account }}</td>
-                        <td class="col-4">${{ balance.amount|floatformat:"0"|intcomma }}</td>
-                    </tr>
-                    {% endfor %}
-                </tbody>
-            </table>
-        </div>
+<div class="grid grid-3">
+    <div>
+        <table class="table">
+            <tbody>
+                <tr>
+                    <td class="td-strong">Cash from Operations</td>
+                    <td class="right td-strong">${{ cash_from_operations|floatformat:"0"|intcomma }}</td>
+                </tr>
+                {% for balance in operations_flows %}
+                <tr>
+                    <td class="td-name">{{ balance.account }}</td>
+                    <td class="right">${{ balance.amount|floatformat:"0"|intcomma }}</td>
+                </tr>
+                {% endfor %}
+            </tbody>
+        </table>
+    </div>
+
+    <div>
+        <table class="table">
+            <tbody>
+                <tr>
+                    <td class="td-strong">Cash from Financing</td>
+                    <td class="right td-strong">${{ cash_from_financing|floatformat:"0"|intcomma }}</td>
+                </tr>
+                {% for balance in financing_flows %}
+                <tr>
+                    <td class="td-name">{{ balance.account }}</td>
+                    <td class="right">${{ balance.amount|floatformat:"0"|intcomma }}</td>
+                </tr>
+                {% endfor %}
+            </tbody>
+        </table>
+    </div>
+
+    <div>
+        <table class="table">
+            <tbody>
+                <tr>
+                    <td class="td-strong">Cash from Investing</td>
+                    <td class="right td-strong">${{ cash_from_investing|floatformat:"0"|intcomma }}</td>
+                </tr>
+                {% for balance in investing_flows %}
+                <tr>
+                    <td class="td-name">{{ balance.account }}</td>
+                    <td class="right">${{ balance.amount|floatformat:"0"|intcomma }}</td>
+                </tr>
+                {% endfor %}
+            </tbody>
+        </table>
     </div>
 </div>

--- a/ledger/templates/api/content/income-content.html
+++ b/ledger/templates/api/content/income-content.html
@@ -1,102 +1,80 @@
 {% load humanize %}
 {% load math_filters %}
-<div class="row">
-    <div class="col">
-        {{ filter_form }}
+{{ filter_form }}
+
+<div class="kpi-row">
+    <div class="kpi">
+        <div class="kpi-value">{{ savings_rate|multiply:100|floatformat:1 }}%</div>
+        <div class="kpi-label">Savings Rate</div>
+    </div>
+    <div class="kpi">
+        <div class="kpi-value">{{ tax_rate|multiply:100|floatformat:1 }}%</div>
+        <div class="kpi-label">Tax Rate</div>
     </div>
 </div>
-<div class="container-fluid">
-    <div class="row">
-        <div class="col-md-12">
-            <div class="row text-center">
-                <!-- Savings Rate -->
-                <div class="col-md-2">
-                    <h5 class="font-weight-bold">{{ savings_rate|multiply:100|floatformat:1 }}%</h5>
-                    <p class="text-secondary">Savings Rate</p>
-                </div>
-                <!-- Tax Rate -->
-                <div class="col-md-2">
-                    <h5 class="font-weight-bold">{{ tax_rate|multiply:100|floatformat:1 }}%</h5>
-                    <p class="text-secondary">Tax Rate</p>
-                </div>
-                <!-- Additional metrics can be added here -->
-            </div>
-        </div>
-    </div>
 
-    <div class="row">
-        <div class="col-md-8">
+<div class="grid grid-main-side">
+    <div>
+        <h4>Net Income: ${{ summary.equity.total|floatformat:"0"|intcomma }}</h4>
+        <table class="table mb-4">
+            <tbody>
+                {% for account in summary.equity.balances %}
+                    {% for balance in account.balances %}
+                    <tr>
+                        <td class="td-name">{{ balance.account }}</td>
+                        <td class="right">${{ balance.amount|floatformat:"0"|intcomma }}</td>
+                    </tr>
+                    {% endfor %}
+                {% endfor %}
+            </tbody>
+        </table>
 
-            <div class="row">
-                <div class="col-md-6">
-                    <h4>Net Income: ${{ summary.equity.total|floatformat:"0"|intcomma }}</h4>
-                    <table class="table table-hover table-sm">
-                        <tbody>
-                            {% for account in summary.equity.balances %}
-                                {% for balance in account.balances %}
-                                <tr>
-                                    <td class="col-8">{{ balance.account }}</td>
-                                    <td class="col-4">${{ balance.amount|floatformat:"0"|intcomma }}</td>
-                                </tr>
-                                {% endfor %}
-                            {% endfor %}
-                        </tbody>
-                    </table>
-                </div>
-            </div>
-            <div class="row">
-                <div class="col-md-6">
-                    <h4>Income: ${{ summary.income.total|floatformat:"0"|intcomma }}</h4>
-                    <table class="table table-hover table-sm">
-                        <tbody>
-                            {% for account in summary.income.balances %}
-                                {% for balance in account.balances %}
-                                <tr 
-                                    class="clickable-row"
-                                    hx-get="{% url 'statement-detail' balance.account.id %}?from_date={{ from_date|date:"Y-m-d" }}&to_date={{ to_date|date:"Y-m-d" }}"
-                                    hx-target="#detail"
-                                >
-                                    <td class="col-8">{{ balance.account }}</td>
-                                    <td class="col-4">${{ balance.amount|floatformat:"0"|intcomma }}</td>
-                                </tr>
-                                {% endfor %}
-                            {% endfor %}
-                        </tbody>
-                    </table>
-                </div>
-
-                <div class="col-md-6">
-                    <h4>Expenses: ${{ summary.expense.total|floatformat:"0"|intcomma }}</h4>
-                    {% for account in summary.expense.balances %}
-                    <table class="table table-hover table-sm">
-                        <tbody>
-                            <tr>
-                                <td class="col-8"><strong>{{ account.name }}</strong></td>
-                                <td class="col-4"><strong>${{ account.total|floatformat:"0"|intcomma }}</strong></td>
-                            </tr>
+        <div class="grid grid-2">
+            <div>
+                <h4>Income: ${{ summary.income.total|floatformat:"0"|intcomma }}</h4>
+                <table class="table">
+                    <tbody>
+                        {% for account in summary.income.balances %}
                             {% for balance in account.balances %}
-                            <tr 
+                            <tr
                                 class="clickable-row"
                                 hx-get="{% url 'statement-detail' balance.account.id %}?from_date={{ from_date|date:"Y-m-d" }}&to_date={{ to_date|date:"Y-m-d" }}"
                                 hx-target="#detail"
                             >
-                                <td class="col-8">{{ balance.account }}</td>
-                                <td class="col-4">${{ balance.amount|floatformat:"0"|intcomma }}</td>
+                                <td class="td-name">{{ balance.account }}</td>
+                                <td class="right">${{ balance.amount|floatformat:"0"|intcomma }}</td>
                             </tr>
                             {% endfor %}
-                        </tbody>
-                    </table>
-                    {% endfor %}
-                </div>
+                        {% endfor %}
+                    </tbody>
+                </table>
             </div>
-        </div>
-        <div class="col-md-4">
-            <div class="row">
-                <div class="col-md-12">
-                    <div id="detail">
-                    </div>
-                </div>
+
+            <div>
+                <h4>Expenses: ${{ summary.expense.total|floatformat:"0"|intcomma }}</h4>
+                {% for account in summary.expense.balances %}
+                <table class="table mb-3">
+                    <tbody>
+                        <tr>
+                            <td class="td-strong">{{ account.name }}</td>
+                            <td class="right td-strong">${{ account.total|floatformat:"0"|intcomma }}</td>
+                        </tr>
+                        {% for balance in account.balances %}
+                        <tr
+                            class="clickable-row"
+                            hx-get="{% url 'statement-detail' balance.account.id %}?from_date={{ from_date|date:"Y-m-d" }}&to_date={{ to_date|date:"Y-m-d" }}"
+                            hx-target="#detail"
+                        >
+                            <td class="td-name">{{ balance.account }}</td>
+                            <td class="right">${{ balance.amount|floatformat:"0"|intcomma }}</td>
+                        </tr>
+                        {% endfor %}
+                    </tbody>
+                </table>
+                {% endfor %}
             </div>
         </div>
     </div>
+
+    <div id="detail"></div>
 </div>

--- a/ledger/templates/api/content/loan-schedule.html
+++ b/ledger/templates/api/content/loan-schedule.html
@@ -1,28 +1,18 @@
 {% load humanize %}
-<div class="set-form" style="margin-top: 18px;">
-  <div class="set-head">
-    <div class="set-head-left">
-      <h2 class="set-h2">Schedule · {{ loan.name }}</h2>
-      <span class="set-count">remaining ${{ remaining_balance|intcomma }}{% if loan.is_closed %} · paid off{% endif %}</span>
+<div class="form">
+  <div class="card-head">
+    <div class="card-head-left">
+      <h2 class="card-title">Schedule · {{ loan.name }}</h2>
+      <span class="card-count">remaining ${{ remaining_balance|intcomma }}{% if loan.is_closed %} · paid off{% endif %}</span>
     </div>
   </div>
 
   {% if message %}
-    <div class="set-alert set-alert-success">{{ message }}</div>
+    <div class="alert alert-success">{{ message }}</div>
   {% endif %}
 
-  <style>
-    .loan-sched { table-layout: fixed; width: 100%; }
-    .loan-sched td.set-td, .loan-sched th { white-space: normal; word-break: break-word; padding: 6px 5px; }
-    .loan-sched .set-input { width: 100%; box-sizing: border-box; padding: 3px 5px; }
-    .loan-sched .ls-bal { display: flex; align-items: center; gap: 4px; }
-    .loan-sched .ls-bal .set-input { flex: 1; min-width: 0; }
-    .loan-sched .ls-actions { display: flex; flex-direction: column; gap: 4px; }
-    .loan-sched .ls-actions .set-btn { width: 100%; padding: 0 6px; height: 24px; font-size: 11px; }
-  </style>
-
-  <div class="set-table-scroll" style="max-height: 640px;">
-  <table class="set-table loan-sched">
+  <div class="table-scroll" style="max-height: 640px;">
+  <table class="table loan-sched">
     <colgroup>
       <col style="width: 5%;" />
       <col style="width: 13%;" />
@@ -46,30 +36,30 @@
     <tbody>
       {% for row in rows %}
       <tr>
-        <td class="set-td set-td-sub">{{ row.sequence }}</td>
-        <td class="set-td set-td-type">{{ row.date|date:"Y-m-d" }}</td>
-        <td class="set-td">
-          <input class="set-input" name="principal_amount" value="{{ row.principal_amount }}" />
+        <td class="td-muted">{{ row.sequence }}</td>
+        <td class="td-2">{{ row.date|date:"Y-m-d" }}</td>
+        <td>
+          <input class="input" name="principal_amount" value="{{ row.principal_amount }}" />
         </td>
-        <td class="set-td">
-          <input class="set-input" name="interest_amount" value="{{ row.interest_amount }}" />
+        <td>
+          <input class="input" name="interest_amount" value="{{ row.interest_amount }}" />
         </td>
-        <td class="set-td">
+        <td>
           {# Saving the row anchors this balance as the new baseline. #}
           <div class="ls-bal">
-            <input class="set-input" name="balance_override" value="{{ row.remaining_balance|intcomma }}" />
+            <input class="input" name="balance_override" value="{{ row.remaining_balance|intcomma }}" />
             {% if row.is_anchored %}<span title="Balance anchored here">⚓</span>{% endif %}
           </div>
         </td>
-        <td class="set-td set-td-closed">{% if row.transaction_id %}✓{% endif %}</td>
-        <td class="set-td">
+        <td class="td-muted center">{% if row.transaction_id %}✓{% endif %}</td>
+        <td>
           <div class="ls-actions">
-            <button type="button" class="set-btn set-btn-primary"
+            <button type="button" class="btn btn-primary"
                     hx-post="{% url 'settings-loan-schedule-row' row.id %}"
                     hx-include="closest tr"
                     hx-target="#loan-schedule-div" hx-swap="innerHTML">Save</button>
             {% if row.is_anchored %}
-            <button type="button" class="set-btn set-btn-clear"
+            <button type="button" class="btn btn-ghost"
                     hx-post="{% url 'settings-loan-schedule-row' row.id %}"
                     hx-vals='{"action": "clear_balance"}'
                     hx-target="#loan-schedule-div" hx-swap="innerHTML">Clear</button>
@@ -78,7 +68,7 @@
         </td>
       </tr>
       {% empty %}
-      <tr><td class="set-empty" colspan="7">No schedule rows.</td></tr>
+      <tr><td class="table-empty" colspan="7">No schedule rows.</td></tr>
       {% endfor %}
     </tbody>
   </table>

--- a/ledger/templates/api/content/loans-content.html
+++ b/ledger/templates/api/content/loans-content.html
@@ -1,40 +1,21 @@
-<div x-data="{
-        q: '',
-        selectedId: {{ selected_id|default:'null' }},
-        total: {{ total }},
-        matches(el) { return !this.q.trim() || el.dataset.search.includes(this.q.toLowerCase()); },
-        visible() {
-          if (!this.q.trim()) return this.total;
-          const needle = this.q.toLowerCase();
-          return Array.from(this.$root.querySelectorAll('tr[data-search]'))
-            .filter(tr => tr.dataset.search.includes(needle)).length;
-        },
-        countLabel() {
-          return this.q.trim() ? (this.visible() + ' of ' + this.total) : (this.total + ' loans');
-        }
-     }">
+<div x-data="searchList({{ total }}, 'loans', {{ selected_id|default:'null' }})">
 
-  <div class="set-head">
-    <div class="set-head-left">
-      <h2 class="set-h2">Loans</h2>
-      <span class="set-count" x-text="countLabel()"></span>
+  <div class="card-head">
+    <div class="card-head-left">
+      <h2 class="card-title">Loans</h2>
+      <span class="card-count" x-text="countLabel()"></span>
     </div>
-    <div class="set-head-right">
-      <div class="set-search">
-        <svg width="12" height="12" viewBox="0 0 16 16" fill="none" stroke="#adb5bd" stroke-width="1.6">
-          <circle cx="7" cy="7" r="4.5"></circle><line x1="10.6" y1="10.6" x2="14" y2="14"></line>
-        </svg>
-        <input x-model="q" placeholder="Search loans" />
-      </div>
-      <button class="set-btn set-btn-primary"
+    <div class="card-head-right">
+      {% include "api/components/search-box.html" with placeholder="Search loans" %}
+      <button class="btn btn-primary"
               @click="selectedId = null"
               hx-get="{% url 'settings-loan-new-form' %}"
               hx-target="#loan-form-div">New Loan</button>
     </div>
   </div>
 
-  <div class="set-table-scroll">
-  <table class="set-table">
+  <div class="table-scroll has-list">
+  <table class="table">
     <thead>
       <tr>
         <th>Name</th>
@@ -48,45 +29,45 @@
     </thead>
     <tbody>
       {% for loan in loans %}
-      <tr class="set-row"
+      <tr class="row"
           data-search="{{ loan.name|lower }} {{ loan.principal_account.name|lower }} {{ loan.interest_account.name|lower }} {{ loan.description_match|lower }}"
           :class="{ selected: selectedId === {{ loan.id }} }"
           x-show="matches($el)"
           @click="selectedId = {{ loan.id }}"
           hx-get="{% url 'settings-loan-form' loan.id %}"
           hx-target="#loan-form-div">
-        <td class="set-td set-td-name">{{ loan.name }}</td>
-        <td class="set-td set-td-type">${{ loan.original_amount }}</td>
-        <td class="set-td set-td-sub">{{ loan.annual_interest_rate }}</td>
-        <td class="set-td set-td-sub">{{ loan.term_months }}mo</td>
-        <td class="set-td set-td-entity">{{ loan.principal_account.name }}</td>
-        <td class="set-td set-td-entity">{{ loan.interest_account.name }}</td>
-        <td class="set-td set-td-closed">{% if loan.is_closed %}✓{% endif %}</td>
+        <td class="td-name">{{ loan.name }}</td>
+        <td class="td-2">${{ loan.original_amount }}</td>
+        <td class="td-muted">{{ loan.annual_interest_rate }}</td>
+        <td class="td-muted">{{ loan.term_months }}mo</td>
+        <td class="td-3">{{ loan.principal_account.name }}</td>
+        <td class="td-3">{{ loan.interest_account.name }}</td>
+        <td class="td-muted center">{% if loan.is_closed %}✓{% endif %}</td>
       </tr>
       {% endfor %}
     </tbody>
   </table>
   </div>
 
-  <div class="set-list">
+  <div class="list">
     {% for loan in loans %}
-    <div class="set-mrow"
+    <div class="lrow"
          data-search="{{ loan.name|lower }} {{ loan.principal_account.name|lower }} {{ loan.interest_account.name|lower }} {{ loan.description_match|lower }}"
          :class="{ selected: selectedId === {{ loan.id }} }"
          x-show="matches($el)"
          @click="selectedId = {{ loan.id }}"
          hx-get="{% url 'settings-loan-form' loan.id %}"
          hx-target="#loan-form-div">
-      <div class="set-mrow-top">
-        <span class="set-mname">{{ loan.name }}</span>
-        <span class="set-mtype">${{ loan.original_amount }}</span>
+      <div class="lrow-top">
+        <span class="lname">{{ loan.name }}</span>
+        <span class="lmeta-right">${{ loan.original_amount }}</span>
       </div>
-      <div class="set-mmeta">{{ loan.annual_interest_rate }} · {{ loan.term_months }}mo · {{ loan.principal_account.name }}</div>
+      <div class="lmeta">{{ loan.annual_interest_rate }} · {{ loan.term_months }}mo · {{ loan.principal_account.name }}</div>
     </div>
     {% endfor %}
   </div>
 
-  <div class="set-empty" x-show="visible() === 0" x-cloak>
+  <div class="table-empty" x-show="visible() === 0" x-cloak>
     No loans match "<span x-text="q"></span>".
   </div>
 

--- a/ledger/templates/api/content/settings-content.html
+++ b/ledger/templates/api/content/settings-content.html
@@ -1,40 +1,21 @@
-<div x-data="{
-        q: '',
-        selectedId: {{ selected_id|default:'null' }},
-        total: {{ total }},
-        matches(el) { return !this.q.trim() || el.dataset.search.includes(this.q.toLowerCase()); },
-        visible() {
-          if (!this.q.trim()) return this.total;
-          const needle = this.q.toLowerCase();
-          return Array.from(this.$root.querySelectorAll('tr[data-search]'))
-            .filter(tr => tr.dataset.search.includes(needle)).length;
-        },
-        countLabel() {
-          return this.q.trim() ? (this.visible() + ' of ' + this.total) : (this.total + ' accounts');
-        }
-     }">
+<div x-data="searchList({{ total }}, 'accounts', {{ selected_id|default:'null' }})">
 
-  <div class="set-head">
-    <div class="set-head-left">
-      <h2 class="set-h2">Accounts</h2>
-      <span class="set-count" x-text="countLabel()"></span>
+  <div class="card-head">
+    <div class="card-head-left">
+      <h2 class="card-title">Accounts</h2>
+      <span class="card-count" x-text="countLabel()"></span>
     </div>
-    <div class="set-head-right">
-      <div class="set-search">
-        <svg width="12" height="12" viewBox="0 0 16 16" fill="none" stroke="#adb5bd" stroke-width="1.6">
-          <circle cx="7" cy="7" r="4.5"></circle><line x1="10.6" y1="10.6" x2="14" y2="14"></line>
-        </svg>
-        <input x-model="q" placeholder="Search accounts" />
-      </div>
-      <button class="set-btn set-btn-primary"
+    <div class="card-head-right">
+      {% include "api/components/search-box.html" with placeholder="Search accounts" %}
+      <button class="btn btn-primary"
               @click="selectedId = null"
               hx-get="{% url 'settings-account-new-form' %}"
               hx-target="#account-form-div">New Account</button>
     </div>
   </div>
 
-  <div class="set-table-scroll">
-  <table class="set-table">
+  <div class="table-scroll has-list">
+  <table class="table">
     <thead>
       <tr>
         <th>Name</th>
@@ -46,47 +27,47 @@
     </thead>
     <tbody>
       {% for account in accounts %}
-      <tr class="set-row"
+      <tr class="row"
           data-search="{{ account.name|lower }} {{ account.get_type_display|lower }} {{ account.get_sub_type_display|lower }}"
           :class="{ selected: selectedId === {{ account.id }} }"
           x-show="matches($el)"
           @click="selectedId = {{ account.id }}"
           hx-get="{% url 'settings-account-form' account.id %}"
           hx-target="#account-form-div">
-        <td class="set-td set-td-name">{{ account.name }}</td>
-        <td class="set-td set-td-type">{{ account.get_type_display }}</td>
-        <td class="set-td set-td-sub">{{ account.get_sub_type_display }}</td>
+        <td class="td-name">{{ account.name }}</td>
+        <td class="td-2">{{ account.get_type_display }}</td>
+        <td class="td-muted">{{ account.get_sub_type_display }}</td>
         {% if account.entity %}
-        <td class="set-td set-td-entity">{{ account.entity.name }}</td>
+        <td class="td-3">{{ account.entity.name }}</td>
         {% else %}
-        <td class="set-td set-td-entity empty">—</td>
+        <td class="td-faint">—</td>
         {% endif %}
-        <td class="set-td set-td-closed">{% if account.is_closed %}Yes{% else %}No{% endif %}</td>
+        <td class="td-muted center">{% if account.is_closed %}Yes{% else %}No{% endif %}</td>
       </tr>
       {% endfor %}
     </tbody>
   </table>
   </div>
 
-  <div class="set-list">
+  <div class="list">
     {% for account in accounts %}
-    <div class="set-mrow"
+    <div class="lrow"
          data-search="{{ account.name|lower }} {{ account.get_type_display|lower }} {{ account.get_sub_type_display|lower }}"
          :class="{ selected: selectedId === {{ account.id }} }"
          x-show="matches($el)"
          @click="selectedId = {{ account.id }}"
          hx-get="{% url 'settings-account-form' account.id %}"
          hx-target="#account-form-div">
-      <div class="set-mrow-top">
-        <span class="set-mname">{{ account.name }}</span>
-        <span class="set-mtype">{{ account.get_type_display }}</span>
+      <div class="lrow-top">
+        <span class="lname">{{ account.name }}</span>
+        <span class="lmeta-right">{{ account.get_type_display }}</span>
       </div>
-      <div class="set-mmeta">{{ account.get_sub_type_display }} · {% if account.entity %}{{ account.entity.name }}{% else %}No entity{% endif %}{% if account.is_closed %} · Closed{% endif %}</div>
+      <div class="lmeta">{{ account.get_sub_type_display }} · {% if account.entity %}{{ account.entity.name }}{% else %}No entity{% endif %}{% if account.is_closed %} · Closed{% endif %}</div>
     </div>
     {% endfor %}
   </div>
 
-  <div class="set-empty" x-show="visible() === 0" x-cloak>
+  <div class="table-empty" x-show="visible() === 0" x-cloak>
     No accounts match "<span x-text="q"></span>".
   </div>
 

--- a/ledger/templates/api/entry_forms/account-form.html
+++ b/ledger/templates/api/entry_forms/account-form.html
@@ -1,5 +1,5 @@
 {{ subtype_map|json_script:"subtype-map" }}
-<div class="set-form"
+<div class="form"
      x-data="{
         type: '{{ values.type }}',
         subtype: '{{ values.sub_type }}',
@@ -10,22 +10,22 @@
         init() { this.normalize(); }
      }">
 
-  <div class="set-form-header">
+  <div class="form-header">
     {% if account %}Edit · {{ account.name }}{% else %}New account{% endif %}
   </div>
 
   {% if change == "create" %}
-    <div class="set-alert set-alert-success">Account created.</div>
+    <div class="alert alert-success">Account created.</div>
   {% elif change == "update" %}
-    <div class="set-alert set-alert-success">Account updated.</div>
+    <div class="alert alert-success">Account updated.</div>
   {% elif change == "delete" %}
-    <div class="set-alert set-alert-success">Account deleted.</div>
+    <div class="alert alert-success">Account deleted.</div>
   {% endif %}
   {% if error %}
-    <div class="set-alert set-alert-danger">{{ error }}</div>
+    <div class="alert alert-danger">{{ error }}</div>
   {% endif %}
   {% if form.non_field_errors %}
-    <div class="set-alert set-alert-danger">{{ form.non_field_errors }}</div>
+    <div class="alert alert-danger">{{ form.non_field_errors }}</div>
   {% endif %}
 
   <form method="post"
@@ -34,67 +34,67 @@
         hx-swap="innerHTML">
     {% csrf_token %}
 
-    <div class="set-grid-1">
+    <div class="grid grid-wide-first">
       <div>
-        <label class="set-label">Name</label>
-        <input class="set-input" name="name" value="{{ values.name }}" placeholder="Account name" />
-        {% for e in form.name.errors %}<div class="set-field-error">{{ e }}</div>{% endfor %}
+        <label class="label">Name</label>
+        <input class="input" name="name" value="{{ values.name }}" placeholder="Account name" />
+        {% for e in form.name.errors %}<div class="field-error">{{ e }}</div>{% endfor %}
       </div>
       <div>
-        <label class="set-label">Type</label>
-        <select class="set-select" name="type" x-model="type" @change="normalize()">
+        <label class="label">Type</label>
+        <select class="select" name="type" x-model="type" @change="normalize()">
           {% for value, label in type_choices %}<option value="{{ value }}">{{ label }}</option>{% endfor %}
         </select>
-        {% for e in form.type.errors %}<div class="set-field-error">{{ e }}</div>{% endfor %}
+        {% for e in form.type.errors %}<div class="field-error">{{ e }}</div>{% endfor %}
       </div>
       <div>
-        <label class="set-label">Sub-type</label>
-        <select class="set-select" name="sub_type" x-model="subtype">
+        <label class="label">Sub-type</label>
+        <select class="select" name="sub_type" x-model="subtype">
           <template x-for="opt in subtypeOptions()" :key="opt.value">
             <option :value="opt.value" x-text="opt.label"></option>
           </template>
         </select>
-        {% for e in form.sub_type.errors %}<div class="set-field-error">{{ e }}</div>{% endfor %}
+        {% for e in form.sub_type.errors %}<div class="field-error">{{ e }}</div>{% endfor %}
       </div>
     </div>
 
-    <div class="set-grid-2">
+    <div class="grid grid-3 grid-end">
       <div>
-        <label class="set-label">Default Entity</label>
-        <select class="set-select" name="entity">
+        <label class="label">Default Entity</label>
+        <select class="select" name="entity">
           <option value="" {% if not values.entity %}selected{% endif %}>Select…</option>
           {% for entity in entities %}
           <option value="{{ entity.id }}" {% if values.entity == entity.id|stringformat:'s' %}selected{% endif %}>{{ entity.name }}</option>
           {% endfor %}
         </select>
-        {% for e in form.entity.errors %}<div class="set-field-error">{{ e }}</div>{% endfor %}
+        {% for e in form.entity.errors %}<div class="field-error">{{ e }}</div>{% endfor %}
       </div>
       <div>
-        <label class="set-label">CSV Profile</label>
-        <select class="set-select" name="csv_profile">
+        <label class="label">CSV Profile</label>
+        <select class="select" name="csv_profile">
           <option value="" {% if not values.csv_profile %}selected{% endif %}>Select…</option>
           {% for profile in csv_profiles %}
           <option value="{{ profile.id }}" {% if values.csv_profile == profile.id|stringformat:'s' %}selected{% endif %}>{{ profile.name }}</option>
           {% endfor %}
         </select>
-        {% for e in form.csv_profile.errors %}<div class="set-field-error">{{ e }}</div>{% endfor %}
+        {% for e in form.csv_profile.errors %}<div class="field-error">{{ e }}</div>{% endfor %}
       </div>
-      <div class="set-checks">
-        <label class="set-check">
+      <div class="checks">
+        <label class="check">
           <input type="checkbox" name="is_closed" {% if values.is_closed %}checked{% endif %} />Closed
         </label>
-        <label class="set-check">
+        <label class="check">
           <input type="checkbox" name="is_depreciation" {% if values.is_depreciation %}checked{% endif %} />Depreciation
         </label>
       </div>
     </div>
 
-    <div class="set-actions">
-      <button type="submit" name="action" value="save" class="set-btn set-btn-primary">{% if account %}Save{% else %}Create{% endif %}</button>
+    <div class="actions">
+      <button type="submit" name="action" value="save" class="btn btn-primary">{% if account %}Save{% else %}Create{% endif %}</button>
       {% if account %}
-      <button type="submit" name="action" value="delete" class="set-btn set-btn-danger">Delete</button>
+      <button type="submit" name="action" value="delete" class="btn btn-danger">Delete</button>
       {% endif %}
-      <button type="button" class="set-btn set-btn-clear"
+      <button type="button" class="btn btn-ghost"
               @click="selectedId = null"
               hx-get="{% url 'settings-account-new-form' %}"
               hx-target="#account-form-div">Clear</button>

--- a/ledger/templates/api/entry_forms/amortization-form.html
+++ b/ledger/templates/api/entry_forms/amortization-form.html
@@ -1,68 +1,45 @@
 <form
-    class="form-sm mt-3"
     id="amortization-form"
     method="post"
     hx-post="{% url 'amortization' %}"
     hx-target="#container"
     hx-trigger="submit"
 >
-    <div class="form-row">
+    <div class="grid grid-auto grid-end mt-3">
 
         {{ form.accrued_journal_entry_item }}
-        <!-- Form group for 'periods' field -->
-        <div class="col-md-2">
-            <input type="text" class="form-control" placeholder="Periods" id="id_periods" name="periods"
+
+        <div class="field">
+            <input type="text" class="input" placeholder="Periods" id="id_periods" name="periods"
                 value="{{ form.periods.value|default_if_none:'' }}">
-            {% if form.periods.errors %}
-                <div class="invalid-feedback">
-                    {{ form.periods.errors.as_text }}
-                </div>
-            {% endif %}
+            {% if form.periods.errors %}<div class="field-error">{{ form.periods.errors.as_text }}</div>{% endif %}
         </div>
 
-        <!-- Form group for 'description' field -->
-        <div class="col-md-2">
-            <input type="text" class="form-control" placeholder="Description" id="id_description" name="description"
+        <div class="field">
+            <input type="text" class="input" placeholder="Description" id="id_description" name="description"
                 value="{{ form.description.value|default_if_none:'' }}">
-            {% if form.description.errors %}
-                <div class="invalid-feedback">
-                    {{ form.description.errors.as_text }}
-                </div>
-            {% endif %}
+            {% if form.description.errors %}<div class="field-error">{{ form.description.errors.as_text }}</div>{% endif %}
         </div>
 
-        <!-- Form group for 'suggested_account' field -->
-        <div class="col-md-2">
-            <select class="form-control" id="id_suggested_account" name="suggested_account">
+        <div class="field">
+            <select class="select" id="id_suggested_account" name="suggested_account">
                 {% for account in form.suggested_account.field.queryset %}
                     <option value="{{ account.pk }}" {% if form.suggested_account.value == account.pk %} selected {% endif %}>
                         {{ account }}
                     </option>
                 {% endfor %}
             </select>
-            {% if form.suggested_account.errors %}
-                <div class="invalid-feedback">
-                    {{ form.suggested_account.errors.as_text }}
-                </div>
-            {% endif %}
+            {% if form.suggested_account.errors %}<div class="field-error">{{ form.suggested_account.errors.as_text }}</div>{% endif %}
         </div>
 
-        <!-- Form group for 'salvage_value' field -->
-        <div class="col-md-2">
-            <input type="text" class="form-control" placeholder="Salvage Value (optional)" id="id_salvage_value" name="salvage_value"
+        <div class="field">
+            <input type="text" class="input" placeholder="Salvage Value (optional)" id="id_salvage_value" name="salvage_value"
                 value="{{ form.salvage_value.value|default_if_none:'' }}">
-            {% if form.salvage_value.errors %}
-                <div class="invalid-feedback">
-                    {{ form.salvage_value.errors.as_text }}
-                </div>
-            {% endif %}
+            {% if form.salvage_value.errors %}<div class="field-error">{{ form.salvage_value.errors.as_text }}</div>{% endif %}
         </div>
 
-        <!-- Submit button -->
-        <div class="col-md-2">
-            <div class="form-group">
-                <button type="submit" class="btn btn-primary">Submit</button>
-            </div>
+        <div class="field">
+            <button type="submit" class="btn btn-primary">Submit</button>
         </div>
     </div>
 </form>

--- a/ledger/templates/api/entry_forms/amortize-form.html
+++ b/ledger/templates/api/entry_forms/amortize-form.html
@@ -1,19 +1,19 @@
 {% load humanize %}
-<div class="row">
-    <div class="col-md-6">
-        <div id="amortization-transactions-table" class="table-responsive" style="max-height: 200px; overflow-y: auto;">
-            <table class="table table-sm">
+<div class="grid grid-2">
+    <div>
+        <div id="amortization-transactions-table" class="table-scroll table-scroll-sm">
+            <table class="table">
                 <thead>
                     <tr>
-                        <th style="position: sticky; top: 0; background: white; z-index: 10;">Date</th>
-                        <th style="position: sticky; top: 0; background: white; z-index: 10;">Amount</th>
-                        <th style="position: sticky; top: 0; background: white; z-index: 10;">Description</th>
+                        <th>Date</th>
+                        <th>Amount</th>
+                        <th>Description</th>
                     </tr>
                 </thead>
                 <tbody>
                     {% for transaction in transactions %}
                     <tr>
-                        <td>{{ transaction.date }}</td>
+                        <td class="td-name">{{ transaction.date }}</td>
                         <td>${{ transaction.amount|floatformat:2|intcomma }}</td>
                         <td>{{ transaction.description }}</td>
                     </tr>
@@ -22,32 +22,23 @@
             </table>
         </div>
     </div>
-    <div class="col-md-3">
+    <div>
         <form
-            class="form-sm"
             hx-post="{% url 'amortize-form' amortization.id %}"
             hx-target="#table-and-form"
-            hx-tigger="submit"
+            hx-trigger="submit"
         >
-            <!-- Date Field -->
-            <div class="col">
-                <div class="form-group">
-                    <select name="date" id="id_date" class="form-control">
-                        {% for option in date_form.date %}
-                            {{ option }}
-                        {% endfor %}
-                    </select>
-                </div>
+            <div class="field">
+                <label class="label" for="id_date">Date</label>
+                <select name="date" id="id_date" class="select">
+                    {% for option in date_form.date %}
+                        {{ option }}
+                    {% endfor %}
+                </select>
             </div>
-            <div class="col">
-                <button
-                    id="clear-button"
-                    class="btn btn-primary form-control"
-                >Amortize</button>
+            <div class="actions">
+                <button id="clear-button" class="btn btn-primary">Amortize</button>
             </div>
         </form>
     </div>
 </div>
-
-
-

--- a/ledger/templates/api/entry_forms/bill-rule-form.html
+++ b/ledger/templates/api/entry_forms/bill-rule-form.html
@@ -1,21 +1,21 @@
-<div class="set-form">
+<div class="form">
 
-  <div class="set-form-header">
+  <div class="form-header">
     {% if rule %}Edit · {{ rule.account.name }} ({{ rule.account_number }}){% else %}New rule{% endif %}
   </div>
 
   {% if change == "create" %}
-    <div class="set-alert set-alert-success">Rule created.</div>
+    <div class="alert alert-success">Rule created.</div>
   {% elif change == "update" %}
-    <div class="set-alert set-alert-success">Rule updated.</div>
+    <div class="alert alert-success">Rule updated.</div>
   {% elif change == "delete" %}
-    <div class="set-alert set-alert-success">Rule deleted.</div>
+    <div class="alert alert-success">Rule deleted.</div>
   {% endif %}
   {% if error %}
-    <div class="set-alert set-alert-danger">{{ error }}</div>
+    <div class="alert alert-danger">{{ error }}</div>
   {% endif %}
   {% if form.non_field_errors %}
-    <div class="set-alert set-alert-danger">{{ form.non_field_errors }}</div>
+    <div class="alert alert-danger">{{ form.non_field_errors }}</div>
   {% endif %}
 
   <form method="post"
@@ -24,76 +24,76 @@
         hx-swap="innerHTML">
     {% csrf_token %}
 
-    <div class="set-grid-1">
+    <div class="grid grid-3">
       <div>
-        <label class="set-label">From address</label>
-        <input class="set-input" name="from_address" value="{{ values.from_address }}" placeholder="billing@vendor.com" />
-        {% for e in form.from_address.errors %}<div class="set-field-error">{{ e }}</div>{% endfor %}
+        <label class="label">From address</label>
+        <input class="input" name="from_address" value="{{ values.from_address }}" placeholder="billing@vendor.com" />
+        {% for e in form.from_address.errors %}<div class="field-error">{{ e }}</div>{% endfor %}
       </div>
       <div>
-        <label class="set-label">Subject</label>
-        <input class="set-input" name="subject" value="{{ values.subject }}" placeholder="Your bill is ready" />
-        {% for e in form.subject.errors %}<div class="set-field-error">{{ e }}</div>{% endfor %}
+        <label class="label">Subject</label>
+        <input class="input" name="subject" value="{{ values.subject }}" placeholder="Your bill is ready" />
+        {% for e in form.subject.errors %}<div class="field-error">{{ e }}</div>{% endfor %}
       </div>
       <div>
-        <label class="set-label">Account number</label>
-        <input class="set-input" name="account_number" value="{{ values.account_number }}" placeholder="1234567890" />
-        {% for e in form.account_number.errors %}<div class="set-field-error">{{ e }}</div>{% endfor %}
+        <label class="label">Account number</label>
+        <input class="input" name="account_number" value="{{ values.account_number }}" placeholder="1234567890" />
+        {% for e in form.account_number.errors %}<div class="field-error">{{ e }}</div>{% endfor %}
       </div>
     </div>
 
-    <div class="set-grid-1">
+    <div class="grid grid-3">
       <div>
-        <label class="set-label">Transaction description match</label>
-        <input class="set-input" name="transaction_description_match" value="{{ values.transaction_description_match }}" placeholder="DOMINION" />
-        {% for e in form.transaction_description_match.errors %}<div class="set-field-error">{{ e }}</div>{% endfor %}
+        <label class="label">Transaction description match</label>
+        <input class="input" name="transaction_description_match" value="{{ values.transaction_description_match }}" placeholder="DOMINION" />
+        {% for e in form.transaction_description_match.errors %}<div class="field-error">{{ e }}</div>{% endfor %}
       </div>
       <div>
-        <label class="set-label">Address hint <span class="set-label-optional">(optional)</span></label>
-        <input class="set-input" name="address_hint" value="{{ values.address_hint }}" placeholder="Oak Ln" />
-        {% for e in form.address_hint.errors %}<div class="set-field-error">{{ e }}</div>{% endfor %}
+        <label class="label">Address hint <span class="label-optional">(optional)</span></label>
+        <input class="input" name="address_hint" value="{{ values.address_hint }}" placeholder="Oak Ln" />
+        {% for e in form.address_hint.errors %}<div class="field-error">{{ e }}</div>{% endfor %}
       </div>
       <div></div>
     </div>
 
-    <div class="set-grid-2">
+    <div class="grid grid-3 grid-end">
       <div>
-        <label class="set-label">Account</label>
-        <select class="set-select" name="account">
+        <label class="label">Account</label>
+        <select class="select" name="account">
           <option value="" {% if not values.account %}selected{% endif %}>Select…</option>
           {% for account in accounts %}
           <option value="{{ account.id }}" {% if values.account == account.id|stringformat:'s' %}selected{% endif %}>{{ account.name }}</option>
           {% endfor %}
         </select>
-        {% for e in form.account.errors %}<div class="set-field-error">{{ e }}</div>{% endfor %}
+        {% for e in form.account.errors %}<div class="field-error">{{ e }}</div>{% endfor %}
       </div>
       <div>
-        <label class="set-label">Default Entity <span class="set-label-optional">(optional)</span></label>
-        <select class="set-select" name="entity">
+        <label class="label">Default Entity <span class="label-optional">(optional)</span></label>
+        <select class="select" name="entity">
           <option value="" {% if not values.entity %}selected{% endif %}>Select…</option>
           {% for entity in entities %}
           <option value="{{ entity.id }}" {% if values.entity == entity.id|stringformat:'s' %}selected{% endif %}>{{ entity.name }}</option>
           {% endfor %}
         </select>
-        {% for e in form.entity.errors %}<div class="set-field-error">{{ e }}</div>{% endfor %}
+        {% for e in form.entity.errors %}<div class="field-error">{{ e }}</div>{% endfor %}
       </div>
       <div>
-        <label class="set-label">Transaction type</label>
-        <select class="set-select" name="transaction_type">
+        <label class="label">Transaction type</label>
+        <select class="select" name="transaction_type">
           {% for value, label in type_choices %}
           <option value="{{ value }}" {% if values.transaction_type == value %}selected{% endif %}>{{ label }}</option>
           {% endfor %}
         </select>
-        {% for e in form.transaction_type.errors %}<div class="set-field-error">{{ e }}</div>{% endfor %}
+        {% for e in form.transaction_type.errors %}<div class="field-error">{{ e }}</div>{% endfor %}
       </div>
     </div>
 
-    <div class="set-actions">
-      <button type="submit" name="action" value="save" class="set-btn set-btn-primary">{% if rule %}Save{% else %}Create{% endif %}</button>
+    <div class="actions">
+      <button type="submit" name="action" value="save" class="btn btn-primary">{% if rule %}Save{% else %}Create{% endif %}</button>
       {% if rule %}
-      <button type="submit" name="action" value="delete" class="set-btn set-btn-danger">Delete</button>
+      <button type="submit" name="action" value="delete" class="btn btn-danger">Delete</button>
       {% endif %}
-      <button type="button" class="set-btn set-btn-clear"
+      <button type="button" class="btn btn-ghost"
               @click="selectedId = null"
               hx-get="{% url 'settings-bill-rule-new-form' %}"
               hx-target="#bill-rule-form-div">Clear</button>

--- a/ledger/templates/api/entry_forms/bulk-account-change-form.html
+++ b/ledger/templates/api/entry_forms/bulk-account-change-form.html
@@ -1,29 +1,25 @@
 <form id="bulk-account-change-form" method="post">
     {% csrf_token %}
-    <div class="row g-3 align-items-end">
-        <div class="col-md-3">
-            <div class="form-group">
-                <label for="id_from_account">FROM Account</label>
-                <select name="from_account" id="id_from_account" class="form-control">
-                    <option value="">---------</option>
-                    {% for account in accounts %}
-                        <option value="{{ account.pk }}">{{ account.name }}</option>
-                    {% endfor %}
-                </select>
-            </div>
+    <div class="grid grid-auto grid-end">
+        <div class="field">
+            <label class="label" for="id_from_account">FROM Account</label>
+            <select name="from_account" id="id_from_account" class="select">
+                <option value="">---------</option>
+                {% for account in accounts %}
+                    <option value="{{ account.pk }}">{{ account.name }}</option>
+                {% endfor %}
+            </select>
         </div>
-        <div class="col-md-3">
-            <div class="form-group">
-                <label for="id_to_account">TO Account</label>
-                <select name="to_account" id="id_to_account" class="form-control">
-                    <option value="">---------</option>
-                    {% for account in accounts %}
-                        <option value="{{ account.pk }}">{{ account.name }}</option>
-                    {% endfor %}
-                </select>
-            </div>
+        <div class="field">
+            <label class="label" for="id_to_account">TO Account</label>
+            <select name="to_account" id="id_to_account" class="select">
+                <option value="">---------</option>
+                {% for account in accounts %}
+                    <option value="{{ account.pk }}">{{ account.name }}</option>
+                {% endfor %}
+            </select>
         </div>
-        <div class="col-md-3">
+        <div class="field">
             <button
                 type="button"
                 class="btn btn-warning"

--- a/ledger/templates/api/entry_forms/edit-tax-charge-form.html
+++ b/ledger/templates/api/entry_forms/edit-tax-charge-form.html
@@ -1,106 +1,85 @@
 {% load humanize %}
 <div id="form-container">
-    <div class="row">
-        <div class="col">
-            <form
-                class="form-sm"
-                method="post"
-                {% if tax_charge %}hx-post="{% url 'edit-tax-charge' pk=tax_charge.pk %}"{% else %}hx-post="{% url 'taxes' %}"{% endif %}
-                hx-target="#table-and-form"
-                hx-trigger="submit"
-                hx-include="#taxes-filter-form"
-            >
-                {% csrf_token %}
+    <form
+        method="post"
+        {% if tax_charge %}hx-post="{% url 'edit-tax-charge' pk=tax_charge.pk %}"{% else %}hx-post="{% url 'taxes' %}"{% endif %}
+        hx-target="#table-and-form"
+        hx-trigger="submit"
+        hx-include="#taxes-filter-form"
+    >
+        {% csrf_token %}
 
-                <div class="row">
-                    <!-- Account Field -->
-                    <div class="col-md-2">
-                        <div class="form-group">
-                            <select name="account" id="id_account" class="form-control">
-                                {% for option in form.account %}
-                                    {{ option }}
-                                {% endfor %}
-                            </select>
-                            {% if form.account.errors %}
-                                <div class="invalid-feedback d-block">
-                                    {{ form.account.errors|striptags }}
-                                </div>
-                            {% endif %}
-                        </div>
-                    </div>
-
-                    <!-- Date Field -->
-                    <div class="col-md-2">
-                        <div class="form-group">
-                            <select name="date" id="id_date_to" class="form-control">
-                                {% for option in form.date %}
-                                    {{ option }}
-                                {% endfor %}
-                            </select>
-                        </div>
-                    </div>
-
-                    <!-- Render the 'amount' field -->
-                    <div class="col-md-2">
-                        <div class="form-group">
-                            <input
-                                type="text"
-                                name="amount"
-                                id="id_amount"
-                                class="form-control"
-                                value="{% if form.amount.value %}{{ form.amount.value|intcomma }}{% else %}0.00{% endif %}"
-                            >
-                        </div>
-                    </div>
-
-                    <div class="col-md-2">
-                        <div class="form-group">
-                            <button type="submit" class="btn btn-primary form-control">Save</button>
-                        </div>
-                    </div>
-                    <div class="col-md-2">
-                        <button
-                            id="clear-button"
-                            class="btn btn-secondary form-control"
-                            hx-get="{% url 'tax-charge-table' %}"
-                            hx-target="#table-and-form"
-                        >Clear</button>
-                    </div>
-                </div>
-            </form>
-        </div>
-    </div>
-    <div class="row">
-        <div class="col-md-4">
-            <table class="table table-sm">
-                <tbody>
-                    <tr>
-                        <th scope="row">Taxable Income</th>
-                        <td>${{ taxable_income|floatformat:2|intcomma }}</td>
-                    </tr>
-                    {% for account in tax_accounts %}
-                    <tr>
-                        <th scope="row">{{ account.name }}</th>
-                        <td>
-                            <div class="d-flex justify-content-between align-items-center">
-                                <span>${{ account.recommended_tax|floatformat:2|intcomma }}</span>
-                                {% if account.recommended_tax is not None %}
-                                <button
-                                    type="button"
-                                    class="btn btn-outline-primary btn-sm py-0"
-                                    style="font-size: 0.75rem; line-height: 1.4;"
-                                    title="Apply this amount to the tax charge"
-                                    hx-post="{% url 'apply-tax-recommendation' account_pk=account.pk end_date=end_date|date:'Y-m-d' %}"
-                                    hx-target="#table-and-form"
-                                    hx-include="#taxes-filter-form"
-                                >Autofill</button>
-                                {% endif %}
-                            </div>
-                        </td>
-                    </tr>
+        <div class="grid grid-auto grid-end mb-4">
+            <!-- Account Field -->
+            <div class="field">
+                <label class="label" for="id_account">Account</label>
+                <select name="account" id="id_account" class="select">
+                    {% for option in form.account %}
+                        {{ option }}
                     {% endfor %}
-                </tbody>
-            </table>
+                </select>
+                {% if form.account.errors %}
+                    <div class="field-error">{{ form.account.errors|striptags }}</div>
+                {% endif %}
+            </div>
+
+            <!-- Date Field -->
+            <div class="field">
+                <label class="label" for="id_date_to">Date</label>
+                <select name="date" id="id_date_to" class="select">
+                    {% for option in form.date %}
+                        {{ option }}
+                    {% endfor %}
+                </select>
+            </div>
+
+            <!-- Amount Field -->
+            <div class="field">
+                <label class="label" for="id_amount">Amount</label>
+                <input type="text" name="amount" id="id_amount" class="input"
+                       value="{% if form.amount.value %}{{ form.amount.value|intcomma }}{% else %}0.00{% endif %}">
+            </div>
+
+            <div class="field">
+                <div class="actions">
+                    <button type="submit" class="btn btn-primary">Save</button>
+                    <button
+                        id="clear-button"
+                        class="btn btn-secondary"
+                        hx-get="{% url 'tax-charge-table' %}"
+                        hx-target="#table-and-form"
+                    >Clear</button>
+                </div>
+            </div>
         </div>
-    </div>
+    </form>
+
+    <table class="table" style="max-width: 480px;">
+        <tbody>
+            <tr>
+                <th scope="row">Taxable Income</th>
+                <td>${{ taxable_income|floatformat:2|intcomma }}</td>
+            </tr>
+            {% for account in tax_accounts %}
+            <tr>
+                <th scope="row">{{ account.name }}</th>
+                <td>
+                    <div class="flex-between gap-2">
+                        <span>${{ account.recommended_tax|floatformat:2|intcomma }}</span>
+                        {% if account.recommended_tax is not None %}
+                        <button
+                            type="button"
+                            class="btn btn-secondary btn-sm"
+                            title="Apply this amount to the tax charge"
+                            hx-post="{% url 'apply-tax-recommendation' account_pk=account.pk end_date=end_date|date:'Y-m-d' %}"
+                            hx-target="#table-and-form"
+                            hx-include="#taxes-filter-form"
+                        >Autofill</button>
+                        {% endif %}
+                    </div>
+                </td>
+            </tr>
+            {% endfor %}
+        </tbody>
+    </table>
 </div>

--- a/ledger/templates/api/entry_forms/entity-tag-form.html
+++ b/ledger/templates/api/entry_forms/entity-tag-form.html
@@ -1,32 +1,21 @@
 {% load humanize %}
-<div class="row">
-    <div class="col-md-12">
-        <form
-            method="post"
-            hx-post="{% url 'tag-entities-form' journal_entry_item_id %}"
-            hx-swap="outerHTML"
-            hx-target="#table-and-form"
-            class="form-group form-sm"
-        >
-        {% csrf_token %}
-            <!-- Date Field -->
-            <div class="form-row mb-3">
-                <div class="col-md-12">
-                    <select class="form-control" name="entity" id="id_entity">
-                        {% for entity in form.entity.field.queryset %}
-                            <option value="{{ entity.pk }}" {% if form.entity.value == entity.pk %} selected {% endif %}>
-                                {{ entity }}
-                            </option>
-                        {% endfor %}
-                    </select>
-                </div>
-            </div>
-            <!-- Submit Button -->
-            <div class="form-row">
-                <div class="col-auto">
-                    <button type="submit" name="action" value="create" class="btn btn-primary mb-3">Add Entity</button>
-                </div>
-            </div>
-        </form>
+<form
+    method="post"
+    hx-post="{% url 'tag-entities-form' journal_entry_item_id %}"
+    hx-swap="outerHTML"
+    hx-target="#table-and-form"
+>
+{% csrf_token %}
+    <div class="field">
+        <select class="select" name="entity" id="id_entity">
+            {% for entity in form.entity.field.queryset %}
+                <option value="{{ entity.pk }}" {% if form.entity.value == entity.pk %} selected {% endif %}>
+                    {{ entity }}
+                </option>
+            {% endfor %}
+        </select>
     </div>
-</div>
+    <div class="actions">
+        <button type="submit" name="action" value="create" class="btn btn-primary">Add Entity</button>
+    </div>
+</form>

--- a/ledger/templates/api/entry_forms/journal-entry-item-form.html
+++ b/ledger/templates/api/entry_forms/journal-entry-item-form.html
@@ -3,7 +3,6 @@
 <form
     id="journal-entry-form"
     method="post"
-    class="form-horizontal form-sm"
     hx-post="{% url 'journal-entries' transaction_id %}"
     hx-target="#table-and-form"
     hx-trigger="submit"
@@ -12,170 +11,128 @@
     {% csrf_token %}
     {{ metadata_form.index }}
     {{ metadata_form.paystub_id }}
-    <div class="row">
-        <div class="col-12">
-            <input type="submit" value="Submit" class="btn btn-primary mt-3" />
-        </div>
-    </div>
+    <input type="submit" value="Submit" class="btn btn-primary mb-3" />
+
     {% if created_entities %}
-    <div class="row">
-        <div class="col-md-6">
-            <small class="text-success">Entities created:</small><br>
-            {% for created_entity in created_entities %}
-                <small class="text-success">{{ created_entity.name }}</small><br>
-            {% endfor %}
-        </div>
+    <div class="mb-3">
+        <small class="text-success">Entities created:</small><br>
+        {% for created_entity in created_entities %}
+            <small class="text-success">{{ created_entity.name }}</small><br>
+        {% endfor %}
     </div>
     {% endif %}
     {% if form_errors %}
-    <div class="row">
-        <div class="col-md-6" role="alert">
-            <div class="alert alert-danger" role="alert">
-            {% for error in form_errors %}
-                <small>{{ error }}</small><br>
-            {% endfor %}
-            </div>
-        </div>
+    <div class="alert alert-danger" role="alert">
+        {% for error in form_errors %}
+            <small>{{ error }}</small><br>
+        {% endfor %}
     </div>
     {% endif %}
-    <div class="row">
+
+    <div class="grid grid-2">
         <!-- Debit Formset Column -->
-        <div class="col-md-6">
-            <h3>Debits</h3>
+        <div>
+            <h3 class="card-title mb-2">Debits</h3>
             {{ debit_formset.management_form }}
-            <small>Total Debits: $<span id="totalDebits">{{ debit_prefilled_total|floatformat:2|intcomma }}</span></small>
+            <small class="muted">Total Debits: $<span id="totalDebits">{{ debit_prefilled_total|floatformat:2|intcomma }}</span></small>
             {% for form in debit_formset %}
-            <div class="row">
-                <div class="col-md-6">
+            <div class="grid grid-wide-first grid-tight mb-2">
+                <div>
                     {{ form.id }}
                     <input
-                        class="form-control {% if form.account.errors %}is-invalid{% endif %}"
+                        class="input {% if form.account.errors %}is-invalid{% endif %}"
                         list="debitAccountOptions"
                         name="{{ form.account.html_name }}"
                         id="{{ form.account.auto_id }}"
                         tabindex="{{ forloop.counter|multiply:6|add:1 }}"
                         value="{% if form.account_name %}{{ form.account_name }}{% elif form.account.value %}{{ form.account.value }}{% endif %}"
-                        {% if not autofocus_debit %}autofocus{% endif %}
-                        >
-                        <datalist id="debitAccountOptions">
-                            {% for text in form.account.field.choices %}
-                                <option value="{{ text }}">
-                            {% endfor %}
-                        </datalist>
-                    </input>
-                    <div class="invalid-feedback">
-                        {% for error in form.account.errors %}
-                            {{ error }}
+                        {% if not autofocus_debit %}autofocus{% endif %}>
+                    <datalist id="debitAccountOptions">
+                        {% for text in form.account.field.choices %}
+                            <option value="{{ text }}">
                         {% endfor %}
-                    </div>
+                    </datalist>
+                    {% for error in form.account.errors %}<div class="field-error">{{ error }}</div>{% endfor %}
                 </div>
-                <div class="col-md-3">
+                <div>
                     <input
                         type="number"
                         step="0.01"
-                        class="form-control {% if form.amount.errors %}is-invalid{% endif %}"
+                        class="input"
                         name="{{ form.amount.html_name }}"
                         id="{{ form.amount.auto_id }}"
                         value="{{ form.amount.value }}"
-                        tabindex="{{ forloop.counter|multiply:6|add:2 }}"
-                    >
-                    <div class="invalid-feedback">
-                        {% for error in form.amount.errors %}
-                            {{ error }}
-                        {% endfor %}
-                    </div>
+                        tabindex="{{ forloop.counter|multiply:6|add:2 }}">
+                    {% for error in form.amount.errors %}<div class="field-error">{{ error }}</div>{% endfor %}
                 </div>
-                <div class="col-md-3">
+                <div>
                     <input
-                        class="form-control {% if form.entity.errors %}is-invalid{% endif %}"
+                        class="input {% if form.entity.errors %}is-invalid{% endif %}"
                         list="debitEntityOptions"
                         name="{{ form.entity.html_name }}"
                         id="{{ form.entity.auto_id }}"
                         tabindex="{{ forloop.counter|multiply:6|add:3 }}"
-                        value="{% if form.entity_name %}{{ form.entity_name }}{% elif form.entity.value %}{{ form.entity.value }}{% endif %}"
-                        >
-                        <datalist id="debitEntityOptions">
-                            {% for text in form.entity.field.choices %}
-                                <option value="{{ text }}">
-                            {% endfor %}
-                        </datalist>
-                    </input>
-                    <div class="invalid-feedback">
-                        {% for error in form.entity.errors %}
-                            {{ error }}
+                        value="{% if form.entity_name %}{{ form.entity_name }}{% elif form.entity.value %}{{ form.entity.value }}{% endif %}">
+                    <datalist id="debitEntityOptions">
+                        {% for text in form.entity.field.choices %}
+                            <option value="{{ text }}">
                         {% endfor %}
-                    </div>
+                    </datalist>
+                    {% for error in form.entity.errors %}<div class="field-error">{{ error }}</div>{% endfor %}
                 </div>
             </div>
             {% endfor %}
         </div>
 
         <!-- Credit Formset Column -->
-        <div class="col-md-6">
-            <h3>Credits</h3>
+        <div>
+            <h3 class="card-title mb-2">Credits</h3>
             {{ credit_formset.management_form }}
-            <small>Total Credits: $<span id="totalCredits">{{ credit_prefilled_total|floatformat:2|intcomma }}</span></small>
+            <small class="muted">Total Credits: $<span id="totalCredits">{{ credit_prefilled_total|floatformat:2|intcomma }}</span></small>
             {% for form in credit_formset %}
-            <div class="row">
-                <div class="col-md-6">
+            <div class="grid grid-wide-first grid-tight mb-2">
+                <div>
                     {{ form.id }}
                     <input
-                        class="form-control {% if form.account.errors %}is-invalid{% endif %}"
+                        class="input {% if form.account.errors %}is-invalid{% endif %}"
                         list="debitAccountOptions"
                         name="{{ form.account.html_name }}"
                         id="{{ form.account.auto_id }}"
                         tabindex="{{ forloop.counter|multiply:6|add:4 }}"
                         value="{% if form.account_name %}{{ form.account_name }}{% elif form.account.value %}{{ form.account.value }}{% endif %}"
-                        {% if autofocus_debit %}autofocus{% endif %}
-                        >
-                        <datalist id="debitAccountOptions">
-                            {% for text in form.account.field.choices %}
-                                <option value="{{ text }}">
-                            {% endfor %}
-                        </datalist>
-                    </input>
-                    <div class="invalid-feedback">
-                        {% for error in form.account.errors %}
-                            {{ error }}
+                        {% if autofocus_debit %}autofocus{% endif %}>
+                    <datalist id="debitAccountOptions">
+                        {% for text in form.account.field.choices %}
+                            <option value="{{ text }}">
                         {% endfor %}
-                    </div>
+                    </datalist>
+                    {% for error in form.account.errors %}<div class="field-error">{{ error }}</div>{% endfor %}
                 </div>
-                <div class="col-md-3">
+                <div>
                     <input
                         type="number"
                         step="0.01"
-                        class="form-control {% if form.amount.errors %}is-invalid{% endif %}"
+                        class="input"
                         name="{{ form.amount.html_name }}"
                         id="{{ form.amount.auto_id }}"
                         value="{{ form.amount.value }}"
-                        tabindex="{{ forloop.counter|multiply:6|add:5 }}"
-                    >
-                    <div class="invalid-feedback">
-                        {% for error in form.amount.errors %}
-                            {{ error }}
-                        {% endfor %}
-                    </div>
+                        tabindex="{{ forloop.counter|multiply:6|add:5 }}">
+                    {% for error in form.amount.errors %}<div class="field-error">{{ error }}</div>{% endfor %}
                 </div>
-                <div class="col-md-3">
+                <div>
                     <input
-                        class="form-control {% if form.entity.errors %}is-invalid{% endif %}"
+                        class="input {% if form.entity.errors %}is-invalid{% endif %}"
                         list="creditEntityOptions"
                         name="{{ form.entity.html_name }}"
                         id="{{ form.entity.auto_id }}"
                         tabindex="{{ forloop.counter|multiply:6|add:6 }}"
-                        value="{% if form.entity_name %}{{ form.entity_name }}{% elif form.entity.value %}{{ form.entity.value }}{% endif %}"
-                        >
-                        <datalist id="creditEntityOptions">
-                            {% for text in form.entity.field.choices %}
-                                <option value="{{ text }}">
-                            {% endfor %}
-                        </datalist>
-                    </input>
-                    <div class="invalid-feedback">
-                        {% for error in form.entity.errors %}
-                            {{ error }}
+                        value="{% if form.entity_name %}{{ form.entity_name }}{% elif form.entity.value %}{{ form.entity.value }}{% endif %}">
+                    <datalist id="creditEntityOptions">
+                        {% for text in form.entity.field.choices %}
+                            <option value="{{ text }}">
                         {% endfor %}
-                    </div>
+                    </datalist>
+                    {% for error in form.entity.errors %}<div class="field-error">{{ error }}</div>{% endfor %}
                 </div>
             </div>
             {% endfor %}

--- a/ledger/templates/api/entry_forms/loan-form.html
+++ b/ledger/templates/api/entry_forms/loan-form.html
@@ -1,31 +1,21 @@
-<div class="set-form loan-form">
+<div class="form">
 
-  <style>
-    .loan-form.set-form { margin-top: 14px; padding-top: 12px; }
-    .loan-form .set-form-header { margin-bottom: 10px; }
-    .loan-form .lf-grid { display: grid; grid-template-columns: repeat(4, 1fr);
-                          gap: 6px 12px; margin-bottom: 8px; align-items: end; }
-    .loan-form .set-label { margin-bottom: 2px; }
-    .loan-form .set-input, .loan-form .set-select { height: 26px; padding: 0 7px; }
-    .loan-form .set-actions { margin-top: 4px; }
-  </style>
-
-  <div class="set-form-header">
+  <div class="form-header">
     {% if loan %}Edit · {{ loan.name }}{% else %}New loan{% endif %}
   </div>
 
   {% if change == "create" %}
-    <div class="set-alert set-alert-success">Loan created — schedule generated.</div>
+    <div class="alert alert-success">Loan created — schedule generated.</div>
   {% elif change == "update" %}
-    <div class="set-alert set-alert-success">Loan updated — schedule regenerated.</div>
+    <div class="alert alert-success">Loan updated — schedule regenerated.</div>
   {% elif change == "delete" %}
-    <div class="set-alert set-alert-success">Loan deleted.</div>
+    <div class="alert alert-success">Loan deleted.</div>
   {% endif %}
   {% if error %}
-    <div class="set-alert set-alert-danger">{{ error }}</div>
+    <div class="alert alert-danger">{{ error }}</div>
   {% endif %}
   {% if form.non_field_errors %}
-    <div class="set-alert set-alert-danger">{{ form.non_field_errors }}</div>
+    <div class="alert alert-danger">{{ form.non_field_errors }}</div>
   {% endif %}
 
   <form method="post"
@@ -34,101 +24,101 @@
         hx-swap="innerHTML">
     {% csrf_token %}
 
-    <div class="lf-grid">
+    <div class="grid grid-4">
       <div>
-        <label class="set-label">Name</label>
-        <input class="set-input" name="name" value="{{ values.name }}" placeholder="Mortgage — 123 Oak Ln" />
-        {% for e in form.name.errors %}<div class="set-field-error">{{ e }}</div>{% endfor %}
+        <label class="label">Name</label>
+        <input class="input" name="name" value="{{ values.name }}" placeholder="Mortgage — 123 Oak Ln" />
+        {% for e in form.name.errors %}<div class="field-error">{{ e }}</div>{% endfor %}
       </div>
       <div>
-        <label class="set-label">Original amount</label>
-        <input class="set-input" name="original_amount" value="{{ values.original_amount }}" placeholder="300,000.00" />
-        {% for e in form.original_amount.errors %}<div class="set-field-error">{{ e }}</div>{% endfor %}
+        <label class="label">Original amount</label>
+        <input class="input" name="original_amount" value="{{ values.original_amount }}" placeholder="300,000.00" />
+        {% for e in form.original_amount.errors %}<div class="field-error">{{ e }}</div>{% endfor %}
       </div>
       <div>
-        <label class="set-label">Annual rate <span class="set-label-optional">(0.0650 = 6.5%)</span></label>
-        <input class="set-input" name="annual_interest_rate" value="{{ values.annual_interest_rate }}" placeholder="0.0650" />
-        {% for e in form.annual_interest_rate.errors %}<div class="set-field-error">{{ e }}</div>{% endfor %}
+        <label class="label">Annual rate <span class="label-optional">(0.0650 = 6.5%)</span></label>
+        <input class="input" name="annual_interest_rate" value="{{ values.annual_interest_rate }}" placeholder="0.0650" />
+        {% for e in form.annual_interest_rate.errors %}<div class="field-error">{{ e }}</div>{% endfor %}
       </div>
       <div>
-        <label class="set-label">Term (months)</label>
-        <input class="set-input" name="term_months" value="{{ values.term_months }}" placeholder="360" />
-        {% for e in form.term_months.errors %}<div class="set-field-error">{{ e }}</div>{% endfor %}
+        <label class="label">Term (months)</label>
+        <input class="input" name="term_months" value="{{ values.term_months }}" placeholder="360" />
+        {% for e in form.term_months.errors %}<div class="field-error">{{ e }}</div>{% endfor %}
       </div>
     </div>
 
-    <div class="lf-grid">
+    <div class="grid grid-4">
       <div>
-        <label class="set-label">First payment date</label>
-        <input class="set-input" type="date" name="start_date" value="{{ values.start_date }}" />
-        {% for e in form.start_date.errors %}<div class="set-field-error">{{ e }}</div>{% endfor %}
+        <label class="label">First payment date</label>
+        <input class="input" type="date" name="start_date" value="{{ values.start_date }}" />
+        {% for e in form.start_date.errors %}<div class="field-error">{{ e }}</div>{% endfor %}
       </div>
       <div>
-        <label class="set-label">Payment <span class="set-label-optional">(blank = computed)</span></label>
-        <input class="set-input" name="payment_amount" value="{{ values.payment_amount }}" placeholder="1,896.20" />
-        {% for e in form.payment_amount.errors %}<div class="set-field-error">{{ e }}</div>{% endfor %}
+        <label class="label">Payment <span class="label-optional">(blank = computed)</span></label>
+        <input class="input" name="payment_amount" value="{{ values.payment_amount }}" placeholder="1,896.20" />
+        {% for e in form.payment_amount.errors %}<div class="field-error">{{ e }}</div>{% endfor %}
       </div>
       <div>
-        <label class="set-label">Principal account <span class="set-label-optional">(liability)</span></label>
-        <select class="set-select" name="principal_account">
+        <label class="label">Principal account <span class="label-optional">(liability)</span></label>
+        <select class="select" name="principal_account">
           <option value="" {% if not values.principal_account %}selected{% endif %}>Select…</option>
           {% for account in liability_accounts %}
           <option value="{{ account.id }}" {% if values.principal_account == account.id|stringformat:'s' %}selected{% endif %}>{{ account.name }}</option>
           {% endfor %}
         </select>
-        {% for e in form.principal_account.errors %}<div class="set-field-error">{{ e }}</div>{% endfor %}
+        {% for e in form.principal_account.errors %}<div class="field-error">{{ e }}</div>{% endfor %}
       </div>
       <div>
-        <label class="set-label">Interest account <span class="set-label-optional">(expense)</span></label>
-        <select class="set-select" name="interest_account">
+        <label class="label">Interest account <span class="label-optional">(expense)</span></label>
+        <select class="select" name="interest_account">
           <option value="" {% if not values.interest_account %}selected{% endif %}>Select…</option>
           {% for account in expense_accounts %}
           <option value="{{ account.id }}" {% if values.interest_account == account.id|stringformat:'s' %}selected{% endif %}>{{ account.name }}</option>
           {% endfor %}
         </select>
-        {% for e in form.interest_account.errors %}<div class="set-field-error">{{ e }}</div>{% endfor %}
+        {% for e in form.interest_account.errors %}<div class="field-error">{{ e }}</div>{% endfor %}
       </div>
     </div>
 
-    <div class="lf-grid">
+    <div class="grid grid-4">
       <div>
-        <label class="set-label">Payment account <span class="set-label-optional">(optional)</span></label>
-        <select class="set-select" name="payment_account">
+        <label class="label">Payment account <span class="label-optional">(optional)</span></label>
+        <select class="select" name="payment_account">
           <option value="" {% if not values.payment_account %}selected{% endif %}>Any</option>
           {% for account in payment_accounts %}
           <option value="{{ account.id }}" {% if values.payment_account == account.id|stringformat:'s' %}selected{% endif %}>{{ account.name }}</option>
           {% endfor %}
         </select>
-        {% for e in form.payment_account.errors %}<div class="set-field-error">{{ e }}</div>{% endfor %}
+        {% for e in form.payment_account.errors %}<div class="field-error">{{ e }}</div>{% endfor %}
       </div>
       <div>
-        <label class="set-label">Description match <span class="set-label-optional">(optional)</span></label>
-        <input class="set-input" name="description_match" value="{{ values.description_match }}" placeholder="WELLS FARGO MTG" />
-        {% for e in form.description_match.errors %}<div class="set-field-error">{{ e }}</div>{% endfor %}
+        <label class="label">Description match <span class="label-optional">(optional)</span></label>
+        <input class="input" name="description_match" value="{{ values.description_match }}" placeholder="WELLS FARGO MTG" />
+        {% for e in form.description_match.errors %}<div class="field-error">{{ e }}</div>{% endfor %}
       </div>
       <div>
-        <label class="set-label">Date window (days)</label>
-        <input class="set-input" name="date_window_days" value="{{ values.date_window_days }}" placeholder="7" />
-        {% for e in form.date_window_days.errors %}<div class="set-field-error">{{ e }}</div>{% endfor %}
+        <label class="label">Date window (days)</label>
+        <input class="input" name="date_window_days" value="{{ values.date_window_days }}" placeholder="7" />
+        {% for e in form.date_window_days.errors %}<div class="field-error">{{ e }}</div>{% endfor %}
       </div>
       <div>
-        <label class="set-label">Entity <span class="set-label-optional">(optional)</span></label>
-        <select class="set-select" name="entity">
+        <label class="label">Entity <span class="label-optional">(optional)</span></label>
+        <select class="select" name="entity">
           <option value="" {% if not values.entity %}selected{% endif %}>Select…</option>
           {% for entity in entities %}
           <option value="{{ entity.id }}" {% if values.entity == entity.id|stringformat:'s' %}selected{% endif %}>{{ entity.name }}</option>
           {% endfor %}
         </select>
-        {% for e in form.entity.errors %}<div class="set-field-error">{{ e }}</div>{% endfor %}
+        {% for e in form.entity.errors %}<div class="field-error">{{ e }}</div>{% endfor %}
       </div>
     </div>
 
-    <div class="set-actions">
-      <button type="submit" name="action" value="save" class="set-btn set-btn-primary">{% if loan %}Save{% else %}Create{% endif %}</button>
+    <div class="actions">
+      <button type="submit" name="action" value="save" class="btn btn-primary">{% if loan %}Save{% else %}Create{% endif %}</button>
       {% if loan %}
-      <button type="submit" name="action" value="delete" class="set-btn set-btn-danger">Delete</button>
+      <button type="submit" name="action" value="delete" class="btn btn-danger">Delete</button>
       {% endif %}
-      <button type="button" class="set-btn set-btn-clear"
+      <button type="button" class="btn btn-ghost"
               @click="selectedId = null"
               hx-get="{% url 'settings-loan-new-form' %}"
               hx-target="#loan-form-div">Clear</button>

--- a/ledger/templates/api/entry_forms/textract-form.html
+++ b/ledger/templates/api/entry_forms/textract-form.html
@@ -1,47 +1,29 @@
-<div class="row">
-    <div class="col">
-        <h3>Upload paystubs</h3>
-        <form
-            method="post"
-            enctype="multipart/form-data"
-            hx-post="{% url 'upload-transactions' %}"
-            hx-target="#textract"
-            hx-trigger="submit"
-        >
-        {% csrf_token %}
+<h3 class="card-title mb-3">Upload paystubs</h3>
+<form
+    method="post"
+    enctype="multipart/form-data"
+    hx-post="{% url 'upload-transactions' %}"
+    hx-target="#textract"
+    hx-trigger="submit"
+>
+{% csrf_token %}
 
-            <div class="mb-3">
-                <input type="file" name="document" id="id_document" class="form-control-file">
-            </div>
-            <div class="mb-3">
-                <select name="{{ form.prefill.name }}" id="id_prefill" class="form-control">
-                    {% for choice in form.prefill.field.queryset %}
-                        <option value="{{ choice.pk }}">
-                            {{ choice }}
-                        </option>
-                    {% endfor %}
-                </select>
-            </div>
-            <button type="submit" name="paystubs" class="btn btn-primary">Submit</button>
-        </form>
+    <div class="field">
+        <input type="file" name="document" id="id_document" class="file-input">
     </div>
-</div>
-<br>
+    <div class="field">
+        <select name="{{ form.prefill.name }}" id="id_prefill" class="select">
+            {% for choice in form.prefill.field.queryset %}
+                <option value="{{ choice.pk }}">{{ choice }}</option>
+            {% endfor %}
+        </select>
+    </div>
+    <button type="submit" name="paystubs" class="btn btn-primary">Submit</button>
+</form>
+
 {% if error %}
-<div class="row">
-    <div class="col">
-        <div class="alert alert-danger" role="alert">
-            Upload failed: {{ error }}
-        </div>
-    </div>
-</div>
+<div class="alert alert-danger mt-3" role="alert">Upload failed: {{ error }}</div>
 {% endif %}
 {% if filename %}
-<div class="row">
-    <div class="col">
-        <div class="alert alert-success" role="alert">
-            Uploaded {{ filename }}
-        </div>
-    </div>
-</div>
+<div class="alert alert-success mt-3" role="alert">Uploaded {{ filename }}</div>
 {% endif %}

--- a/ledger/templates/api/entry_forms/transaction-form.html
+++ b/ledger/templates/api/entry_forms/transaction-form.html
@@ -1,6 +1,6 @@
 {% load humanize %}
-<div class="row">
-    <div class="col-md-6">
+<div class="grid grid-2">
+    <div>
         <form
             method="post"
             {% if transaction %}
@@ -11,21 +11,20 @@
             hx-swap="innerHTML"
             hx-target="#table-and-form"
             hx-include="#transactions-filter-form"
-            class="form-group form-sm"
         >
         {% csrf_token %}
 
-            <!-- Date Field -->
-            <div class="form-row align-items-center">
-                <div class="col-md-4">
-                    <label for="{{ form.date.id_for_label }}" class="sr-only">{{ form.date.label }}</label>
-                    <input type="date" name="{{ form.date.html_name }}" id="{{ form.date.id_for_label }}" class="form-control mb-2" value="{{ form.date.value|date:'Y-m-d' }}" placeholder="{{ form.date.label }}">
+            <div class="grid grid-3 mb-3">
+                <!-- Date Field -->
+                <div>
+                    <label for="{{ form.date.id_for_label }}" class="label">{{ form.date.label }}</label>
+                    <input type="date" name="{{ form.date.html_name }}" id="{{ form.date.id_for_label }}" class="input" value="{{ form.date.value|date:'Y-m-d' }}" placeholder="{{ form.date.label }}">
                 </div>
 
                 <!-- Account Field -->
-                <div class="col-md-4">
-                    <label for="id_account" class="sr-only">Account</label>
-                    <input class="form-control mb-2" list="accountOptions" name="account" id="id_account" value="{{ form.account_name }}" placeholder="Account">
+                <div>
+                    <label for="id_account" class="label">Account</label>
+                    <input class="input" list="accountOptions" name="account" id="id_account" value="{{ form.account_name }}" placeholder="Account">
                     <datalist id="accountOptions">
                         {% for value, text in form.account.field.choices %}
                             <option value="{{ text }}">
@@ -34,24 +33,26 @@
                 </div>
 
                 <!-- Amount Field -->
-                <div class="col-md-4">
-                    <div class="input-group mb-2">
-                        <div class="input-group-prepend">
-                            <div class="input-group-text">$</div>
-                        </div>
-                        <input type="text" name="{{ form.amount.html_name }}" id="{{ form.amount.id_for_label }}" class="form-control" value="{{ form.amount.value|default_if_none:''|intcomma }}" placeholder="{{ form.amount.label }}">
+                <div>
+                    <label for="{{ form.amount.id_for_label }}" class="label">{{ form.amount.label }}</label>
+                    <div class="field-currency">
+                        <span class="prefix">$</span>
+                        <input type="text" name="{{ form.amount.html_name }}" id="{{ form.amount.id_for_label }}" class="input" value="{{ form.amount.value|default_if_none:''|intcomma }}" placeholder="{{ form.amount.label }}">
                     </div>
                 </div>
             </div>
-            <div class="form-row align-items-center">
+
+            <div class="grid grid-2 mb-3">
                 <!-- Description Field -->
-                <div class="col-md-8">
-                    <input type="text" name="{{ form.description.html_name }}" id="{{ form.description.id_for_label }}" class="form-control mb-2" value="{{ form.description.value|default_if_none:'' }}" placeholder="{{ form.description.label }}">
+                <div>
+                    <label for="{{ form.description.id_for_label }}" class="label">{{ form.description.label }}</label>
+                    <input type="text" name="{{ form.description.html_name }}" id="{{ form.description.id_for_label }}" class="input" value="{{ form.description.value|default_if_none:'' }}" placeholder="{{ form.description.label }}">
                 </div>
 
                 <!-- Suggested Account Field -->
-                <div class="col-md-4">
-                    <input class="form-control mb-2" list="suggestedAccountOptions" name="suggested_account" id="id_suggested_account" value="{{ form.suggested_account_name }}" placeholder="Suggested Account">
+                <div>
+                    <label for="id_suggested_account" class="label">Suggested Account</label>
+                    <input class="input" list="suggestedAccountOptions" name="suggested_account" id="id_suggested_account" value="{{ form.suggested_account_name }}" placeholder="Suggested Account">
                     <datalist id="suggestedAccountOptions">
                         {% for value, text in form.suggested_account.field.choices %}
                             <option value="{{ text }}">
@@ -59,37 +60,30 @@
                     </datalist>
                 </div>
             </div>
-            <div class="form-row align-items-center">
-                <!-- Type Field (as Button Group) -->
-                <div class="col-auto">
-                    <div class="btn-group btn-group-toggle mb-2" role="group" aria-label="Transaction type" data-toggle="buttons">
-                        {% for value, label in form.type.field.choices %}
-                            <label class="btn btn-outline-primary {% if form.type.value == value %}active{% endif %}">
-                                <input type="radio" name="{{ form.type.html_name }}" id="id_type_{{ value }}" value="{{ value }}" {% if form.type.value == value %}checked{% endif %} autocomplete="off">
-                                {{ label }}
-                            </label>
-                        {% endfor %}
-                    </div>
+
+            <!-- Type Field (segmented radio group) -->
+            <div class="field">
+                <div class="segmented" role="group" aria-label="Transaction type">
+                    {% for value, label in form.type.field.choices %}
+                        <label>
+                            <input type="radio" name="{{ form.type.html_name }}" id="id_type_{{ value }}" value="{{ value }}" {% if form.type.value == value %}checked{% endif %} autocomplete="off">
+                            {{ label }}
+                        </label>
+                    {% endfor %}
                 </div>
             </div>
 
-            <!-- Submit Button -->
-            <div class="form-row">
-                <div class="col-auto">
-                    <button type="submit" name="action" value="create" class="btn btn-primary mb-2">Save</button>
-                </div>
+            <!-- Submit Buttons -->
+            <div class="actions">
+                <button type="submit" name="action" value="create" class="btn btn-primary">Save</button>
                 {% if transaction %}
-                <div class="col-auto">
-                    <button type="submit" name="action" value="delete" class="btn btn-danger mb-2">Delete</button>
-                </div>
-                <div class="col-auto">
-                    <button type="submit" name="action" value="clear" class="btn btn-secondary mb-2">Clear</button>
-                </div>
+                <button type="submit" name="action" value="delete" class="btn btn-danger">Delete</button>
+                <button type="submit" name="action" value="clear" class="btn btn-secondary">Clear</button>
                 {% endif %}
             </div>
         </form>
     </div>
-    <div class="col-md-6">
+    <div>
     {% if created_transaction %}
         {% include 'api/components/transaction-success.html' %}
     {% endif %}

--- a/ledger/templates/api/entry_forms/transaction-link-form.html
+++ b/ledger/templates/api/entry_forms/transaction-link-form.html
@@ -11,9 +11,5 @@
 
     {{ link_form }}
 
-    <div class="row">
-        <div class="col-12">
-            <input type="submit" value="Link" class="btn btn-primary mt-3" />
-        </div>
-    </div>
+    <input type="submit" value="Link" class="btn btn-primary mt-3" />
 </form>

--- a/ledger/templates/api/entry_forms/upload-form.html
+++ b/ledger/templates/api/entry_forms/upload-form.html
@@ -1,40 +1,30 @@
 {% load humanize %}
 
-<div class="row">
-    <div class="col">
-        <h3>Upload transaction CSVs</h3>
-        <form
-            method="post"
-            enctype="multipart/form-data"
-            hx-post="{% url 'upload-transactions' %}"
-            hx-target="#csv-upload"
-            hx-trigger="submit"
-        >
-        {% csrf_token %}
-            <!-- Render the 'transaction_csv' field -->
-            <div class="mb-3">
-                <input type="file" name="transaction_csv" id="id_transaction_csv" class="form-control-file">
-            </div>
-            <!-- Render the 'account' field -->
-            <div class="mb-3">
-                <select name="account" id="id_account" class="form-control">
-                    {% for account in form.account.field.queryset %}
-                        <option value="{{ account.pk }}">{{ account }}</option>
-                    {% endfor %}
-                </select>
-            </div>
+<h3 class="card-title mb-3">Upload transaction CSVs</h3>
+<form
+    method="post"
+    enctype="multipart/form-data"
+    hx-post="{% url 'upload-transactions' %}"
+    hx-target="#csv-upload"
+    hx-trigger="submit"
+>
+{% csrf_token %}
+    <div class="field">
+        <input type="file" name="transaction_csv" id="id_transaction_csv" class="file-input">
+    </div>
+    <div class="field">
+        <select name="account" id="id_account" class="select">
+            {% for account in form.account.field.queryset %}
+                <option value="{{ account.pk }}">{{ account }}</option>
+            {% endfor %}
+        </select>
+    </div>
 
-            <button type="submit" name="transactions" class="btn btn-primary">Submit</button>
-        </form>
-    </div>
-</div>
-<br>
+    <button type="submit" name="transactions" class="btn btn-primary">Submit</button>
+</form>
+
 {% if count %}
-<div class="row">
-    <div class="col">
-        <div class="alert alert-success" role="alert">
-            Uploaded {{ count }} transactions to {{ account.name }}
-        </div>
-    </div>
+<div class="alert alert-success mt-3" role="alert">
+    Uploaded {{ count }} transactions to {{ account.name }}
 </div>
 {% endif %}

--- a/ledger/templates/api/entry_forms/wallet-form.html
+++ b/ledger/templates/api/entry_forms/wallet-form.html
@@ -1,83 +1,63 @@
-<div class="row">
-    <div class="col-md-6">
-        <form method="post" hx-post="/" hx-swap="innerHTML" hx-target="#form-block" class="form-group">
-            {% csrf_token %}
+<form method="post" hx-post="/" hx-swap="innerHTML" hx-target="#form-block" class="page-narrow">
+    {% csrf_token %}
 
-            <!-- Date Field -->
-            <div class="form-group">
-                <input type="date" name="{{ form.date.html_name }}" id="{{ form.date.id_for_label }}"
-                    class="form-control"
-                    value="{{ form.date.value|date:'Y-m-d' }}"
-                    placeholder="{{ form.date.label }}">
-                {% for error in form.date.errors %}
-                    <div class="alert alert-danger">{{ error }}</div>
-                {% endfor %}
-            </div>
-
-            <!-- Amount Field -->
-            <div class="form-group">
-                <div class="input-group">
-                    <div class="input-group-prepend">
-                        <span class="input-group-text">$</span>
-                    </div>
-                    <input type="text" name="{{ form.amount.html_name }}" id="{{ form.amount.id_for_label }}"
-                        class="form-control"
-                        value="{{ form.amount.value|default_if_none:'' }}"
-                        placeholder="{{ form.amount.label }}"
-                        autofocus
-                    >
-                </div>
-                {% for error in form.amount.errors %}
-                    <div class="alert alert-danger">{{ error }}</div>
-                {% endfor %}
-            </div>
-
-            <!-- Description Field -->
-            <div class="form-group">
-                <input type="text" name="{{ form.description.html_name }}" id="{{ form.description.id_for_label }}"
-                    class="form-control"
-                    value="{{ form.description.value|default_if_none:'' }}"
-                    placeholder="{{ form.description.label }}">
-                {% for error in form.description.errors %}
-                    <div class="alert alert-danger">{{ error }}</div>
-                {% endfor %}
-            </div>
-
-            <!-- Suggested Account Field -->
-            <div class="form-group">
-                <input
-                    class="form-control"
-                    list="accountOptions"
-                    name="suggested_account"
-                    id="id_suggested_account"
-                >
-                    <datalist id="accountOptions">
-                        {% for value, text in form.suggested_account.field.choices %}
-                            <option value="{{ text }}">
-                        {% endfor %}
-                    </datalist>
-                </input>
-            </div>
-
-
-            <!-- Type Field -->
-            <div class="form-group">
-                <!-- Button Group Styled Radio Buttons -->
-                <div class="btn-group btn-group-toggle" data-toggle="buttons">
-                    {% for value, label in form.type.field.choices %}
-                        <label class="btn btn-outline-primary {% if form.type.value == value %}active{% endif %}">
-                            <input type="radio" name="{{ form.type.html_name }}" id="id_type_{{ value }}" value="{{ value }}" {% if form.type.value == value %}checked{% endif %} autocomplete="off">
-                            {{ label }}
-                        </label>
-                    {% endfor %}
-                </div>
-                {% for error in form.type.errors %}
-                    <div class="alert alert-danger">{{ error }}</div>
-                {% endfor %}
-            </div>
-
-            <!-- Submit Button -->
-            <button type="submit" class="btn btn-primary">Save</button>
-        </form>
+    <!-- Date Field -->
+    <div class="field">
+        <label class="label" for="{{ form.date.id_for_label }}">{{ form.date.label }}</label>
+        <input type="date" name="{{ form.date.html_name }}" id="{{ form.date.id_for_label }}"
+            class="input"
+            value="{{ form.date.value|date:'Y-m-d' }}"
+            placeholder="{{ form.date.label }}">
+        {% for error in form.date.errors %}<div class="field-error">{{ error }}</div>{% endfor %}
     </div>
-</div>
+
+    <!-- Amount Field -->
+    <div class="field">
+        <label class="label" for="{{ form.amount.id_for_label }}">{{ form.amount.label }}</label>
+        <div class="field-currency">
+            <span class="prefix">$</span>
+            <input type="text" name="{{ form.amount.html_name }}" id="{{ form.amount.id_for_label }}"
+                class="input"
+                value="{{ form.amount.value|default_if_none:'' }}"
+                placeholder="{{ form.amount.label }}"
+                autofocus>
+        </div>
+        {% for error in form.amount.errors %}<div class="field-error">{{ error }}</div>{% endfor %}
+    </div>
+
+    <!-- Description Field -->
+    <div class="field">
+        <label class="label" for="{{ form.description.id_for_label }}">{{ form.description.label }}</label>
+        <input type="text" name="{{ form.description.html_name }}" id="{{ form.description.id_for_label }}"
+            class="input"
+            value="{{ form.description.value|default_if_none:'' }}"
+            placeholder="{{ form.description.label }}">
+        {% for error in form.description.errors %}<div class="field-error">{{ error }}</div>{% endfor %}
+    </div>
+
+    <!-- Suggested Account Field -->
+    <div class="field">
+        <label class="label" for="id_suggested_account">Suggested Account</label>
+        <input class="input" list="accountOptions" name="suggested_account" id="id_suggested_account">
+        <datalist id="accountOptions">
+            {% for value, text in form.suggested_account.field.choices %}
+                <option value="{{ text }}">
+            {% endfor %}
+        </datalist>
+    </div>
+
+    <!-- Type Field (segmented radio group) -->
+    <div class="field">
+        <div class="segmented">
+            {% for value, label in form.type.field.choices %}
+                <label>
+                    <input type="radio" name="{{ form.type.html_name }}" id="id_type_{{ value }}" value="{{ value }}" {% if form.type.value == value %}checked{% endif %} autocomplete="off">
+                    {{ label }}
+                </label>
+            {% endfor %}
+        </div>
+        {% for error in form.type.errors %}<div class="field-error">{{ error }}</div>{% endfor %}
+    </div>
+
+    <button type="submit" class="btn btn-primary">Save</button>
+</form>

--- a/ledger/templates/api/filter_forms/from-to-date-form.html
+++ b/ledger/templates/api/filter_forms/from-to-date-form.html
@@ -4,35 +4,27 @@
     hx-get="{{ get_url }}"
     hx-target="#container"
     hx-trigger="submit"
-    class="mb-3 form-sm"
 >
-    <div class="row">
+    <div class="filter-bar">
         {% if statement_type != 'balance' %}
-        <!-- Date From Field -->
-        <div class="col-md-2">
-            <div class="form-group">
-                <input type="date" name="{{ filter_form.date_from.html_name }}" id="{{ filter_form.date_from.auto_id }}" class="form-control"
-                       value="{{ filter_form.date_from.value|default_if_none:'' }}" placeholder="Start Date">
-            </div>
+        <div class="field fw-date">
+            <label class="label" for="{{ filter_form.date_from.auto_id }}">Start Date</label>
+            <input type="date" name="{{ filter_form.date_from.html_name }}" id="{{ filter_form.date_from.auto_id }}" class="input"
+                   value="{{ filter_form.date_from.value|default_if_none:'' }}">
         </div>
         {% else %}
-                <input hidden="true" type="date" name="{{ filter_form.date_from.html_name }}" id="{{ filter_form.date_from.auto_id }}" class="form-control"
-                       value="{{ filter_form.date_from.value|default_if_none:'' }}" placeholder="Start Date">
+            <input hidden="true" type="date" name="{{ filter_form.date_from.html_name }}" id="{{ filter_form.date_from.auto_id }}"
+                   value="{{ filter_form.date_from.value|default_if_none:'' }}">
         {% endif %}
 
-        <!-- Date To Field -->
-        <div class="col-md-2">
-            <div class="form-group">
-                <input type="date" name="{{ filter_form.date_to.html_name }}" id="{{ filter_form.date_to.auto_id }}" class="form-control"
-                       value="{{ filter_form.date_to.value|default_if_none:'' }}" placeholder="End Date">
-            </div>
+        <div class="field fw-date">
+            <label class="label" for="{{ filter_form.date_to.auto_id }}">End Date</label>
+            <input type="date" name="{{ filter_form.date_to.html_name }}" id="{{ filter_form.date_to.auto_id }}" class="input"
+                   value="{{ filter_form.date_to.value|default_if_none:'' }}">
         </div>
 
-        <div class="col-md-2">
-            <!-- Submit Button -->
-            <div class="form-group">
-                <button type="submit" class="btn btn-primary">Filter</button>
-            </div>
+        <div class="fw-auto">
+            <button type="submit" class="btn btn-primary">Filter</button>
         </div>
     </div>
 </form>

--- a/ledger/templates/api/filter_forms/reconciliation-filter-form.html
+++ b/ledger/templates/api/filter_forms/reconciliation-filter-form.html
@@ -1,31 +1,23 @@
 <form
     id="reconciliation-filter-form"
     method="get"
-    class="form-sm"
     hx-get="{% url 'reconciliation-table' %}"
     hx-target="#table-and-form"
-    hx-tigger="submit"
+    hx-trigger="submit"
 >
     <!-- CSRF token is not required for GET requests -->
-    <div class="row">
-        <!-- Date Field -->
-        <div class="col-md-2">
-            <div class="form-group">
-                <label for="id_date">Date</label>
-                <select name="date" id="id_date" class="form-control">
-                    {% for option in filter_form.date %}
-                        {{ option }}
-                    {% endfor %}
-                </select>
-            </div>
+    <div class="filter-bar">
+        <div class="field fw-narrow">
+            <label class="label" for="id_date">Date</label>
+            <select name="date" id="id_date" class="select">
+                {% for option in filter_form.date %}
+                    {{ option }}
+                {% endfor %}
+            </select>
         </div>
 
-        <!-- Submit Button -->
-        <div class="col-md-2">
-            <div class="form-group">
-                <label>&nbsp;</label> <!-- Empty label for alignment -->
-                <button type="submit" class="btn btn-primary form-control">Filter</button>
-            </div>
+        <div class="fw-auto">
+            <button type="submit" class="btn btn-primary">Filter</button>
         </div>
     </div>
 </form>

--- a/ledger/templates/api/filter_forms/search-filter-form.html
+++ b/ledger/templates/api/filter_forms/search-filter-form.html
@@ -5,50 +5,40 @@
     hx-target="#search-content"
     hx-trigger="submit"
     hx-swap="innerHTML"
-    class="mb-3 form-sm"
 >
-    <div class="row g-3">
-        <!-- Description -->
-        <div class="col-md-2">
-            <div class="form-group">
-                <label for="id_description">Description</label>
-                <input type="text" name="description" id="id_description" class="form-control"
-                       value="{{ form.description.value|default_if_none:'' }}">
-            </div>
+    <div class="filter-bar">
+        <div class="field fw-wide">
+            <label class="label" for="id_description">Description</label>
+            <input type="text" name="description" id="id_description" class="input"
+                   value="{{ form.description.value|default_if_none:'' }}">
         </div>
 
-        <!-- Date From and Date To -->
-        <div class="col-md-2">
-            <div class="form-group">
-                <label for="id_date_from">Date From</label>
-                <input type="date" name="date_from" id="id_date_from" class="form-control"
+        <div class="filter-col">
+            <div class="field">
+                <label class="label" for="id_date_from">Date From</label>
+                <input type="date" name="date_from" id="id_date_from" class="input"
                        value="{{ form.date_from.value|default_if_none:'' }}">
             </div>
-            <div class="form-group">
-                <label for="id_date_to">Date To</label>
-                <input type="date" name="date_to" id="id_date_to" class="form-control"
+            <div class="field">
+                <label class="label" for="id_date_to">Date To</label>
+                <input type="date" name="date_to" id="id_date_to" class="input"
                        value="{{ form.date_to.value|default_if_none:'' }}">
             </div>
         </div>
 
-        <!-- Transaction Account -->
-        <div class="col-md-3">
+        <div>
             {% include "api/components/typeahead-multiselect.html" with field=form.account label="Account" all_label="All accounts" %}
         </div>
 
-        <!-- Related Account -->
-        <div class="col-md-3">
+        <div>
             {% include "api/components/typeahead-multiselect.html" with field=form.related_account label="Related Account" all_label="All accounts" %}
         </div>
 
-        <!-- Type -->
-        <div class="col-md-2">
+        <div>
             {% include "api/components/typeahead-multiselect.html" with field=form.transaction_type label="Type" all_label="All types" %}
         </div>
-    </div>
 
-    <div class="row mt-2">
-        <div class="col">
+        <div class="fw-auto">
             <button type="submit" class="btn btn-primary">Search</button>
         </div>
     </div>

--- a/ledger/templates/api/filter_forms/tax-charge-filter-form.html
+++ b/ledger/templates/api/filter_forms/tax-charge-filter-form.html
@@ -1,55 +1,41 @@
 <form
     id="taxes-filter-form"
     method="get"
-    class="form-sm"
     hx-get="{% url 'tax-charge-table' %}"
     hx-target="#table-and-form"
-    hx-tigger="submit"
+    hx-trigger="submit"
 >
     <!-- CSRF token is not required for GET requests -->
-    <div class="row">
-        <!-- Date From Field -->
-        <div class="col-md-2">
-            <div class="form-group">
-                <label for="id_date_from">Date From</label>
-                <select name="date_from" id="id_date_from" class="form-control" value="{{ filter_form.date_from.value }}">
-                    {% for option in filter_form.date_from %}
-                        {{ option }}
-                    {% endfor %}
-                </select>
-            </div>
+    <div class="filter-bar">
+        <div class="field fw-date">
+            <label class="label" for="id_date_from">Date From</label>
+            <select name="date_from" id="id_date_from" class="select">
+                {% for option in filter_form.date_from %}
+                    {{ option }}
+                {% endfor %}
+            </select>
         </div>
 
-        <!-- Date To Field -->
-        <div class="col-md-2">
-            <div class="form-group">
-                <label for="id_date_to">Date To</label>
-                <select name="date_to" id="id_date_to" class="form-control">
-                    {% for option in filter_form.date_to %}
-                        {{ option }}
-                    {% endfor %}
-                </select>
-            </div>
+        <div class="field fw-date">
+            <label class="label" for="id_date_to">Date To</label>
+            <select name="date_to" id="id_date_to" class="select">
+                {% for option in filter_form.date_to %}
+                    {{ option }}
+                {% endfor %}
+            </select>
         </div>
 
-        <!-- Type Field -->
-        <div class="col-md-2">
-            <div class="form-group">
-                <label for="id_tax_type">Type</label>
-                <select name="tax_type" id="id_tax_type" class="form-control">
-                    {% for option in filter_form.tax_type %}
-                        {{ option }}
-                    {% endfor %}
-                </select>
-            </div>
+        <div class="field">
+            <label class="label" for="id_tax_type">Type</label>
+            <select name="tax_type" id="id_tax_type" class="select">
+                {% for option in filter_form.tax_type %}
+                    {{ option }}
+                {% endfor %}
+            </select>
         </div>
 
-        <!-- Submit Button -->
-        <div class="col-md-2">
-            <div class="form-group">
-                <label>&nbsp;</label> <!-- Empty label for alignment -->
-                <button type="submit" class="btn btn-primary form-control">Filter</button>
-            </div>
+        <div class="fw-auto">
+            <button type="submit" class="btn btn-primary">Filter</button>
         </div>
     </div>
 </form>

--- a/ledger/templates/api/filter_forms/transactions-filter-form.html
+++ b/ledger/templates/api/filter_forms/transactions-filter-form.html
@@ -5,50 +5,42 @@
     hx-target="#table-and-form"
     hx-trigger="submit"
     hx-swap="outerHTML"
-    class="mb-3 form-sm"
 >
-    <details open>
-        <summary class="mb-2" style="cursor: pointer;"><strong>Filters</strong></summary>
-    <div class="row g-3">
-        <!-- Stacked Date From and Date To Fields -->
-        <div class="col-md-2">
-            <div class="form-group">
-                <label for="id_date_from">Date From</label>
-                <input type="date" name="{{ filter_form.date_from.html_name }}" id="{{ filter_form.date_from.auto_id }}" class="form-control"
+    <div class="filter-bar">
+        <div class="filter-col">
+            <div class="field">
+                <label class="label" for="id_date_from">Date From</label>
+                <input type="date" name="{{ filter_form.date_from.html_name }}" id="{{ filter_form.date_from.auto_id }}" class="input"
                        value="{{ filter_form.date_from.value|default_if_none:'' }}">
             </div>
-            <div class="form-group">
-                <label for="id_date_to">Date To</label>
-                <input type="date" name="{{ filter_form.date_to.html_name }}" id="{{ filter_form.date_to.auto_id }}" class="form-control"
+            <div class="field">
+                <label class="label" for="id_date_to">Date To</label>
+                <input type="date" name="{{ filter_form.date_to.html_name }}" id="{{ filter_form.date_to.auto_id }}" class="input"
                        value="{{ filter_form.date_to.value|default_if_none:'' }}">
             </div>
         </div>
 
-        <!-- Stacked Account and Related Account Fields -->
-        <div class="col-md-3">
+        <div class="filter-col">
             {% include "api/components/typeahead-multiselect.html" with field=filter_form.account label="Account" all_label="All accounts" %}
             {% include "api/components/typeahead-multiselect.html" with field=filter_form.related_account label="Related Account" all_label="All accounts" %}
         </div>
 
-        <!-- Type Field -->
-        <div class="col-md-2">
+        <div>
             {% include "api/components/typeahead-multiselect.html" with field=filter_form.transaction_type label="Type" all_label="All types" %}
         </div>
 
-        <!-- Stacked Is Closed and Linked Fields -->
-        <div class="col-md-2">
-            <div class="form-group">
-                <label for="id_is_closed">Is Closed</label>
-                <select name="{{ filter_form.is_closed.html_name }}" id="{{ filter_form.is_closed.auto_id }}" class="form-control">
+        <div class="filter-col">
+            <div class="field">
+                <label class="label" for="id_is_closed">Is Closed</label>
+                <select name="{{ filter_form.is_closed.html_name }}" id="{{ filter_form.is_closed.auto_id }}" class="select">
                     {% for option in filter_form.is_closed %}
                         {{ option }}
                     {% endfor %}
                 </select>
             </div>
-
-            <div class="form-group">
-                <label for="id_has_linked_transaction">Linked</label>
-                <select name="{{ filter_form.has_linked_transaction.html_name }}" id="{{ filter_form.has_linked_transaction.auto_id }}" class="form-control">
+            <div class="field">
+                <label class="label" for="id_has_linked_transaction">Linked</label>
+                <select name="{{ filter_form.has_linked_transaction.html_name }}" id="{{ filter_form.has_linked_transaction.auto_id }}" class="select">
                     {% for option_value, option_label in filter_form.has_linked_transaction.field.choices %}
                         <option value="{{ option_value }}" {% if option_value == filter_form.has_linked_transaction.value %}selected{% endif %}>
                             {{ option_label }}
@@ -58,26 +50,20 @@
             </div>
         </div>
 
-        <!-- Submit + Rerun tag Button -->
-        <div class="col-md-3">
-            <div class="form-group">
-                <label>&nbsp;</label> <!-- Empty label for alignment (matches other filter forms) -->
-                <div>
-                    <button type="submit" class="btn btn-primary">Filter</button>
-                    <!-- New Button -->
-                    <button
-                        type="button"
-                        class="btn btn-secondary"
-                        hx-get="{% url 'trigger-autotag' %}"
-                        hx-trigger="click"
-                        hx-target="#autotag-success"
-                        hx-swap="innerHTML">
-                        Run Autotag
-                    </button>
-                    <div id="autotag-success"></div>
-                </div>
+        <div class="fw-auto">
+            <div class="actions">
+                <button type="submit" class="btn btn-primary">Filter</button>
+                <button
+                    type="button"
+                    class="btn btn-secondary"
+                    hx-get="{% url 'trigger-autotag' %}"
+                    hx-trigger="click"
+                    hx-target="#autotag-success"
+                    hx-swap="innerHTML">
+                    Run Autotag
+                </button>
             </div>
+            <div id="autotag-success"></div>
         </div>
     </div>
-    </details>
 </form>

--- a/ledger/templates/api/login.html
+++ b/ledger/templates/api/login.html
@@ -1,21 +1,24 @@
-<!DOCTYPE html>
+{% load static %}<!DOCTYPE html>
 <html lang="en">
 <head>
     <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>Login</title>
-    <!-- Add Bootstrap or other CSS frameworks if you want -->
+    <link rel="stylesheet" href="{% static 'css/app.css' %}">
 </head>
 <body>
-    <div class="container">
-        <h2>Login</h2>
-        <form method="post">
-            {% csrf_token %}
-            {{ form.as_p }}
-            <button type="submit">Login</button>
-        </form>
-        {% if form.errors %}
-            <p>Your username and password didn't match. Please try again.</p>
-        {% endif %}
+    <div class="page page-narrow">
+        <div class="card">
+            <h2>Login</h2>
+            <form method="post">
+                {% csrf_token %}
+                {{ form.as_p }}
+                <button type="submit" class="btn btn-primary">Login</button>
+            </form>
+            {% if form.errors %}
+                <p class="text-danger small mt-3">Your username and password didn't match. Please try again.</p>
+            {% endif %}
+        </div>
     </div>
 </body>
 </html>

--- a/ledger/templates/api/tables/amortization-table.html
+++ b/ledger/templates/api/tables/amortization-table.html
@@ -1,43 +1,39 @@
 {% load humanize %}
 {% if amortizations %}
-<h4>Open Schedules</h4>
-<div class="row">
-    <div class="col-md-12">
-        <div id="amortization-table" class="table-responsive">
-            <table class="table table-hover table-sm">
-                <thead>
-                    <tr class="clickable-row">
-                        <th style="position: sticky; top: 0; background: white; z-index: 10;">Type</th>
-                        <th style="position: sticky; top: 0; background: white; z-index: 10;">Date</th>
-                        <th style="position: sticky; top: 0; background: white; z-index: 10;">Expense Account</th>
-                        <th style="position: sticky; top: 0; background: white; z-index: 10;">Description</th>
-                        <th style="position: sticky; top: 0; background: white; z-index: 10;">Amount (Remaining)</th>
-                        <th style="position: sticky; top: 0; background: white; z-index: 10;">Salvage</th>
-                        <th style="position: sticky; top: 0; background: white; z-index: 10;">Periods (Remaining)</th>
-                        <th style="position: sticky; top: 0; background: white; z-index: 10;">Latest Entry</th>
-                    </tr>
-                </thead>
-                <tbody>
-                    {% for amortization in amortizations %}
-                    <tr
-                        class="clickable-row"
-                        hx-get="{% url 'amortize-form' amortization.id %}"
-                        hx-target="#amortize-form"
-                    >
-                        <td>{% if amortization.is_depreciation %}Depreciation{% else %}Amortization{% endif %}</td>
-                        <td>{{ amortization.accrued_journal_entry_item.journal_entry.transaction.date }}</td>
-                        <td>{{ amortization.suggested_account }}</td>
-                        <td>{{ amortization.description }}</td>
-                        <td>${{ amortization.amount|floatformat:2|intcomma }} (${{ amortization.remaining_balance|floatformat:2|intcomma }})</td>
-                        <td>{% if amortization.is_depreciation %}${{ amortization.salvage_value|floatformat:2|intcomma }}{% else %}—{% endif %}</td>
-                        <td>{{ amortization.periods }} ({{ amortization.remaining_periods }})</td>
-                        <td>{{ amortization.latest_transaction_date }}</td>
-                    </tr>
-                    {% endfor %}
-                </tbody>
-            </table>
-        </div>
-    </div>
+<h4 class="card-title mb-3">Open Schedules</h4>
+<div id="amortization-table" class="table-scroll">
+    <table class="table">
+        <thead>
+            <tr>
+                <th>Type</th>
+                <th>Date</th>
+                <th>Expense Account</th>
+                <th>Description</th>
+                <th>Amount (Remaining)</th>
+                <th>Salvage</th>
+                <th>Periods (Remaining)</th>
+                <th>Latest Entry</th>
+            </tr>
+        </thead>
+        <tbody>
+            {% for amortization in amortizations %}
+            <tr
+                class="clickable-row"
+                hx-get="{% url 'amortize-form' amortization.id %}"
+                hx-target="#amortize-form"
+            >
+                <td class="td-name">{% if amortization.is_depreciation %}Depreciation{% else %}Amortization{% endif %}</td>
+                <td>{{ amortization.accrued_journal_entry_item.journal_entry.transaction.date }}</td>
+                <td>{{ amortization.suggested_account }}</td>
+                <td>{{ amortization.description }}</td>
+                <td>${{ amortization.amount|floatformat:2|intcomma }} (${{ amortization.remaining_balance|floatformat:2|intcomma }})</td>
+                <td>{% if amortization.is_depreciation %}${{ amortization.salvage_value|floatformat:2|intcomma }}{% else %}—{% endif %}</td>
+                <td>{{ amortization.periods }} ({{ amortization.remaining_periods }})</td>
+                <td>{{ amortization.latest_transaction_date }}</td>
+            </tr>
+            {% endfor %}
+        </tbody>
+    </table>
 </div>
 
 {% block extra_js %}

--- a/ledger/templates/api/tables/entity-balances-grouped.html
+++ b/ledger/templates/api/tables/entity-balances-grouped.html
@@ -1,9 +1,9 @@
 {% load humanize %}
-<div class="d-flex justify-content-end mb-2">
+<div class="flex justify-end mb-2">
     <a href="#"
        hx-get="{% url 'entity-balances' %}?hide_zero={% if hide_zero %}0{% else %}1{% endif %}"
        hx-target="#balances-table"
-       style="font-size:.75rem; text-decoration:none;">
+       class="small">
         {% if hide_zero %}
             <i class="bi bi-eye"></i> Show zero balances
         {% else %}
@@ -12,32 +12,30 @@
     </a>
 </div>
 
-<div class="row no-gutters">
-    <div class="col-md-6 pr-2">
+<div class="grid grid-2">
+    <div>
         {% for group in grouped_balances %}
-            <div class="group-section mb-3">
-                <div class="group-header d-flex align-items-baseline justify-content-between">
+            <div class="mb-3">
+                <div class="flex-between items-baseline mb-2">
                     <div>
                         {{ group.account_name }}
                         {% if group.zero_count %}
-                            <span class="text-secondary ml-2" style="font-size:.7rem; font-weight:normal;">
-                                {{ group.zero_count }} hidden
-                            </span>
+                            <span class="text-secondary small">{{ group.zero_count }} hidden</span>
                         {% endif %}
                     </div>
-                    <div class="text-secondary" style="font-size:.7rem;">
+                    <div class="text-secondary small">
                         Net ${{ group.net_balance|floatformat:2|intcomma }}
                     </div>
                 </div>
                 {% if group.rows %}
-                    <div class="table-responsive">
-                        <table class="table table-hover table-sm mb-0">
+                    <div class="table-scroll">
+                        <table class="table">
                             <thead>
                                 <tr>
                                     <th>Entity Name</th>
-                                    <th class="text-right">Total Debits</th>
-                                    <th class="text-right">Total Credits</th>
-                                    <th class="text-right">Balance</th>
+                                    <th class="right">Total Debits</th>
+                                    <th class="right">Total Credits</th>
+                                    <th class="right">Balance</th>
                                 </tr>
                             </thead>
                             <tbody>
@@ -45,13 +43,10 @@
                                     <tr class="clickable-row"
                                         hx-get="{% url 'entity-history' row.entity_id %}?account={{ row.account_id }}"
                                         hx-target="#history-table">
-                                        <td>{{ row.entity_name }}</td>
-                                        <td class="text-right">${{ row.total_debits|floatformat:2|intcomma }}</td>
-                                        <td class="text-right">${{ row.total_credits|floatformat:2|intcomma }}</td>
-                                        <td class="text-right
-                                            {% if row.balance > 0 %}text-success
-                                            {% elif row.balance < 0 %}text-danger
-                                            {% else %}text-muted{% endif %}">
+                                        <td class="td-name">{{ row.entity_name }}</td>
+                                        <td class="right">${{ row.total_debits|floatformat:2|intcomma }}</td>
+                                        <td class="right">${{ row.total_credits|floatformat:2|intcomma }}</td>
+                                        <td class="right {% if row.balance > 0 %}text-success{% elif row.balance < 0 %}text-danger{% else %}text-muted{% endif %}">
                                             ${{ row.balance|floatformat:2|intcomma }}
                                         </td>
                                     </tr>
@@ -63,12 +58,12 @@
             </div>
         {% endfor %}
     </div>
-    <div class="col-md-6 pl-2" style="border-left:1px solid #dee2e6;">
-        <div id="history-table" style="position:sticky; top:1rem;">
+    <div>
+        <div id="history-table" class="sticky-pane">
             {% if entity_history_table %}
                 {{ entity_history_table }}
             {% else %}
-                <div class="text-muted text-center" style="padding-top:3rem; font-size:.75rem;">
+                <div class="text-muted text-center small" style="padding-top:3rem;">
                     Select an entity to see its transaction history.
                 </div>
             {% endif %}

--- a/ledger/templates/api/tables/entity-balances-table.html
+++ b/ledger/templates/api/tables/entity-balances-table.html
@@ -1,13 +1,9 @@
 {% load humanize %}
-<div class="row">
-    <div class="col-md-12">
-        <h4>Balances</h4>
-    </div>
-</div>
-<div class="row">
-    <div class="col-md-6">
-        <div id="entity-balances-table" class="table-responsive">
-            <table class="table table-hover table-sm">
+<h4 class="card-title mb-3">Balances</h4>
+<div class="grid grid-2">
+    <div>
+        <div id="entity-balances-table" class="table-scroll">
+            <table class="table">
                 <thead>
                     <tr>
                         <th>Entity Name</th>
@@ -19,15 +15,11 @@
                 <tbody>
                     {% for balance in entities_balances %}
                         <tr
-                            {% if balance.entity__name == preselected_entity.name %}
-                                class="clickable-row table-active"
-                            {% else %}
-                                class="clickable-row"
-                            {% endif %}
+                            class="clickable-row{% if balance.entity__name == preselected_entity.name %} table-active{% endif %}"
                             hx-get="{% url 'entity-history' balance.entity__id %}"
-                            hx-target="#history-table" 
+                            hx-target="#history-table"
                         >
-                            <td>{{ balance.entity__name }}</td>
+                            <td class="td-name">{{ balance.entity__name }}</td>
                             <td>${{ balance.total_debits|floatformat:2|intcomma }}</td>
                             <td>${{ balance.total_credits|floatformat:2|intcomma }}</td>
                             <td>${{ balance.balance|floatformat:2|intcomma }}</td>
@@ -37,7 +29,7 @@
             </table>
         </div>
     </div>
-    <div class="col-md-6">
+    <div>
         <div id="history-table">
             {{ entity_history_table }}
         </div>

--- a/ledger/templates/api/tables/entity-history-table.html
+++ b/ledger/templates/api/tables/entity-history-table.html
@@ -1,12 +1,10 @@
 {% load humanize %}
 {% if entity_name %}
-    <div class="d-flex align-items-baseline justify-content-between mb-1">
+    <div class="flex-between items-baseline mb-2">
         <div>
             <strong>{{ entity_name }}</strong>
             {% if account_name %}
-                <span class="text-secondary ml-1" style="font-size:.75rem;">
-                    · {{ account_name }}
-                </span>
+                <span class="text-secondary small">· {{ account_name }}</span>
             {% endif %}
         </div>
         {% if final_balance is not None %}
@@ -16,15 +14,15 @@
         {% endif %}
     </div>
 {% endif %}
-<div id="entity-history-table" class="table-responsive" style="max-height:520px; overflow-y:auto;">
-    <table class="table table-hover table-sm mb-0">
+<div id="entity-history-table" class="table-scroll" style="max-height:520px;">
+    <table class="table">
         <thead>
             <tr>
-                <th style="position:sticky; top:0; background:#fff; box-shadow:inset 0 -1px 0 #dee2e6;">Date</th>
-                <th style="position:sticky; top:0; background:#fff; box-shadow:inset 0 -1px 0 #dee2e6;">Transaction</th>
-                <th class="text-right" style="position:sticky; top:0; background:#fff; box-shadow:inset 0 -1px 0 #dee2e6;">Amount</th>
-                <th class="text-right" style="position:sticky; top:0; background:#fff; box-shadow:inset 0 -1px 0 #dee2e6;">Balance</th>
-                <th style="position:sticky; top:0; background:#fff; box-shadow:inset 0 -1px 0 #dee2e6;"></th>
+                <th>Date</th>
+                <th>Transaction</th>
+                <th class="right">Amount</th>
+                <th class="right">Balance</th>
+                <th></th>
             </tr>
         </thead>
         <tbody>
@@ -32,16 +30,15 @@
                 <tr id="row-{{ entry.id }}">
                     <td>{{ entry.journal_entry.date }}</td>
                     <td>{{ entry.journal_entry.transaction.description|slice:":24" }}{% if entry.journal_entry.transaction.description|length > 24 %}...{% endif %}</td>
-                    <td class="text-right{% if entry.type == 'debit' %} text-danger{% endif %}">
+                    <td class="right{% if entry.type == 'debit' %} text-danger{% endif %}">
                         {% if entry.type == "debit" %}-{% endif %}${{ entry.amount|floatformat:2|intcomma }}
                     </td>
-                    <td class="text-right {% if entry.balance > 0 %}text-success{% elif entry.balance < 0 %}text-danger{% else %}text-muted{% endif %}">
+                    <td class="right {% if entry.balance > 0 %}text-success{% elif entry.balance < 0 %}text-danger{% else %}text-muted{% endif %}">
                         ${{ entry.balance|floatformat:2|intcomma }}
                     </td>
                     <td>
                         <button
-                            class="btn btn-outline-secondary btn-sm"
-                            style="padding:.05rem .3rem; font-size:.7rem;"
+                            class="btn btn-secondary btn-sm"
                             hx-post="{% url 'untag-journal-entry' entry.id %}"
                             hx-target="#table-and-form"
                             hx-swap="outerHTML">

--- a/ledger/templates/api/tables/payables-receivables-table.html
+++ b/ledger/templates/api/tables/payables-receivables-table.html
@@ -1,33 +1,29 @@
 {% load humanize %}
-<div class="row">
-    <div class="col-md-12">
-        <div id="payables-receivables-table" class="table-responsive">
-            <table class="table table-hover table-sm">
-                <thead>
-                    <tr class="clickable-row">
-                        <th style="position: sticky; top: 0; background: white; z-index: 10;">Date</th>
-                        <th style="position: sticky; top: 0; background: white; z-index: 10;">Entry Type</th>
-                        <th style="position: sticky; top: 0; background: white; z-index: 10;">Amount</th>
-                        <th style="position: sticky; top: 0; background: white; z-index: 10;">Description</th>
-                    </tr>
-                </thead>
-                <tbody>
-                    {% for payable_receivable in payables_receivables %}
-                    <tr
-                        class="clickable-row{% if forloop.first %} table-active{% endif %}"
-                        hx-get="{% url 'tag-entities-form' payable_receivable.pk %}"
-                        hx-target="#form"
-                    >
-                        <td>{{ payable_receivable.journal_entry.transaction.date }}</td>
-                        <td>{{ payable_receivable.type }}</td>
-                        <td>{{ payable_receivable.amount }}</td>
-                        <td>{{ payable_receivable.journal_entry.transaction.description }}</td>
-                    </tr>
-                    {% endfor %}
-                </tbody>
-            </table>
-        </div>
-    </div>
+<div id="payables-receivables-table" class="table-scroll">
+    <table class="table">
+        <thead>
+            <tr>
+                <th>Date</th>
+                <th>Entry Type</th>
+                <th>Amount</th>
+                <th>Description</th>
+            </tr>
+        </thead>
+        <tbody>
+            {% for payable_receivable in payables_receivables %}
+            <tr
+                class="clickable-row{% if forloop.first %} table-active{% endif %}"
+                hx-get="{% url 'tag-entities-form' payable_receivable.pk %}"
+                hx-target="#form"
+            >
+                <td class="td-name">{{ payable_receivable.journal_entry.transaction.date }}</td>
+                <td>{{ payable_receivable.type }}</td>
+                <td>{{ payable_receivable.amount }}</td>
+                <td>{{ payable_receivable.journal_entry.transaction.description }}</td>
+            </tr>
+            {% endfor %}
+        </tbody>
+    </table>
 </div>
 
 {% block extra_js %}

--- a/ledger/templates/api/tables/paystub-detail.html
+++ b/ledger/templates/api/tables/paystub-detail.html
@@ -1,18 +1,18 @@
 {% load humanize %}
 {% if paystub_values %}
-<table class="table table-sm mb-2" style="background: transparent;">
+<table class="table mb-2" style="background: transparent;">
     <thead>
         <tr>
             <th>Account</th>
-            <th style="text-align: right;">Value</th>
+            <th class="right">Value</th>
             <th>Type</th>
         </tr>
     </thead>
     <tbody>
         {% for paystub_value in paystub_values %}
         <tr>
-            <td>{{ paystub_value.account }}</td>
-            <td style="text-align: right;">${{ paystub_value.amount }}</td>
+            <td class="td-name">{{ paystub_value.account }}</td>
+            <td class="right">${{ paystub_value.amount }}</td>
             <td>{{ paystub_value.journal_entry_item_type }}</td>
         </tr>
         {% endfor %}
@@ -20,7 +20,7 @@
 </table>
 
 {% if show_fill_button %}
-<div class="d-flex justify-content-end">
+<div class="flex justify-end">
     <button
         @click="fillPaystub({{ paystub_id }})"
         x-bind:disabled="!selectedRowId"

--- a/ledger/templates/api/tables/paystubs-table-poller.html
+++ b/ledger/templates/api/tables/paystubs-table-poller.html
@@ -2,9 +2,8 @@
      hx-get="{% url 'paystub-table' %}"
      {% if has_active_jobs %}hx-trigger="every 2s"{% endif %}
      hx-swap="outerHTML">
-    <br>
-    <h5>Paystubs</h5>
-    <table class="table table-sm">
+    <h5 class="card-title mt-4 mb-3">Paystubs</h5>
+    <table class="table">
         <thead>
             <tr>
                 <th>File</th>
@@ -14,18 +13,20 @@
         <tbody>
             {% for s3file in pending_files %}
             <tr>
-                <td>{{ s3file.user_filename }}</td>
+                <td class="td-name">{{ s3file.user_filename }}</td>
                 <td>
                     {% if s3file.status == "PENDING" %}
                         <span class="text-muted">⏳ Queued</span>
                     {% elif s3file.status == "PROCESSING" %}
                         <span class="text-primary">⚙️ Sending to Gemini...</span>
                     {% elif s3file.status == "FAILED" %}
-                        <span class="text-danger" title="{{ s3file.error_message }}">❌ Failed — {{ s3file.short_error }}</span>
-                        <button type="button" class="btn btn-sm btn-outline-secondary ms-2"
-                                hx-post="{% url 'paystub-retry' s3file.id %}"
-                                hx-target="#paystubs-table-poller"
-                                hx-swap="outerHTML">↻ Retry</button>
+                        <span class="status-line">
+                            <span class="text-danger" title="{{ s3file.error_message }}">❌ Failed — {{ s3file.short_error }}</span>
+                            <button type="button" class="btn btn-secondary btn-sm"
+                                    hx-post="{% url 'paystub-retry' s3file.id %}"
+                                    hx-target="#paystubs-table-poller"
+                                    hx-swap="outerHTML">↻ Retry</button>
+                        </span>
                     {% endif %}
                 </td>
             </tr>

--- a/ledger/templates/api/tables/paystubs-table.html
+++ b/ledger/templates/api/tables/paystubs-table.html
@@ -1,23 +1,22 @@
 {% load humanize %}
 <div id="paystubs-table-wrapper">
     {% if paystubs %}
-    <div id="paystubs-table" class="table-responsive">
-        <table class="table table-hover table-sm" style="table-layout: fixed; width: 100%;">
+    <div id="paystubs-table" class="table-scroll table-scroll-lg">
+        <table class="table" style="table-layout: fixed; width: 100%;">
             <thead>
                 <tr>
-                    <th class="fixed-header" style="width: 45%;">Title</th>
-                    <th class="fixed-header" style="width: 55%;">Document</th>
+                    <th style="width: 45%;">Title</th>
+                    <th style="width: 55%;">Document</th>
                 </tr>
             </thead>
             <tbody>
                 {% for paystub in paystubs %}
                 <tr
                     class="clickable-row"
-                    style="cursor: pointer;"
                     @click="togglePaystub({{ paystub.id }}, '{% url 'paystub-detail' paystub.id %}{% if show_fill_button %}?show_fill_button=true{% endif %}')"
                 >
-                    <td class="transaction-column" title="{{ paystub.title }}">{{ paystub.title }}</td>
-                    <td class="transaction-column" title="{{ paystub.document.user_filename }}">{{ paystub.document.user_filename }}</td>
+                    <td class="cell-clip td-name" title="{{ paystub.title }}">{{ paystub.title }}</td>
+                    <td class="cell-clip" title="{{ paystub.document.user_filename }}">{{ paystub.document.user_filename }}</td>
                 </tr>
                 <tr x-show="expandedPaystubId === {{ paystub.id }}" x-cloak>
                     <td colspan="2" class="bg-light">
@@ -29,6 +28,6 @@
         </table>
     </div>
     {% else %}
-    <p class="text-muted"><small>No unlinked paystubs.</small></p>
+    <p class="text-muted small">No unlinked paystubs.</p>
     {% endif %}
 </div>

--- a/ledger/templates/api/tables/reconciliation-table.html
+++ b/ledger/templates/api/tables/reconciliation-table.html
@@ -1,18 +1,15 @@
 {% load humanize %}
-<div class="row">
-    <div class="col">
-    <form
-        method="post"
-        class="form-sm"
-        hx-post="{% url 'reconciliation' %}"
-        hx-target="#table-and-form"
-        hx-trigger="submit"
-        hx-include="#reconciliation-filter-form"
-    >
-        {% csrf_token %}
-        <div class="row">
-        <div class="col-md-6">
-            <table class="table table-sm">
+<form
+    method="post"
+    hx-post="{% url 'reconciliation' %}"
+    hx-target="#table-and-form"
+    hx-trigger="submit"
+    hx-include="#reconciliation-filter-form"
+>
+    {% csrf_token %}
+    <div class="grid grid-2">
+        <div>
+            <table class="table">
                 <thead>
                     <tr>
                         <th>Account</th>
@@ -26,18 +23,12 @@
                     {% for reconciliation, form in left_reconciliations %}
                         {{ form.id }}
                         <tr class="{% if reconciliation.current_balance != form.amount.value %}highlight-yellow{% endif %}">
-                            <td>{{ reconciliation.account }}</td>
+                            <td class="td-name">{{ reconciliation.account }}</td>
                             <td>${{ reconciliation.current_balance|floatformat:2|intcomma }}</td>
                             <td>
-                                <div class="form-row">
-                                    <div class="col">
-                                        <div class="input-group input-group-sm">
-                                            <div class="input-group-prepend">
-                                                <span class="input-group-text">$</span>
-                                            </div>
-                                            <input type="text" name="{{ form.amount.html_name }}" id="{{ form.amount.id_for_label }}" value="{{ form.amount.value|default_if_none:''|intcomma }}" class="form-control">
-                                        </div>
-                                    </div>
+                                <div class="field-currency">
+                                    <span class="prefix">$</span>
+                                    <input type="text" name="{{ form.amount.html_name }}" id="{{ form.amount.id_for_label }}" value="{{ form.amount.value|default_if_none:''|intcomma }}" class="input">
                                 </div>
                             </td>
                             <td>
@@ -48,8 +39,8 @@
                 </tbody>
             </table>
         </div>
-        <div class="col-md-6">
-            <table class="table table-sm">
+        <div>
+            <table class="table">
                 <thead>
                     <tr>
                         <th>Account</th>
@@ -63,18 +54,12 @@
                     {% for reconciliation, form in right_reconciliations %}
                         {{ form.id }}
                         <tr class="{% if reconciliation.current_balance != form.amount.value %}highlight-yellow{% endif %}">
-                            <td>{{ reconciliation.account }}</td>
+                            <td class="td-name">{{ reconciliation.account }}</td>
                             <td>${{ reconciliation.current_balance|floatformat:2|intcomma }}</td>
                             <td>
-                                <div class="form-row">
-                                    <div class="col">
-                                        <div class="input-group input-group-sm">
-                                            <div class="input-group-prepend">
-                                                <span class="input-group-text">$</span>
-                                            </div>
-                                            <input type="text" name="{{ form.amount.html_name }}" id="{{ form.amount.id_for_label }}" value="{{ form.amount.value|default_if_none:''|intcomma }}" class="form-control">
-                                        </div>
-                                    </div>
+                                <div class="field-currency">
+                                    <span class="prefix">$</span>
+                                    <input type="text" name="{{ form.amount.html_name }}" id="{{ form.amount.id_for_label }}" value="{{ form.amount.value|default_if_none:''|intcomma }}" class="input">
                                 </div>
                             </td>
                             <td>
@@ -86,7 +71,5 @@
             </table>
         </div>
     </div>
-    <button class="btn btn-primary" type="submit" value="Submit">Update</button>
-    </form>
-    </div>
-</div>
+    <button class="btn btn-primary mt-3" type="submit" value="Submit">Update</button>
+</form>

--- a/ledger/templates/api/tables/search-results-table.html
+++ b/ledger/templates/api/tables/search-results-table.html
@@ -1,48 +1,44 @@
 {% load humanize %}
-<div class="row">
-    <div class="col">
-        <p class="text-muted">{{ count }} transaction{{ count|pluralize }} found</p>
-        <div id="search-results-table" class="table-responsive" style="max-height: 400px; overflow-y: auto;">
-            <table class="table table-hover table-sm">
-                <thead>
-                    <tr>
-                        <th style="position: sticky; top: 0; background: white; z-index: 10;">Date</th>
-                        <th style="position: sticky; top: 0; background: white; z-index: 10;">Account</th>
-                        <th style="position: sticky; top: 0; background: white; z-index: 10;">Amount</th>
-                        <th style="position: sticky; top: 0; background: white; z-index: 10;">Description</th>
-                        <th style="position: sticky; top: 0; background: white; z-index: 10;">Category</th>
-                        <th style="position: sticky; top: 0; background: white; z-index: 10;">DR Accounts</th>
-                        <th style="position: sticky; top: 0; background: white; z-index: 10;">CR Accounts</th>
-                        <th style="position: sticky; top: 0; background: white; z-index: 10;">Entities</th>
-                    </tr>
-                </thead>
-                <tbody>
-                    {% for row in transactions_data %}
-                    <tr>
-                        <td>{{ row.transaction.date }}</td>
-                        <td>{{ row.transaction.account }}</td>
-                        <td>${{ row.transaction.amount|floatformat:2|intcomma }}</td>
-                        <td>{{ row.transaction.description }}</td>
-                        <td>{{ row.transaction.category }}</td>
-                        <td>
-                            {% for jei in row.debit_items %}
-                                {{ jei.account.name }}{% if not forloop.last %}, {% endif %}
-                            {% endfor %}
-                        </td>
-                        <td>
-                            {% for jei in row.credit_items %}
-                                {{ jei.account.name }}{% if not forloop.last %}, {% endif %}
-                            {% endfor %}
-                        </td>
-                        <td>
-                            {% for entity_name in row.entity_names %}
-                                {{ entity_name }}{% if not forloop.last %}, {% endif %}
-                            {% endfor %}
-                        </td>
-                    </tr>
+<p class="muted fs-body mb-3">{{ count }} transaction{{ count|pluralize }} found</p>
+<div id="search-results-table" class="table-scroll" style="max-height: 400px;">
+    <table class="table">
+        <thead>
+            <tr>
+                <th>Date</th>
+                <th>Account</th>
+                <th>Amount</th>
+                <th>Description</th>
+                <th>Category</th>
+                <th>DR Accounts</th>
+                <th>CR Accounts</th>
+                <th>Entities</th>
+            </tr>
+        </thead>
+        <tbody>
+            {% for row in transactions_data %}
+            <tr>
+                <td class="td-name">{{ row.transaction.date }}</td>
+                <td>{{ row.transaction.account }}</td>
+                <td>${{ row.transaction.amount|floatformat:2|intcomma }}</td>
+                <td>{{ row.transaction.description }}</td>
+                <td>{{ row.transaction.category }}</td>
+                <td>
+                    {% for jei in row.debit_items %}
+                        {{ jei.account.name }}{% if not forloop.last %}, {% endif %}
                     {% endfor %}
-                </tbody>
-            </table>
-        </div>
-    </div>
+                </td>
+                <td>
+                    {% for jei in row.credit_items %}
+                        {{ jei.account.name }}{% if not forloop.last %}, {% endif %}
+                    {% endfor %}
+                </td>
+                <td>
+                    {% for entity_name in row.entity_names %}
+                        {{ entity_name }}{% if not forloop.last %}, {% endif %}
+                    {% endfor %}
+                </td>
+            </tr>
+            {% endfor %}
+        </tbody>
+    </table>
 </div>

--- a/ledger/templates/api/tables/statement-detail-table.html
+++ b/ledger/templates/api/tables/statement-detail-table.html
@@ -1,25 +1,21 @@
 {% load humanize %}
-<div class="fixed-table-container">
-    <div id="statement-detail-table" class="table-responsive">
-        <table class="table table-hover table-sm">
-            <thead class="fixed-header">
+<div id="statement-detail-table" class="table-scroll sticky-pane" style="max-height: 70vh;">
+    <table class="table">
+        <thead>
+            <tr>
+                <th>Date</th>
+                <th>Transaction</th>
+                <th class="right">Amount</th>
+            </tr>
+        </thead>
+        <tbody>
+            {% for entry in journal_entry_items %}
                 <tr>
-                    <th>Date</th>
-                    <th class="transaction-column">Transaction</th>
-                    <th>Amount</th>
+                    <td>{{ entry.journal_entry.date }}</td>
+                    <td class="cell-clip">{{ entry.journal_entry.transaction.description }}</td>
+                    <td class="right">${{ entry.amount_signed|floatformat:2|intcomma }}</td>
                 </tr>
-            </thead>
-            <tbody>
-                {% for entry in journal_entry_items %}
-                    <tr>
-                        <td>{{ entry.journal_entry.date }}</td>
-                        <td class="transaction-column">{{ entry.journal_entry.transaction.description }}</td>
-                        <td>
-                            ${{ entry.amount_signed|floatformat:2|intcomma }}
-                        </td>
-                    </tr>
-                {% endfor %}
-            </tbody>
-        </table>
-    </div>
+            {% endfor %}
+        </tbody>
+    </table>
 </div>

--- a/ledger/templates/api/tables/tax-table.html
+++ b/ledger/templates/api/tables/tax-table.html
@@ -1,36 +1,32 @@
 {% load humanize %}
 {% load math_filters %}
 
-<div class="row">
-    <div class="col">
-    <table class="table table-hover table-sm">
-        <thead>
-            <tr>
-                <th>Transaction</th>
-                <th>Date</th>
-                <th>Amount</th>
-                <th>Income</th>
-                <th>Tax Rate</th>
+<table class="table">
+    <thead>
+        <tr>
+            <th>Transaction</th>
+            <th>Date</th>
+            <th>Amount</th>
+            <th>Income</th>
+            <th>Tax Rate</th>
+        </tr>
+    </thead>
+    <tbody>
+        {% for tax_charge in tax_charges %}
+            <tr class="clickable-row" hx-get="{% url 'tax-form-bound' pk=tax_charge.pk %}" hx-target="#form-container">
+                <td class="td-name">{{ tax_charge.transaction_string }}</td>
+                <td>{{ tax_charge.date }}</td>
+                <td>${{ tax_charge.amount|floatformat:2|intcomma }}</td>
+                <td>${{ tax_charge.taxable_income|floatformat:2|intcomma }}</td>
+                <td>{% if not tax_charge.type == 'property' %}{{ tax_charge.tax_rate|multiply:100|floatformat:2 }}%{% endif %}</td>
             </tr>
-        </thead>
-        <tbody>
-            {% for tax_charge in tax_charges %}
-                <tr class="clickable-row" hx-get="{% url 'tax-form-bound' pk=tax_charge.pk %}" hx-target="#form-container">
-                    <td>{{ tax_charge.transaction_string }}</td>
-                    <td>{{ tax_charge.date }}</td>
-                    <td>${{ tax_charge.amount|floatformat:2|intcomma }}</td>
-                    <td>${{ tax_charge.taxable_income|floatformat:2|intcomma }}</td>
-                    <td>{% if not tax_charge.type == 'property' %}{{ tax_charge.tax_rate|multiply:100|floatformat:2 }}%{% endif %}</td>
-                </tr>
-            {% empty %}
-                <tr>
-                    <td colspan="6">No tax charges found.</td>
-                </tr>
-            {% endfor %}
-        </tbody>
-    </table>
-    </div>
-</div>
+        {% empty %}
+            <tr>
+                <td colspan="6" class="table-empty">No tax charges found.</td>
+            </tr>
+        {% endfor %}
+    </tbody>
+</table>
 
 {% block extra_js %}
 {% include "api/components/clickable-row-script.html" %}

--- a/ledger/templates/api/tables/transactions-table-new.html
+++ b/ledger/templates/api/tables/transactions-table-new.html
@@ -1,37 +1,33 @@
 {% load humanize %}
-<div class="row">
-    <div class="col">
-        <div id="transactions-table" class="table-responsive" style="max-height: 200px; overflow-y: auto;">
-            <table class="table table-hover table-sm">
-                <thead>
-                    <tr>
-                        <th style="position: sticky; top: 0; background: white; z-index: 10;">Date</th>
-                        <th style="position: sticky; top: 0; background: white; z-index: 10;">Account</th>
-                        <th style="position: sticky; top: 0; background: white; z-index: 10;">Amount</th>
-                        <th style="position: sticky; top: 0; background: white; z-index: 10;">Description</th>
-                        <th style="position: sticky; top: 0; background: white; z-index: 10;">Type</th>
-                    </tr>
-                </thead>
-                <tbody>
-                    {% for transaction in transactions %}
-                    <tr
-                        class="clickable-row{% if forloop.counter0 == index and not no_highlight %} table-active{% endif %}"
-                        hx-get="{{ row_url }}form/{{ transaction.id }}/?row_index={{ forloop.counter0 }}"
-                        hx-target="#form-div"
-                        data-transaction-id="{{ transaction.id }}"
-                        @click="selectedRowId = {{ transaction.id }}; rowIndex = {{ forloop.counter0 }}"
-                    >
-                        <td>{{ transaction.date }}</td>
-                        <td>{{ transaction.account }}</td>
-                        <td>${{ transaction.amount|floatformat:2|intcomma }}</td>
-                        <td>{{ transaction.description }}</td>
-                        <td>{{ transaction.get_type_display }}</td>
-                    </tr>
-                    {% endfor %}
-                </tbody>
-            </table>
-        </div>
-    </div>
+<div id="transactions-table" class="table-scroll table-scroll-sm">
+    <table class="table">
+        <thead>
+            <tr>
+                <th>Date</th>
+                <th>Account</th>
+                <th>Amount</th>
+                <th>Description</th>
+                <th>Type</th>
+            </tr>
+        </thead>
+        <tbody>
+            {% for transaction in transactions %}
+            <tr
+                class="clickable-row{% if forloop.counter0 == index and not no_highlight %} table-active{% endif %}"
+                hx-get="{{ row_url }}form/{{ transaction.id }}/?row_index={{ forloop.counter0 }}"
+                hx-target="#form-div"
+                data-transaction-id="{{ transaction.id }}"
+                @click="selectedRowId = {{ transaction.id }}; rowIndex = {{ forloop.counter0 }}"
+            >
+                <td class="td-name">{{ transaction.date }}</td>
+                <td>{{ transaction.account }}</td>
+                <td>${{ transaction.amount|floatformat:2|intcomma }}</td>
+                <td>{{ transaction.description }}</td>
+                <td class="td-muted">{{ transaction.get_type_display }}</td>
+            </tr>
+            {% endfor %}
+        </tbody>
+    </table>
 </div>
 {% if double_row_click %}
     {% include "api/components/two-row-select-script.html" %}

--- a/ledger/templates/api/tables/unattached-prepaids.html
+++ b/ledger/templates/api/tables/unattached-prepaids.html
@@ -1,14 +1,14 @@
 {% load humanize %}
 {% if journal_entry_items %}
-<h4>Unattached Prepaid Expenses</h4>
-<div id="transactions-table" class="table-responsive" style="max-height: 200px; overflow-y: auto;">
-    <table class="table table-hover table-sm">
+<h4 class="card-title mb-3">Unattached Prepaid Expenses</h4>
+<div id="transactions-table" class="table-scroll table-scroll-sm">
+    <table class="table">
         <thead>
             <tr>
-                <th style="position: sticky; top: 0; background: white; z-index: 10;">Date</th>
-                <th style="position: sticky; top: 0; background: white; z-index: 10;">Account</th>
-                <th style="position: sticky; top: 0; background: white; z-index: 10;">Amount</th>
-                <th style="position: sticky; top: 0; background: white; z-index: 10;">Description</th>
+                <th>Date</th>
+                <th>Account</th>
+                <th>Amount</th>
+                <th>Description</th>
             </tr>
         </thead>
         <tbody>
@@ -18,7 +18,7 @@
                 hx-get="{% url 'amortization-form' journal_entry_item.id %}"
                 hx-target="#amortization-form"
             >
-                <td>{{ journal_entry_item.journal_entry.transaction.date }}</td>
+                <td class="td-name">{{ journal_entry_item.journal_entry.transaction.date }}</td>
                 <td>{{ journal_entry_item.account }}</td>
                 <td>${{ journal_entry_item.amount|floatformat:2|intcomma }}</td>
                 <td>{{ journal_entry_item.journal_entry.transaction.description }}</td>

--- a/ledger/templates/api/views/index.html
+++ b/ledger/templates/api/views/index.html
@@ -3,11 +3,7 @@
 {% endblock %}
 
 {% block content %}
-<div class="row">
-    <div class="col">
-        <h2>Wallet transactions</h2>
-    </div>
-</div>
+<h2>Wallet transactions</h2>
 
 <div id="form-block">
     {{ form }}

--- a/ledger/templates/api/views/journal-entry-view.html
+++ b/ledger/templates/api/views/journal-entry-view.html
@@ -30,24 +30,16 @@
                 );
             }
          }">
-        <div class="row">
-            <div class="col-md-8">
-                <div id="table">
-                    {{ table }}
-                </div>
+        <div class="grid grid-main-side">
+            <div id="table">
+                {{ table }}
             </div>
-            <div class="col-md-4">
-                <div id="paystubs">
-                    {{ paystubs_table }}
-                </div>
+            <div id="paystubs">
+                {{ paystubs_table }}
             </div>
         </div>
-        <div class="row">
-            <div class="col-md-12">
-                <div id="form-div">
-                    {{ entry_form }}
-                </div>
-            </div>
+        <div id="form-div" class="mt-4">
+            {{ entry_form }}
         </div>
     </div>
 </div>

--- a/ledger/templates/api/views/payables-receivables.html
+++ b/ledger/templates/api/views/payables-receivables.html
@@ -3,27 +3,19 @@
 {% endif %}
 
 <div id="table-and-form">
-    <div class="row">
-        <div class="col-md-6">
-            {% if table %}
-            <div id="table">
-                {{ table }}
-            </div>
+    <div class="grid grid-main-side">
+        {% if table %}
+        <div id="table">
+            {{ table }}
+        </div>
+        {% endif %}
+        <div id="form">
+            {% if form %}
+                {{ form }}
             {% endif %}
         </div>
-        <div class="col-md-4">
-            <div id="form">
-                {% if form %}
-                    {{ form }}
-                {% endif %}
-            </div>
-        </div>
     </div>
-    <div class="row">
-        <div class="col-md-12">
-            <div id="balances-table">
-                {{ balances_table }}
-            </div>
-        </div>
+    <div id="balances-table">
+        {{ balances_table }}
     </div>
 </div>

--- a/ledger/templates/api/views/settings.html
+++ b/ledger/templates/api/views/settings.html
@@ -1,150 +1,4 @@
-<style>
-  /* ---- Settings page (design: "Ledger Settings (Interactive)", Direction A) ---- */
-  .set-page { max-width: 1160px; margin: 0 auto; padding: 30px 24px 60px;
-              font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif; }
-  .set-layout { display: flex; gap: 38px; }
-
-  .set-menu { width: 160px; flex: none; }
-  .set-menu-title { font-size: 11px; font-weight: 600; letter-spacing: .07em; text-transform: uppercase;
-                    color: #aeb4ba; margin-bottom: 13px; padding-left: 11px; }
-  .set-menu-list { display: flex; flex-direction: column; }
-  .set-menu-item { font-size: 14px; color: #6c757d; font-weight: 400; padding: 7px 0 7px 11px;
-                   border-left: 2px solid transparent; cursor: pointer; }
-  .set-menu-item.active { color: #007bff; font-weight: 600; border-left-color: #007bff; }
-
-  .set-main { flex: 1; min-width: 0; }
-
-  .set-head { display: flex; align-items: center; justify-content: space-between; margin-bottom: 15px; }
-  .set-head-left { display: flex; align-items: baseline; gap: 9px; }
-  .set-h2 { margin: 0; font-size: 16px; font-weight: 600; color: #212529; }
-  .set-count { font-size: 12px; color: #9aa0a6; }
-  .set-head-right { display: flex; align-items: center; gap: 10px; }
-
-  .set-search { display: flex; align-items: center; gap: 7px; width: 230px; height: 30px;
-                border: 1px solid #ced4da; border-radius: 4px; padding: 0 9px; background: #fff; }
-  .set-search input { border: none; outline: none; font-size: 12px; color: #212529; background: transparent;
-                      width: 100%; font-family: inherit; }
-  .set-search input::placeholder { color: #aeb4ba; }
-
-  .set-btn { height: 30px; padding: 0 14px; border: none; border-radius: 4px; font-size: 12px;
-             font-weight: 500; cursor: pointer; font-family: inherit; }
-  .set-btn-primary { background: #007bff; color: #fff; }
-  .set-btn-danger { background: #dc3545; color: #fff; }
-  .set-btn-clear { background: #f1f3f5; color: #6c757d; border: 1px solid #e2e5e8; }
-
-  /* Fixed-height table area: the list scrolls internally so the edit form
-     below is always visible no matter how many accounts exist. */
-  .set-table-scroll { max-height: 340px; overflow-y: auto; }
-  .set-table { width: 100%; border-collapse: collapse; }
-  .set-table th { padding: 8px 12px; font-size: 11px; letter-spacing: .04em; text-transform: uppercase;
-                  color: #9aa0a6; font-weight: 600; border-bottom: 1px solid #e2e5e8; text-align: left;
-                  position: sticky; top: 0; background: #fff; z-index: 1; }
-  .set-table th.center { text-align: center; }
-  .set-row { cursor: pointer; border-bottom: 1px solid #f0f2f4; }
-  .set-row:hover { background: #f7f9fb; }
-  .set-row.selected { background: #f2f8ff; box-shadow: inset 2px 0 0 #007bff; }
-  .set-td { padding: 8px 12px; font-size: 12px; white-space: nowrap; }
-  .set-td-name { color: #212529; font-weight: 500; }
-  .set-row.selected .set-td-name { font-weight: 600; }
-  .set-td-type { color: #343a40; }
-  .set-td-sub { color: #6c757d; }
-  .set-td-entity { color: #495057; }
-  .set-td-entity.empty { color: #b6bcc2; }
-  .set-td-closed { color: #6c757d; text-align: center; }
-  .set-empty { padding: 22px 12px; font-size: 12px; color: #9aa0a6; text-align: center; }
-
-  .set-form { margin-top: 22px; padding-top: 18px; border-top: 1px solid #e9ecef; }
-  .set-form-header { font-size: 11px; font-weight: 600; letter-spacing: .05em; text-transform: uppercase;
-                     color: #9aa0a6; margin-bottom: 15px; }
-  .set-grid-1 { display: grid; grid-template-columns: 2fr 1fr 1fr; gap: 14px 18px; margin-bottom: 14px; }
-  .set-grid-2 { display: grid; grid-template-columns: 1fr 1fr 1fr; gap: 14px 18px; align-items: end; margin-bottom: 18px; }
-  .set-label { display: block; font-size: 11px; color: #6c757d; margin-bottom: 5px; }
-  .set-input, .set-select { height: 30px; border: 1px solid #ced4da; border-radius: 4px; padding: 0 9px;
-                            font-size: 12px; color: #212529; background: #fff; width: 100%;
-                            font-family: inherit; outline: none; }
-  .set-select { padding: 0 7px; cursor: pointer; }
-  .set-checks { display: flex; gap: 20px; padding-bottom: 7px; }
-  .set-check { display: inline-flex; align-items: center; gap: 7px; font-size: 12px; color: #212529; cursor: pointer; }
-  .set-check input { width: 14px; height: 14px; accent-color: #007bff; cursor: pointer; margin: 0; }
-  .set-actions { display: flex; gap: 9px; }
-  .set-field-error { font-size: 11px; color: #dc3545; margin-top: 4px; }
-  .set-alert { font-size: 12px; border-radius: 4px; padding: 8px 11px; margin-bottom: 14px; }
-  .set-alert-success { background: #e9f7ef; color: #1e7e44; }
-  .set-alert-danger { background: #fdecee; color: #b02a37; }
-
-  /* Status badges for the Utility Bills monitor */
-  .set-badge { display: inline-block; font-size: 11px; font-weight: 600; line-height: 1;
-               padding: 4px 8px; border-radius: 10px; white-space: nowrap; }
-  .set-badge-matched { background: #e9f7ef; color: #1e7e44; }
-  .set-badge-parsed { background: #eaf2ff; color: #1c63d4; }
-  .set-badge-unresolved { background: #fff4e5; color: #b76e00; }
-  .set-badge-failed { background: #fdecee; color: #b02a37; }
-  .set-badge-pending { background: #f1f3f5; color: #6c757d; }
-
-  /* Per-request "busy" indicator, scoped to the row that fired the request.
-     htmx adds .htmx-request to the element named by hx-indicator (only the
-     clicked button's target), so a sibling indicator shows just for that row. */
-  .set-busy { display: none; font-size: 11.5px; color: #1c63d4; white-space: nowrap; }
-  .set-busy.htmx-request { display: inline; }
-  .set-btn[disabled] { opacity: .6; cursor: default; }
-  .set-btn-retry { height: 22px; padding: 0 8px; }
-  .set-label-optional { color: #aeb4ba; }
-
-  /* Status cell: badge + short error + retry stay on one line, vertically
-     centered, via an inline-flex row (no odd stacking). */
-  .set-status-line { display: inline-flex; align-items: center; gap: 8px; white-space: nowrap; }
-  /* Short error is the compact label; full text shows in a hover tooltip. */
-  .set-err { position: relative; }
-  .set-err-short { font-size: 11px; color: #b02a37; cursor: help; border-bottom: 1px dotted #e0a3a8; }
-  .set-err-tip { display: none; position: absolute; top: calc(100% + 5px); left: 0; z-index: 30;
-                 width: max-content; max-width: 320px; white-space: normal; font-size: 11px;
-                 line-height: 1.45; color: #fff; background: #212529; padding: 7px 9px;
-                 border-radius: 5px; box-shadow: 0 4px 14px rgba(0,0,0,.20); }
-  .set-err:hover .set-err-tip { display: block; }
-
-  .set-stub { border: 1px dashed #d8dce0; border-radius: 8px; padding: 46px 24px; text-align: center; background: #fafbfc; }
-  .set-stub-title { font-size: 13px; color: #868e96; font-weight: 500; }
-  .set-stub-sub { font-size: 12px; color: #aeb4ba; margin-top: 4px; }
-
-  /* Mobile stacked account list — hidden on desktop, shown in the media query
-     below in place of the table. Mirrors the design's narrow-screen list. */
-  .set-list { display: none; border-top: 1px solid #e2e5e8; }
-  .set-mrow { padding: 11px 12px; cursor: pointer; border-bottom: 1px solid #f0f2f4; }
-  .set-mrow.selected { background: #f2f8ff; box-shadow: inset 2px 0 0 #007bff; }
-  .set-mrow-top { display: flex; align-items: baseline; justify-content: space-between; gap: 10px; }
-  .set-mname { font-size: 13px; color: #212529; font-weight: 500;
-               min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
-  .set-mrow.selected .set-mname { font-weight: 600; }
-  .set-mtype { font-size: 12px; color: #495057; white-space: nowrap; flex: none; }
-  .set-mmeta { font-size: 11.5px; color: #9aa0a6; margin-top: 3px; }
-
-  /* ---- Mobile reflow (design breakpoint: < 760px) ----
-     The custom (non-Bootstrap) content area reflows to a single column; the
-     side rail becomes a horizontal tab strip and the table becomes a stacked
-     list. The Bootstrap top nav handles its own responsiveness, untouched. */
-  @media (max-width: 760px) {
-    .set-page { padding: 18px 14px 48px; }
-    .set-layout { flex-direction: column; gap: 18px; }
-
-    .set-menu { width: auto; }
-    .set-menu-title { display: none; }
-    .set-menu-list { flex-direction: row; overflow-x: auto; gap: 2px; border-bottom: 1px solid #e9ecef; }
-    .set-menu-item { padding: 9px 13px; border-left: none; border-bottom: 2px solid transparent; white-space: nowrap; }
-    .set-menu-item.active { border-bottom-color: #007bff; }
-
-    .set-head { flex-direction: column; align-items: stretch; gap: 11px; }
-    .set-head-right { width: 100%; }
-    .set-search { flex: 1; min-width: 0; }
-
-    .set-table-scroll { display: none; }
-    .set-list { display: block; }
-
-    .set-grid-1, .set-grid-2 { grid-template-columns: 1fr; }
-  }
-</style>
-
-<div class="set-page"
-     x-data="{
+<div x-data="{
         section: 'Accounts',
         sections: ['Accounts', 'Bill Rules', 'Utility Bills', 'Loans', 'Entities', 'Paystubs', 'Auto Tags', 'CSV Profiles'],
         stubs: {
@@ -154,21 +8,21 @@
           'CSV Profiles': 'Column mappings for each bank\'s CSV export format.'
         }
      }">
-  <div class="set-layout">
+  <div class="split">
 
-    <!-- flat menu -->
-    <div class="set-menu">
-      <div class="set-menu-title">Settings</div>
-      <div class="set-menu-list">
+    <!-- section menu -->
+    <div class="split-side">
+      <div class="menu-title">Settings</div>
+      <div class="menu-list">
         <template x-for="s in sections" :key="s">
-          <span class="set-menu-item" :class="{ active: section === s }"
+          <span class="menu-item" :class="{ active: section === s }"
                 @click="section = s" x-text="s"></span>
         </template>
       </div>
     </div>
 
     <!-- main -->
-    <div class="set-main">
+    <div class="split-main">
       <!-- Accounts (functional) -->
       <div x-show="section === 'Accounts'">
         <div id="settings-content">{{ content }}</div>
@@ -178,7 +32,7 @@
       <div x-show="section === 'Bill Rules'">
         <div id="bill-rules-content"
              hx-get="{% url 'settings-bill-rules' %}" hx-trigger="load">
-          <div class="set-empty">Loading…</div>
+          <div class="table-empty">Loading…</div>
         </div>
       </div>
 
@@ -186,7 +40,7 @@
       <div x-show="section === 'Utility Bills'">
         <div id="bills-content"
              hx-get="{% url 'settings-bills' %}" hx-trigger="load">
-          <div class="set-empty">Loading…</div>
+          <div class="table-empty">Loading…</div>
         </div>
       </div>
 
@@ -194,17 +48,17 @@
       <div x-show="section === 'Loans'">
         <div id="loans-content"
              hx-get="{% url 'settings-loans' %}" hx-trigger="load">
-          <div class="set-empty">Loading…</div>
+          <div class="table-empty">Loading…</div>
         </div>
       </div>
 
       <!-- Stub sections -->
       <div x-show="stubs[section]" x-cloak>
-        <h2 class="set-h2" style="margin-bottom: 4px;" x-text="section"></h2>
-        <p style="margin: 0 0 26px; font-size: 12px; color: #9aa0a6;" x-text="stubs[section]"></p>
-        <div class="set-stub">
-          <div class="set-stub-title"><span x-text="section"></span> settings</div>
-          <div class="set-stub-sub">List + form for this section follows the same pattern as Accounts.</div>
+        <h2 class="card-title mb-2" x-text="section"></h2>
+        <p class="muted fs-body mb-4" x-text="stubs[section]"></p>
+        <div class="stub">
+          <div class="stub-title"><span x-text="section"></span> settings</div>
+          <div class="stub-sub">List + form for this section follows the same pattern as Accounts.</div>
         </div>
       </div>
     </div>

--- a/ledger/templates/api/views/statement.html
+++ b/ledger/templates/api/views/statement.html
@@ -1,14 +1,6 @@
-<div class="row">
-    <div class="col">
-        <h2>{{ title }}</h2>
-    </div>
-</div>
+<h2>{{ title }}</h2>
 
-<div class="row">
-    <div class="col">
-        {{ filter_form }}
-    </div>
-</div>
+{{ filter_form }}
 
 <div id="statement-content">
     {{ statement }}

--- a/ledger/templates/api/views/upload-transactions.html
+++ b/ledger/templates/api/views/upload-transactions.html
@@ -1,42 +1,35 @@
 <h2>Upload Files</h2>
-<br><br>
-<div class="row">
-    <div id="csv-upload" class="col-md-4">
+
+<div class="grid grid-2">
+    <div id="csv-upload" class="form-narrow">
         {{ form }}
     </div>
-    <dviv id="textract" class="col-md-4">
-        <div class="row">
-            {{ textract_form }}
-        </div>
+    <div id="textract" class="form-narrow">
+        {{ textract_form }}
     </div>
 </div>
 
-<div class="row">
-    <div class="col-md-4">
-        <div x-data="{
-                expandedPaystubId: null,
-                togglePaystub(id, url) {
-                    if (this.expandedPaystubId === id) {
-                        this.expandedPaystubId = null;
-                        return;
-                    }
-                    this.expandedPaystubId = id;
-                    const target = document.getElementById(`paystub-detail-${id}`);
-                    if (!target.innerHTML.trim()) {
-                        htmx.ajax('GET', url, {target: target});
-                    }
+<div class="mt-4 form-narrow">
+    <div x-data="{
+            expandedPaystubId: null,
+            togglePaystub(id, url) {
+                if (this.expandedPaystubId === id) {
+                    this.expandedPaystubId = null;
+                    return;
                 }
-             }">
-            <div id="paystubs">
-                {{ paystubs_table }}
-            </div>
+                this.expandedPaystubId = id;
+                const target = document.getElementById(`paystub-detail-${id}`);
+                if (!target.innerHTML.trim()) {
+                    htmx.ajax('GET', url, {target: target});
+                }
+            }
+         }">
+        <div id="paystubs">
+            {{ paystubs_table }}
         </div>
     </div>
 </div>
 
-<br>
-<div class="row">
-    <div class="col">
-        <a href="{% url 'trend' %}" class="btn btn-primary">Download summary CSV</a>
-    </div>
+<div class="mt-4">
+    <a href="{% url 'trend' %}" class="btn btn-primary">Download summary CSV</a>
 </div>


### PR DESCRIPTION
## Summary

The frontend had accumulated a hodgepodge of Bootstrap 4.5, per-template `<style>` blocks, and ~76 inline styles across several redesigns. This replaces it with **one token-driven stylesheet** (`ledger/static/css/app.css`), inspired by the Settings screen, as the single source of truth — consistent across every page and mobile-responsive throughout.

## What changed

- **Removed Bootstrap + popper** (CDN); kept jQuery, htmx, Alpine. Rebuilt the nav as a custom Alpine hamburger + Financials dropdown.
- **Central design system** in `app.css`: `:root` design tokens (colors, spacing, radii, type, focus ring) plus shared components — layout grid, cards, tables (`.table-scroll`), forms/fields, buttons, `.filter-bar`, badges, alerts, and statement KPI cards. Single **760px** breakpoint reflows grids → single column, nav → hamburger, Settings rail → tab strip.
- **Every page and partial converted** off Bootstrap to the shared classes (statements, transactions, taxes, reconciliation, journal entries, search, amortizations, upload, balances, settings, login).
- **Reuse**: shared `searchList` Alpine component + `search-box.html` partial for the Settings list fragments; restored `is-invalid` on journal-entry inputs.
- **Design refinements** from review: inline filter bars (no dropdown) with fixed-width fields, fixed-width KPI cards, wider suggested-account field, narrower reconciliation/upload/statement controls, taller paystub table, spacing fixes.
- **Infra**: serve `app.css` via `STATICFILES_DIRS`; `.gitignore` the `collectstatic` artifact (`staticfiles/`).

## Test plan

- `uv run python manage.py test` — **451 non-e2e + 14 e2e** tests pass (Playwright e2e run in isolation; updated selectors for the renamed classes).
- Manual: walk every nav screen + the three Financials and resize below 760px — consistent look, everything reflows to a single column.

🤖 Generated with [Claude Code](https://claude.com/claude-code)