### PR TITLE
Tolerate whitespace/case drift in recharacterize name resolution

### DIFF
--- a/api/services/recharacterize_services.py
+++ b/api/services/recharacterize_services.py
@@ -74,24 +74,34 @@ def is_protected_account(account: Account) -> bool:
     )
 
 
+def _resolve_named(model, name: Optional[str], label: str):
+    """Resolves a catalog name to a row, tolerating the whitespace/case drift the
+    LLM introduces even when told to copy names verbatim.
+
+    Tries an exact match first, then falls back to a stripped, case-insensitive
+    match so " Federal Taxes Payable" or "federal taxes payable" still resolve.
+    The fallback only resolves when it is unambiguous (exactly one match).
+    """
+    stripped = (name or "").strip()
+    if not stripped:
+        return None, None
+    row = model.objects.filter(name=name).first()
+    if row is not None:
+        return row, None
+    candidates = list(model.objects.filter(name__iexact=stripped)[:2])
+    if len(candidates) == 1:
+        return candidates[0], None
+    return None, f"{label} '{name}' was not found."
+
+
 def resolve_account(name: Optional[str]) -> Tuple[Optional[Account], Optional[str]]:
     """Resolves an account name to an Account, or returns a blocking error."""
-    if not name:
-        return None, None
-    account = Account.objects.filter(name=name).first()
-    if account is None:
-        return None, f"Account '{name}' was not found."
-    return account, None
+    return _resolve_named(Account, name, "Account")
 
 
 def resolve_entity(name: Optional[str]) -> Tuple[Optional[Entity], Optional[str]]:
     """Resolves an entity name to an Entity, or returns a blocking error."""
-    if not name:
-        return None, None
-    entity = Entity.objects.filter(name=name).first()
-    if entity is None:
-        return None, f"Entity '{name}' was not found."
-    return entity, None
+    return _resolve_named(Entity, name, "Entity")
 
 
 def _parse_date(value: Any) -> Tuple[Optional[datetime.date], Optional[str]]:

--- a/api/tests/services/test_recharacterize_services.py
+++ b/api/tests/services/test_recharacterize_services.py
@@ -268,6 +268,26 @@ class RecharacterizeServicesTest(TestCase):
         self.assertTrue(preview_plan(ops).has_blocks)
         self.assertFalse(apply_plan(ops).success)
 
+    def test_account_name_with_whitespace_resolves(self):
+        # The LLM is told to copy names verbatim but sometimes adds stray
+        # whitespace; a leading/trailing space must still resolve.
+        ops = [
+            {
+                "filter": {"account": "  Groceries  "},
+                "action": {"type": "set_entity", "entity": "Ally Bank"},
+            }
+        ]
+        self.assertFalse(preview_plan(ops).has_blocks)
+
+    def test_account_name_case_insensitive_resolves(self):
+        ops = [
+            {
+                "filter": {"account": "groceries"},
+                "action": {"type": "set_entity", "entity": "ally bank"},
+            }
+        ]
+        self.assertFalse(preview_plan(ops).has_blocks)
+
     def test_empty_filter_blocked(self):
         ops = [
             {"filter": {}, "action": {"type": "set_entity", "entity": "Ally Bank"}}


### PR DESCRIPTION
## Problem

A recharacterization preview reported real accounts as **"not found"** — e.g. `Federal Taxes Payable`, `Federal Taxes`, `State Taxes Payable` — even though those accounts exist with exactly those names. The accounts shown in the chat were correct, but the plan was blocked anyway.

## Cause

The LLM proposes operations as JSON naming accounts/entities. `resolve_account`/`resolve_entity` did a strict, byte-exact lookup (`Account.objects.filter(name=name)`). At temperature 0 the model still occasionally emits a name with stray leading/trailing whitespace or a different case, so a name that *displays* identically to the catalog isn't byte-identical — and the strict lookup fails.

## Fix

Route both resolvers through a shared `_resolve_named` helper that:
1. tries the exact match first (unchanged fast path), then
2. falls back to a stripped, case-insensitive match (`name__iexact`), resolving **only when unambiguous** (exactly one match) so it can never silently pick the wrong row.

This preserves the module's deterministic, can't-corrupt-the-books guarantee — it forgives whitespace/case only, never fuzzy-guesses a different account.

## Tests

Added `test_account_name_with_whitespace_resolves` (`"  Groceries  "`) and `test_account_name_case_insensitive_resolves` (`"groceries"`). Full `test_recharacterize_services` suite passes (17 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)