### PR TITLE
Retry stranded failed bill-parse jobs during Gmail poll

### DIFF
--- a/api/management/commands/poll_bill_emails.py
+++ b/api/management/commands/poll_bill_emails.py
@@ -18,6 +18,7 @@ class Command(BaseCommand):
             self.style.SUCCESS(
                 f"fetched={result.fetched} new={result.new} "
                 f"parsed={result.parsed} unresolved={result.unresolved} "
-                f"failed={result.failed}"
+                f"failed={result.failed} retried={result.retried} "
+                f"recovered={result.recovered}"
             )
         )

--- a/api/services/bill_services.py
+++ b/api/services/bill_services.py
@@ -210,15 +210,49 @@ class PollResult:
     parsed: int = 0
     unresolved: int = 0
     failed: int = 0
+    retried: int = 0
+    recovered: int = 0
+
+
+def retry_failed_bills() -> tuple[int, int]:
+    """
+    Re-runs Gemini on every bill stuck in FAILED status, using each bill's stored
+    raw_text (no Gmail round-trip). Lets transient parse failures (timeouts, rate
+    limits) self-heal on the next poll even after the source email has aged out of
+    the Gmail search window.
+
+    Returns (retried, recovered): how many FAILED bills were re-attempted and how
+    many left FAILED status. Each bill is parsed independently so one bill's hard
+    failure can't strand the rest.
+    """
+    failed_bills = list(
+        UtilityBill.objects.filter(status=UtilityBill.Status.FAILED)
+    )
+    recovered = 0
+    for bill in failed_bills:
+        try:
+            updated = _parse_and_resolve_bill(bill)
+        except Exception:  # noqa: BLE001 - never let one bill abort the sweep
+            logger.exception("Failed to retry bill %s", bill.source_message_id)
+            continue
+        if updated.status != UtilityBill.Status.FAILED:
+            recovered += 1
+    return len(failed_bills), recovered
 
 
 def poll_bill_emails() -> PollResult:
     """
-    Searches Gmail for each configured (from_address, subject) pair and ingests
-    any new messages. Idempotent via source_message_id dedupe. Shared by the
-    scheduled management command and the Settings "Poll now" action.
+    Re-runs any stranded FAILED bills, then searches Gmail for each configured
+    (from_address, subject) pair and ingests new messages. Idempotent via
+    source_message_id dedupe. Shared by the scheduled management command and the
+    Settings "Poll now" action.
     """
     result = PollResult()
+
+    # Heal stranded Gemini failures first. Bills recovered here drop out of FAILED
+    # status, so the Gmail loop below won't re-attempt them (ingest_message skips
+    # non-FAILED existing records).
+    result.retried, result.recovered = retry_failed_bills()
 
     # Search each distinct (from_address, subject) once, even when several rules
     # share a vendor; account_number resolves the property afterward.

--- a/api/tests/services/test_bill_services.py
+++ b/api/tests/services/test_bill_services.py
@@ -11,6 +11,7 @@ from api.services.bill_services import (
     poll_bill_emails,
     resolve_bill_account,
     retry_bill,
+    retry_failed_bills,
 )
 from api.tests.testing_factories import AccountFactory, TransactionFactory
 
@@ -315,6 +316,83 @@ class RetryBillTest(TestCase):
 
     def test_retry_missing_returns_none(self):
         self.assertIsNone(retry_bill(99999))
+
+
+class RetryFailedBillsTest(TestCase):
+    @staticmethod
+    def make_failed_bill(message_id="f1", **kwargs):
+        defaults = {
+            "source_message_id": message_id,
+            "status": UtilityBill.Status.FAILED,
+            "raw_text": "body",
+            "error_message": "boom",
+        }
+        defaults.update(kwargs)
+        return UtilityBill.objects.create(**defaults)
+
+    @patch("api.services.bill_services.parse_bill_with_gemini")
+    def test_recovers_failed_bill(self, mock_parse):
+        make_rule(account_number="123")
+        bill = self.make_failed_bill()
+        mock_parse.return_value = {
+            "account_number": "123",
+            "amount": Decimal("88.42"),
+        }
+
+        retried, recovered = retry_failed_bills()
+
+        self.assertEqual((retried, recovered), (1, 1))
+        bill.refresh_from_db()
+        self.assertEqual(bill.status, UtilityBill.Status.PARSED)
+        self.assertEqual(bill.error_message, "")
+
+    @patch("api.services.bill_services.parse_bill_with_gemini")
+    def test_bill_that_fails_again_stays_failed(self, mock_parse):
+        bill = self.make_failed_bill()
+        mock_parse.side_effect = ValueError("still broken")
+
+        retried, recovered = retry_failed_bills()
+
+        self.assertEqual((retried, recovered), (1, 0))
+        bill.refresh_from_db()
+        self.assertEqual(bill.status, UtilityBill.Status.FAILED)
+
+    @patch("api.services.bill_services.parse_bill_with_gemini")
+    def test_non_failed_bills_untouched(self, mock_parse):
+        parsed = self.make_failed_bill(
+            message_id="p1", status=UtilityBill.Status.PARSED
+        )
+
+        retried, recovered = retry_failed_bills()
+
+        self.assertEqual((retried, recovered), (0, 0))
+        mock_parse.assert_not_called()
+        parsed.refresh_from_db()
+        self.assertEqual(parsed.status, UtilityBill.Status.PARSED)
+
+    @patch("api.services.bill_services.parse_bill_with_gemini")
+    @patch("api.services.bill_services.search_messages")
+    @patch("api.services.bill_services.build_gmail_service")
+    def test_poll_recovers_stranded_bill_with_no_new_email(
+        self, mock_build, mock_search, mock_parse
+    ):
+        rule = make_rule(account_number="123")
+        bill = self.make_failed_bill(from_address=rule.from_address)
+        mock_build.return_value = object()
+        mock_search.return_value = []  # nothing new in the Gmail window
+        mock_parse.return_value = {
+            "account_number": "123",
+            "amount": Decimal("88.42"),
+        }
+
+        result = poll_bill_emails()
+
+        self.assertEqual(result.fetched, 0)
+        self.assertEqual(result.new, 0)
+        self.assertEqual(result.retried, 1)
+        self.assertEqual(result.recovered, 1)
+        bill.refresh_from_db()
+        self.assertEqual(bill.status, UtilityBill.Status.PARSED)
 
 
 class TriggerWiringTest(TestCase):

--- a/api/views/bill_settings_views.py
+++ b/api/views/bill_settings_views.py
@@ -159,7 +159,7 @@ class BillsView(LoginRequiredMixin, View):
             message = (
                 f"Poll complete — fetched {result.fetched}, new {result.new}, "
                 f"parsed {result.parsed}, unresolved {result.unresolved}, "
-                f"failed {result.failed}."
+                f"failed {result.failed}, recovered {result.recovered}."
             )
         elif action == "retry":
             bill_id = request.POST.get("bill_id")


### PR DESCRIPTION
## Summary

The Gmail-sync cron now reruns failed Gemini bill-parse jobs on every poll.

Previously a `UtilityBill` whose Gemini parse threw was only re-attempted if its **same email reappeared** in the next Gmail search. Because the search is bounded by `GMAIL_SEARCH_WINDOW_DAYS`, once the email aged out of that window a transient failure (timeout, rate limit, blip) was stranded as `FAILED` forever unless someone manually clicked "Retry" in Settings.

## Changes

- **`retry_failed_bills()`** (`api/services/bill_services.py`) — sweeps every `FAILED` bill and re-parses it via the existing `_parse_and_resolve_bill()` using the bill's stored `raw_text` (no Gmail round-trip). Each bill is isolated in its own try/except so one hard failure can't abort the sweep. Returns `(retried, recovered)`.
- **`poll_bill_emails()`** runs the sweep **first**, then fetches from Gmail. Healing failures up front means recovered bills drop out of `FAILED`, so the fetch loop's `ingest_message` naturally skips them — no double Gemini calls.
- `PollResult` and the `poll_bill_emails` management-command output gain `retried` / `recovered` counts so scheduled runs report the sweep.

## Testing

`uv run python manage.py test api.tests.services.test_bill_services` — 26 tests pass, including new coverage for recovery, repeat-failure staying `FAILED`, non-`FAILED` bills untouched, and end-to-end recovery via `poll_bill_emails` when the Gmail search returns nothing new.

🤖 Generated with [Claude Code](https://claude.com/claude-code)