### PR TITLE
Trim CLAUDE.md and document AI integration

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -39,7 +39,7 @@ Ledger is a Django personal accounting application that generates three accounti
 
 - **ledger/** - Django project configuration (settings, urls, wsgi)
 - **api/** - Main Django app containing all business logic
-  - `models.py` - 19 model classes for accounting entities
+  - `models.py` - model classes for accounting entities
   - `statement.py` - Statement generation (IncomeStatement, BalanceSheet, CashFlowStatement, Trend)
   - `views/` - HTMX-based views returning HTML fragments
   - `services/` - Business logic (journal_entry_services.py)
@@ -69,6 +69,14 @@ Every Transaction creates a JournalEntry with balanced JournalEntryItems:
 
 HTMX-based - views return HTML fragments via `render_to_string()`. No separate API endpoints; views render templates directly for AJAX updates.
 
+### AI Integration
+
+Gemini (Google) powers document parsing and an agentic recharacterization flow:
+- `api/services/gemini_services.py` — paystub/bill parsing from PDFs/email
+- `api/services/recharacterize_services.py` — multi-turn LLM bulk recharacterization of journal entry items
+
+Runs async via Celery (e.g. `process_gemini_paystub` in `tasks.py`).
+
 ### Local Development Setup
 
 Create `ledger/local_settings.py` with SECRET_KEY, AWS credentials, and database config (see README.md for template).
@@ -79,199 +87,13 @@ Tests use Factory Boy (`api/tests/testing_factories.py`) for test data. Test str
 - `api/tests/models/` - Model unit tests
 - `api/tests/statement/` - Statement generation tests
 
-## Code Organization Patterns
+## Code Organization
 
-This codebase follows a strict separation of concerns for maintainability and testability. The refactoring of `journal_entry_views.py` serves as the reference implementation of this pattern.
+Strict layering for maintainability and testability: Views → Helpers → Forms → Services → Models.
 
-### Architecture Layers
+- **Views** (`api/views/`): HTTP orchestration only — parse request, call a service, render via a helper. No model writes, no inline HTML, no business logic.
+- **Helpers** (`api/views/*_helpers.py`): pure functions that render templates via `render_to_string()`. No DB access, no business logic.
+- **Forms** (`api/forms.py`): field-level validation (e.g. `CommaDecimalField` for currency).
+- **Services** (`api/services/`): business logic and DB writes. Wrap multi-step writes in `@db_transaction.atomic`, use bulk ops (`bulk_create`/`bulk_update`), type-hint everything, and return result dataclasses (`success` / `data` / `error`). Most writes live here, though a few forms still write directly — prefer services for new code.
 
-```
-Views (HTTP orchestration)
-  ↓
-Helpers (pure HTML rendering functions)
-  ↓
-Forms (field validation)
-  ↓
-Services (business logic + atomic DB writes)
-  ↓
-Models (domain entities)
-```
-
-### Service Layer Guidelines (`api/services/`)
-
-Services contain all business logic and database writes:
-
-- **All database writes must be in services** - No `.save()`, `.delete()`, or `.create()` in views
-- **Use `@db_transaction.atomic`** for multi-step operations to ensure atomicity
-- **Return dataclass result objects** (e.g., `SaveResult`, `ValidationResult`) with:
-  - `success: bool` - Whether operation succeeded
-  - `data: Optional[Model]` - The created/updated object
-  - `error: Optional[str]` - Error message if failed
-- **Use bulk operations** - `bulk_create()`, `bulk_update()` for efficiency
-- **Type hints required** on all function parameters and return types
-- **Pure functions** - No HTTP dependencies (no `request` objects)
-- **Single responsibility** - Each function does one thing well
-
-**Example:**
-```python
-@dataclass
-class SaveResult:
-    success: bool
-    journal_entry: Optional[JournalEntry] = None
-    error: Optional[str] = None
-
-@db_transaction.atomic
-def save_journal_entry(
-    date: datetime.date,
-    memo: str,
-    items: List[Dict[str, Any]]
-) -> SaveResult:
-    """Creates a journal entry with balanced items."""
-    # Validation
-    if not validate_items_balance(items):
-        return SaveResult(success=False, error="Debits must equal credits")
-
-    # Create entry
-    entry = JournalEntry.objects.create(date=date, memo=memo)
-
-    # Bulk create items
-    item_objects = [JournalEntryItem(**item, journal_entry=entry) for item in items]
-    JournalEntryItem.objects.bulk_create(item_objects)
-
-    return SaveResult(success=True, journal_entry=entry)
-```
-
-### Helper Function Guidelines (`api/views/*_helpers.py`)
-
-Helpers are pure functions for HTML rendering:
-
-- **Pure functions** - Given the same input, always return the same output
-- **No database writes** - Only read data passed as parameters
-- **No business logic** - No calculations, validations, or complex transformations
-- **Accept data structures, return HTML strings** - Use `render_to_string()`
-- **Template-focused** - Thin wrappers around Django templates
-- **No HTTP dependencies** - No `request` objects
-
-**Example:**
-```python
-def render_journal_entry_form(
-    journal_entry: Optional[JournalEntry] = None,
-    accounts: Optional[List[Account]] = None
-) -> str:
-    """Renders the journal entry form HTML."""
-    form = JournalEntryForm(instance=journal_entry)
-    return render_to_string(
-        'journal_entry_form.html',
-        {'form': form, 'accounts': accounts}
-    )
-
-def render_journal_entry_table(
-    entries: List[JournalEntry],
-    row_url: str
-) -> str:
-    """Renders the journal entry table HTML."""
-    return render_to_string(
-        'journal_entry_table.html',
-        {'entries': entries, 'row_url': row_url}
-    )
-```
-
-### View Guidelines (`api/views/`)
-
-Views handle HTTP orchestration only:
-
-- **HTTP orchestration** - Parse requests, call services, render responses
-- **Call services for business logic** - Never implement business logic in views
-- **Call helpers for rendering** - Never build HTML strings in views
-- **No direct database writes** - All writes go through services
-- **No complex calculations** - Delegate to services
-- **Minimal logic** - Just routing between services and helpers
-
-**Example:**
-```python
-def post(self, request, journal_entry_id=None):
-    # 1. Parse action
-    action = request.POST.get("action")
-
-    # 2. Handle via service
-    if action == "delete":
-        result = delete_journal_entry(journal_entry_id)
-    else:
-        form = JournalEntryForm(request.POST)
-        if form.is_valid():
-            result = save_journal_entry(**form.cleaned_data)
-
-    # 3. Handle result
-    if not result.success:
-        return HttpResponse(result.error, status=400)
-
-    # 4. Render via helpers
-    entries = get_journal_entries()  # Service function
-    table_html = render_journal_entry_table(entries, self.row_url)
-    form_html = render_journal_entry_form()
-
-    return HttpResponse(table_html + form_html)
-```
-
-### Form Guidelines (`api/forms.py`)
-
-Forms handle field-level validation only:
-
-- **Field validation** - Type checking, format validation, range checks
-- **No business logic** - No cross-model validations or complex rules
-- **No database writes** - Forms validate, services save
-- **Use custom fields** - Like `CommaDecimalField` for currency formatting
-
-### Benefits of This Pattern
-
-1. **Testability** - Services and helpers are pure functions, easy to unit test
-2. **Reusability** - Services can be called from views, management commands, Celery tasks
-3. **Maintainability** - Clear separation makes it easy to find and modify code
-4. **Type Safety** - Type hints enable static analysis and IDE autocomplete
-5. **Atomicity** - Database operations are properly wrapped in transactions
-
-### Reference Implementation
-
-See these files for the canonical example:
-- `api/services/journal_entry_services.py` - Service layer
-- `api/views/journal_entry_helpers.py` - Helper functions
-- `api/views/journal_entry_views.py` - View layer
-- `api/tests/services/test_journal_entry_services.py` - Service tests
-
-### Anti-Patterns to Avoid
-
-❌ **Database writes in views:**
-```python
-def post(self, request):
-    transaction = form.save()  # NO!
-    transaction.delete()  # NO!
-```
-
-❌ **Business logic in views:**
-```python
-def post(self, request):
-    # Complex filtering and calculations
-    transactions = Transaction.objects.filter(...)  # NO!
-    total = sum(t.amount for t in transactions)  # NO!
-```
-
-❌ **HTML building in views:**
-```python
-def get(self, request):
-    html = "<table>"  # NO!
-    for item in items:
-        html += f"<tr><td>{item}</td></tr>"
-    return HttpResponse(html)
-```
-
-✅ **Correct pattern:**
-```python
-def post(self, request):
-    # Service handles business logic
-    result = transaction_service.save_transaction(**form.cleaned_data)
-
-    # Helper handles rendering
-    html = transaction_helpers.render_transaction_table(result.transactions)
-
-    return HttpResponse(html)
-```
+Canonical example to follow: `api/services/journal_entry_services.py`, `api/views/journal_entry_views.py`, `api/views/journal_entry_helpers.py`, and `api/tests/services/test_journal_entry_services.py`.


### PR DESCRIPTION
## Summary

Refreshes `CLAUDE.md` so it stays broadly useful without going stale. Audited the file against the current codebase and found it mostly accurate but with a stale fact, a missing feature, and a bloated section that duplicates real source files.

## Changes

- **Fix stale count** — dropped the hardcoded "19 model classes" (actually 21 now); it drifts on every model addition.
- **Document AI integration** — added a brief section pointing at `api/services/gemini_services.py` (paystub/bill parsing) and `api/services/recharacterize_services.py` (agentic recharacterization), plus the `process_gemini_paystub` Celery task. This feature area was entirely undocumented.
- **Condense Code Organization** — replaced ~200 lines of inline code examples with a ~10-line principles list plus a pointer to the `journal_entry` reference implementation. The guidance is intact; the drift-prone duplicated code is gone. Softened "all writes must be in services" to match reality (a few forms still write directly).

Net: 278 → 99 lines, same enforced guidance, far less surface area to go stale.

🤖 Generated with [Claude Code](https://claude.com/claude-code)