### PR TITLE
Show entity name in income statement transaction pop-out

### DIFF
--- a/api/services/statement_services.py
+++ b/api/services/statement_services.py
@@ -217,13 +217,21 @@ def get_statement_detail_items(
             journal_entry__date__lte=to_date,
             amount__gt=0,
         )
-        .select_related("journal_entry__transaction", "account")
+        .select_related("journal_entry__transaction", "account", "entity")
         .order_by("journal_entry__date")
     )
 
     # Apply signing logic
     for entry in journal_entry_items:
         entry.amount_signed = entry.amount
+
+        # Prefer the human-readable entity name; fall back to the raw
+        # transaction description when the item has no entity.
+        entry.display_label = (
+            entry.entity.name
+            if entry.entity
+            else entry.journal_entry.transaction.description
+        )
 
         # INCOME debits are negative (reduces income)
         if (

--- a/api/tests/services/test_statement_services.py
+++ b/api/tests/services/test_statement_services.py
@@ -23,6 +23,7 @@ from api.services.statement_services import (
 from api.statement import Balance
 from api.tests.testing_factories import (
     AccountFactory,
+    EntityFactory,
     JournalEntryFactory,
     JournalEntryItemFactory,
 )
@@ -426,6 +427,52 @@ class GetStatementDetailItemsTest(TestCase):
         )
 
         self.assertEqual(result.journal_entry_items[0].amount_signed, Decimal("200"))
+
+    def test_display_label_uses_entity_when_present(self):
+        """display_label should be the item's entity name when set."""
+        account = AccountFactory()
+        entity = EntityFactory(name="Whole Foods")
+        entry = JournalEntryFactory(date=date(2024, 6, 15))
+
+        JournalEntryItemFactory(
+            journal_entry=entry,
+            account=account,
+            amount=Decimal("100"),
+            type=JournalEntryItem.JournalEntryType.DEBIT,
+            entity=entity,
+        )
+
+        result = get_statement_detail_items(
+            account_id=account.pk,
+            from_date="2024-01-01",
+            to_date="2024-12-31",
+        )
+
+        self.assertEqual(result.journal_entry_items[0].display_label, "Whole Foods")
+
+    def test_display_label_falls_back_to_transaction_description(self):
+        """display_label should fall back to the transaction description when no entity."""
+        account = AccountFactory()
+        entry = JournalEntryFactory(date=date(2024, 6, 15))
+
+        JournalEntryItemFactory(
+            journal_entry=entry,
+            account=account,
+            amount=Decimal("100"),
+            type=JournalEntryItem.JournalEntryType.DEBIT,
+            entity=None,
+        )
+
+        result = get_statement_detail_items(
+            account_id=account.pk,
+            from_date="2024-01-01",
+            to_date="2024-12-31",
+        )
+
+        self.assertEqual(
+            result.journal_entry_items[0].display_label,
+            entry.transaction.description,
+        )
 
 
 class CalculateCashFlowMetricsTest(TestCase):

--- a/ledger/templates/api/tables/statement-detail-table.html
+++ b/ledger/templates/api/tables/statement-detail-table.html
@@ -12,7 +12,7 @@
             {% for entry in journal_entry_items %}
                 <tr>
                     <td>{{ entry.journal_entry.date }}</td>
-                    <td class="cell-clip">{{ entry.journal_entry.transaction.description }}</td>
+                    <td class="cell-clip">{{ entry.display_label }}</td>
                     <td class="right">${{ entry.amount_signed|floatformat:2|intcomma }}</td>
                 </tr>
             {% endfor %}


### PR DESCRIPTION
## Summary
The Income Statement transactions pop-out previously labeled each row with the raw `transaction.description` — typically a noisy imported bank string (e.g. `WHOLEFDS #123 SQ AMEX`). Each `JournalEntryItem` already carries its own `entity` (the human-readable party for that leg), so this defaults the label to the entity name and falls back to the transaction description when an item has no entity.

## Changes
- `get_statement_detail_items()` now prefetches `entity` via `select_related` and decorates each item with a computed `display_label`, following the existing `amount_signed` pattern.
- `statement-detail-table.html` renders `entry.display_label` in the label cell.
- Added two service tests covering the entity-present and description-fallback cases.

## Testing
- `uv run python manage.py test api.tests.services.test_statement_services` — 24 passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)