### PR TITLE
Tag tax charge journal entries with account default entity

### DIFF
--- a/api/models.py
+++ b/api/models.py
@@ -536,25 +536,27 @@ class TaxCharge(models.Model):
             )
         journal_entry.delete_journal_entry_items()
 
+        tax_payable_account = self.account.tax_payable_account
         JournalEntryItem.objects.create(
             journal_entry=journal_entry,
             type=JournalEntryItem.JournalEntryType.DEBIT,
             amount=self.transaction.amount,
             account=self.account,
+            entity=self.account.entity,
         )
         JournalEntryItem.objects.create(
             journal_entry=journal_entry,
             type=JournalEntryItem.JournalEntryType.CREDIT,
             amount=self.transaction.amount,
-            account=self.account.tax_payable_account,
+            account=tax_payable_account,
+            entity=tax_payable_account.entity,
         )
 
         # Update the Reconciliation per the new tax amount
-        liability_account = self.account.tax_payable_account
-        liability_balance = liability_account.get_balance(self.date)
+        liability_balance = tax_payable_account.get_balance(self.date)
         try:
             reconciliation = Reconciliation.objects.get(
-                date=self.date, account=self.account.tax_payable_account
+                date=self.date, account=tax_payable_account
             )
             reconciliation.amount = liability_balance
             reconciliation.save()

--- a/api/tests/models/test_taxcharge.py
+++ b/api/tests/models/test_taxcharge.py
@@ -1,6 +1,6 @@
 from django.test import TestCase
 from django.db import IntegrityError
-from api.tests.testing_factories import TransactionFactory, AccountFactory, ReconciliationFactory
+from api.tests.testing_factories import TransactionFactory, AccountFactory, ReconciliationFactory, EntityFactory
 from api.models import TaxCharge, Account, JournalEntry, JournalEntryItem
 from datetime import date
 from decimal import Decimal
@@ -96,6 +96,44 @@ class TaxChargeModelTests(TestCase):
         self.assertTrue(tax_charge.transaction)
         transaction.refresh_from_db()
         self.assertEqual(transaction.amount, Decimal('100.00'))
+
+    def test_tags_journal_entry_items_with_account_default_entity(self):
+        # Give each tax account a default entity
+        expense_entity = EntityFactory()
+        payable_entity = EntityFactory()
+        self.property_tax_account.entity = expense_entity
+        self.property_tax_account.save()
+        self.property_tax_payable_account.entity = payable_entity
+        self.property_tax_payable_account.save()
+
+        transaction = TransactionFactory(account=self.property_tax_account)
+        tax_charge = TaxCharge.objects.create(
+            account=self.property_tax_account,
+            transaction=transaction,
+            date=date.today(),
+            amount=Decimal('100.00')
+        )
+
+        debit = tax_charge.transaction.journal_entry.journal_entry_items.get(
+            type=JournalEntryItem.JournalEntryType.DEBIT
+        )
+        credit = tax_charge.transaction.journal_entry.journal_entry_items.get(
+            type=JournalEntryItem.JournalEntryType.CREDIT
+        )
+        self.assertEqual(debit.entity, expense_entity)
+        self.assertEqual(credit.entity, payable_entity)
+
+    def test_journal_entry_items_have_no_entity_when_account_has_no_default(self):
+        transaction = TransactionFactory(account=self.property_tax_account)
+        tax_charge = TaxCharge.objects.create(
+            account=self.property_tax_account,
+            transaction=transaction,
+            date=date.today(),
+            amount=Decimal('100.00')
+        )
+
+        for item in tax_charge.transaction.journal_entry.journal_entry_items.all():
+            self.assertIsNone(item.entity)
 
     def test_creates_tax_charge_side_effects_with_existing_reconciliation(self):
         transaction = TransactionFactory(amount=10, account=self.property_tax_account)


### PR DESCRIPTION
## Problem

When tax charges are auto-created via the Taxes tab, the resulting journal entries showed **no entity** — even when a default entity was configured on the tax account. `TaxCharge.save()` built its debit/credit `JournalEntryItem`s without ever reading the account's `entity`, so the field was silently ignored.

## Fix

Derive each journal entry item's entity from its own account, matching how the normal transaction flow tags entities:
- Debit item → `self.account.entity` (tax expense account)
- Credit item → `tax_payable_account.entity` (payable account)

Both `Account.entity` fields are nullable, so items stay untagged when no default is set (today's behavior) and pick up the entity automatically once one is configured. Also cached the repeated `tax_payable_account` lookup in `save()`.

## Tests

Added two cases to `test_taxcharge.py`:
- Items are tagged with their account's default entity
- Items have no entity when the account has no default (graceful fallback)

All 7 tests in the module pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)