### PR TITLE
Fix mobile horizontal scroll on Income Statement transaction pop-out

### DIFF
--- a/ledger/static/css/app.css
+++ b/ledger/static/css/app.css
@@ -595,6 +595,12 @@ h4, h5 { font-size: var(--fs-md); font-weight: 600; margin: 0 0 var(--space-2); 
   .table-scroll.has-list { display: none; }
   .has-list + .list, .list.show-mobile { display: block; }
 
+  /* Statement detail pop-out: fit within the viewport on mobile */
+  #statement-detail-table .table { table-layout: fixed; width: 100%; }
+  #statement-detail-table .table td,
+  #statement-detail-table .table th { white-space: normal; word-break: break-word; }
+  #statement-detail-table .cell-clip { max-width: none; }
+
   /* Cards a touch tighter */
   .card { padding: var(--space-4); }
 }


### PR DESCRIPTION
## Problem

On mobile, viewing the Income Statement and tapping an account row to "pop out" its transactions caused the column to suddenly widen and forced a side-to-side horizontal scroll, since the injected transaction list was wider than the screen.

## Root cause

The detail partial (`statement-detail-table.html`) renders a 3-column table that inherits two width-forcing rules from the design system:

- `.table td { white-space: nowrap; }` — no column may wrap
- `.cell-clip { max-width: 250px; }` — the description column reserves up to 250px

With default `table-layout: auto`, the table's intrinsic minimum width (Date + 250px description + Amount) exceeds a phone viewport. On desktop the detail sits in the narrow `2fr 1fr` side column; on mobile `.grid-main-side` collapses to a single full-width column and the oversized table overflows.

## Fix

CSS-only change in the existing `@media (max-width: 760px)` block, scoped to `#statement-detail-table` so other tables are unaffected:

- `table-layout: fixed; width: 100%` — columns share the available width instead of growing to content
- `white-space: normal; word-break: break-word` — long descriptions wrap to multiple lines
- `cell-clip { max-width: none }` — drops the 250px floor

Desktop behavior is unchanged.

## Testing

- Income Statement at ~375px (DevTools device toolbar): tap a row → detail fits the screen, no horizontal page scroll, long descriptions wrap.
- Desktop view unchanged; other tables unaffected (scoped to `#statement-detail-table`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)