### PR TITLE
Split recharacterize entity-change from account-change eligibility

### DIFF
--- a/api/services/gemini_services.py
+++ b/api/services/gemini_services.py
@@ -350,12 +350,14 @@ def parse_bill_with_gemini(email_text: str) -> Dict[str, Any]:
 def build_recharacterize_system_prompt(
     account_names: List[str],
     entity_names: List[str],
-    protected_account_names: List[str],
+    swap_blocked_account_names: List[str],
 ) -> str:
     """Builds the system instruction for the recharacterization chat."""
     accounts_list = "\n".join(f"- {n}" for n in account_names) or "  (none)"
     entities_list = "\n".join(f"- {n}" for n in entity_names) or "  (none)"
-    protected_list = "\n".join(f"- {n}" for n in protected_account_names) or "  (none)"
+    swap_blocked_list = (
+        "\n".join(f"- {n}" for n in swap_blocked_account_names) or "  (none)"
+    )
 
     return f"""You are a careful bookkeeping assistant for a double-entry \
 personal accounting app. You help the user bulk-"recharacterize" past journal \
@@ -404,9 +406,11 @@ that would match everything.
 "action.to_account" (the account to change TO).
 - You may only set/clear an entity or swap an account. You can NEVER change \
 amounts or whether an item is a debit or a credit.
-- These accounts are system-managed and must NEVER appear in a filter or action; \
-if the user asks to touch them, refuse in "reply":
-{protected_list}
+- These accounts are system-managed: their items MAY be re-tagged with \
+"set_entity" or "clear_entity", but they must NEVER be the "filter.account" or \
+"action.to_account" of a "change_account" swap. If the user asks to swap one of \
+them, refuse the swap in "reply":
+{swap_blocked_list}
 - A year like "2025" means date_from 2025-01-01 and date_to 2025-12-31.
 - Across turns, keep prior operations in mind; when the user refines the request, \
 return the full updated operations list.

--- a/api/services/recharacterize_services.py
+++ b/api/services/recharacterize_services.py
@@ -18,7 +18,7 @@ from dataclasses import dataclass, field
 from typing import Any, Dict, List, Optional, Tuple
 
 from django.db import transaction as db_transaction
-from django.db.models import Q, QuerySet
+from django.db.models import QuerySet
 
 from api.models import Account, Entity, JournalEntryItem
 from api.services import gemini_services
@@ -26,14 +26,16 @@ from api.services import gemini_services
 logger = logging.getLogger(__name__)
 
 
-# Retained-earnings and unrealized-gains accounts are derived by statement and
-# reconciliation logic (see api/statement.py cash-flow logic and
-# Reconciliation.plug_investment_change), so their entries must never be
-# hand-edited, nor be the source/target of an account swap.
-PROTECTED_SPECIAL_TYPES = [
+# Starting-equity, retained-earnings, and unrealized-gains accounts are derived
+# by statement and reconciliation logic (see api/statement.py cash-flow logic
+# and Reconciliation.plug_investment_change), so their balances must never be
+# moved by an account swap. Their items may still be re-tagged with an entity —
+# entity tagging never touches a balance — so this set blocks account swaps only.
+SWAP_BLOCKED_SPECIAL_TYPES = [
     Account.SpecialType.UNREALIZED_GAINS_AND_LOSSES,
+    Account.SpecialType.STARTING_EQUITY,
 ]
-PROTECTED_SUB_TYPES = [
+SWAP_BLOCKED_SUB_TYPES = [
     Account.SubType.RETAINED_EARNINGS,
     Account.SubType.UNREALIZED_INVESTMENT_GAINS,
 ]
@@ -52,25 +54,10 @@ SAMPLE_LIMIT = 25
 # --- Account / entity helpers ----------------------------------------------
 
 
-def _protected_accounts_queryset() -> QuerySet:
-    return Account.objects.filter(
-        Q(special_type__in=PROTECTED_SPECIAL_TYPES)
-        | Q(sub_type__in=PROTECTED_SUB_TYPES)
-    )
-
-
-def _protected_account_ids() -> frozenset:
-    """The ids of every system-managed account, materialized once so callers can
-    exclude them with a literal ``IN (...)`` instead of a correlated subquery."""
-    return frozenset(
-        _protected_accounts_queryset().values_list("id", flat=True)
-    )
-
-
-def is_protected_account(account: Account) -> bool:
+def is_swap_blocked_account(account: Account) -> bool:
     return (
-        account.special_type in PROTECTED_SPECIAL_TYPES
-        or account.sub_type in PROTECTED_SUB_TYPES
+        account.special_type in SWAP_BLOCKED_SPECIAL_TYPES
+        or account.sub_type in SWAP_BLOCKED_SUB_TYPES
     )
 
 
@@ -164,17 +151,12 @@ def _filter_criteria(
     return rows
 
 
-def _evaluate_operation(
-    operation: Dict[str, Any], protected_ids: Optional[frozenset] = None
-) -> EvaluatedOperation:
+def _evaluate_operation(operation: Dict[str, Any]) -> EvaluatedOperation:
     """Resolves names, enforces guardrails, and builds the matched queryset.
 
     Returns an EvaluatedOperation whose ``errors`` list is non-empty when the
-    operation is blocked. Used identically by preview and apply. ``protected_ids``
-    is the system-managed account id set; computed on demand when omitted.
+    operation is blocked. Used identically by preview and apply.
     """
-    if protected_ids is None:
-        protected_ids = _protected_account_ids()
     result = EvaluatedOperation()
     filter_data = operation.get("filter") or {}
     action_data = operation.get("action") or {}
@@ -265,15 +247,15 @@ def _evaluate_operation(
         if filter_account and to_account:
             if filter_account == to_account:
                 result.errors.append("The FROM and TO accounts are the same.")
-            if is_protected_account(filter_account):
+            if is_swap_blocked_account(filter_account):
                 result.errors.append(
                     f"\"{filter_account.name}\" is a system-managed account and "
-                    "cannot be changed."
+                    "cannot be the source of an account swap."
                 )
-            if is_protected_account(to_account):
+            if is_swap_blocked_account(to_account):
                 result.errors.append(
                     f"\"{to_account.name}\" is a system-managed account and cannot "
-                    "be a destination."
+                    "be the destination of an account swap."
                 )
             if (
                 filter_account.type != to_account.type
@@ -302,13 +284,6 @@ def _evaluate_operation(
         entity_is_empty=entity_is_empty,
         entry_type=entry_type,
     )
-
-    # System-managed items are never recharacterized; silently drop them from
-    # entity actions so the rest of the sweep proceeds without the user having
-    # to filter them out. (Account swaps target an explicit, already-vetted
-    # account, so there is nothing to exclude there.)
-    if result.action_kind in (ACTION_SET_ENTITY, ACTION_CLEAR_ENTITY):
-        queryset = queryset.exclude(account_id__in=protected_ids)
 
     result.queryset = queryset
     return result
@@ -375,10 +350,9 @@ def preview_plan(operations: List[Dict[str, Any]]) -> PlanPreview:
     op_previews: List[OperationPreview] = []
     total_affected = 0
     has_blocks = False
-    protected_ids = _protected_account_ids()
 
     for index, operation in enumerate(operations):
-        evaluation = _evaluate_operation(operation, protected_ids)
+        evaluation = _evaluate_operation(operation)
         if evaluation.blocked:
             has_blocks = True
             op_previews.append(
@@ -439,10 +413,9 @@ def apply_plan(operations: List[Dict[str, Any]]) -> ApplyResult:
     if not operations:
         return ApplyResult(success=False, error="There is nothing to apply.")
 
-    protected_ids = _protected_account_ids()
     evaluations = []
     for operation in operations:
-        evaluation = _evaluate_operation(operation, protected_ids)
+        evaluation = _evaluate_operation(operation)
         if evaluation.blocked:
             return ApplyResult(
                 success=False,
@@ -477,12 +450,14 @@ class TurnResult:
 
 
 def _build_catalogs() -> Tuple[List[str], List[str], List[str]]:
-    protected_ids = _protected_account_ids()
+    # Every account is available for entity tagging, so all names go in the
+    # usable catalog. The swap-blocked subset is flagged separately so the LLM
+    # knows those names may never be the source/target of an account swap.
     accounts = list(Account.objects.all().order_by("name"))
-    account_names = [a.name for a in accounts if a.id not in protected_ids]
-    protected_names = [a.name for a in accounts if a.id in protected_ids]
+    account_names = [a.name for a in accounts]
+    swap_blocked_names = [a.name for a in accounts if is_swap_blocked_account(a)]
     entity_names = list(Entity.objects.order_by("name").values_list("name", flat=True))
-    return account_names, entity_names, protected_names
+    return account_names, entity_names, swap_blocked_names
 
 
 def run_turn(messages: List[Dict[str, str]]) -> TurnResult:
@@ -492,11 +467,11 @@ def run_turn(messages: List[Dict[str, str]]) -> TurnResult:
     Returns the assistant's reply plus the structured operations it proposed.
     Never raises — model/parse failures degrade to a friendly reply.
     """
-    account_names, entity_names, protected_names = _build_catalogs()
+    account_names, entity_names, swap_blocked_names = _build_catalogs()
     system_prompt = gemini_services.build_recharacterize_system_prompt(
         account_names=account_names,
         entity_names=entity_names,
-        protected_account_names=protected_names,
+        swap_blocked_account_names=swap_blocked_names,
     )
 
     try:

--- a/api/tests/services/test_recharacterize_services.py
+++ b/api/tests/services/test_recharacterize_services.py
@@ -75,6 +75,12 @@ class RecharacterizeServicesTest(TestCase):
             sub_type=Account.SubType.INTEREST,
             is_closed=False,
         )
+        self.starting_equity = AccountFactory(
+            name="Starting Equity",
+            type=Account.Type.EQUITY,
+            special_type=Account.SpecialType.STARTING_EQUITY,
+            is_closed=False,
+        )
         self.ally_bank = EntityFactory(name="Ally Bank")
 
         # Two 2025 "Verizon" entries with a debit on Ally Checking.
@@ -221,15 +227,15 @@ class RecharacterizeServicesTest(TestCase):
         self.assertFalse(apply_plan(ops).success)
         _ = unrealized
 
-    def test_set_entity_excludes_protected_items(self):
+    def test_set_entity_includes_swap_blocked_items(self):
         retained = AccountFactory(
             name="Retained Earnings",
             type=Account.Type.EQUITY,
             sub_type=Account.SubType.RETAINED_EARNINGS,
             is_closed=False,
         )
-        # A protected item and a normal item, both untagged, both in 2025.
-        prot_debit, _ = make_entry(
+        # A swap-blocked item and a normal item, both untagged, both in 2025.
+        blocked_debit, _ = make_entry(
             "Year close", datetime.date(2025, 1, 1), retained, self.checking
         )
         normal_debit, _ = make_entry(
@@ -245,16 +251,60 @@ class RecharacterizeServicesTest(TestCase):
                 "action": {"type": "set_entity", "entity": "Ally Bank"},
             }
         ]
-        # No block — the protected item is silently excluded, not a blocker.
+        # Entity tagging is allowed on every account, including swap-blocked ones.
         preview = preview_plan(ops)
         self.assertFalse(preview.has_blocks)
         result = apply_plan(ops)
         self.assertTrue(result.success)
 
-        prot_debit.refresh_from_db()
+        blocked_debit.refresh_from_db()
         normal_debit.refresh_from_db()
-        self.assertIsNone(prot_debit.entity)  # protected, excluded
+        self.assertEqual(blocked_debit.entity, self.ally_bank)  # now included
         self.assertEqual(normal_debit.entity, self.ally_bank)
+
+    def test_starting_equity_swap_blocked(self):
+        other_equity = AccountFactory(
+            name="Other Equity",
+            type=Account.Type.EQUITY,
+            is_closed=False,
+        )
+        # Blocked as the swap source.
+        from_ops = [
+            {
+                "filter": {"account": "Starting Equity"},
+                "action": {"type": "change_account", "to_account": "Other Equity"},
+            }
+        ]
+        self.assertTrue(preview_plan(from_ops).has_blocks)
+        self.assertFalse(apply_plan(from_ops).success)
+        # Blocked as the swap destination.
+        to_ops = [
+            {
+                "filter": {"account": "Other Equity"},
+                "action": {"type": "change_account", "to_account": "Starting Equity"},
+            }
+        ]
+        self.assertTrue(preview_plan(to_ops).has_blocks)
+        self.assertFalse(apply_plan(to_ops).success)
+        _ = other_equity
+
+    def test_set_entity_on_starting_equity_allowed(self):
+        debit, _ = make_entry(
+            "Opening balance",
+            datetime.date(2025, 1, 1),
+            self.starting_equity,
+            self.checking,
+        )
+        ops = [
+            {
+                "filter": {"account": "Starting Equity"},
+                "action": {"type": "set_entity", "entity": "Ally Bank"},
+            }
+        ]
+        self.assertFalse(preview_plan(ops).has_blocks)
+        self.assertTrue(apply_plan(ops).success)
+        debit.refresh_from_db()
+        self.assertEqual(debit.entity, self.ally_bank)
 
     # --- resolution / safety ------------------------------------------------
 


### PR DESCRIPTION
## Context

The recharacterization tool used a single "protected accounts" set to drive two different behaviors at once: entity set/clear silently *excluded* those accounts, and account swaps *blocked* them. This change splits those concerns.

## Changes

- **Entity changes are now allowed on every account.** Removed the silent exclusion so set/clear-entity sweeps every matching item regardless of account (entity tagging never moves a balance).
- **Account swaps remain blocked** for the derived/plugged accounts whose balances are computed by statement and reconciliation logic — and **starting equity is now added** to that set, alongside unrealized gains/losses, unrealized investment gains, and retained earnings.
- Renamed the single "protected" concept to a swap-specific one (`SWAP_BLOCKED_*`, `is_swap_blocked_account`) and updated the Gemini system prompt: these accounts may be re-tagged with an entity but may never be the source/destination of a `change_account` swap.
- Clarified the swap-block error messages to reflect that only swaps (not entity tagging) are blocked.

## Tests

- Flipped the old exclusion test to assert entity tagging now applies to formerly-protected items.
- Added coverage for starting equity being blocked as both swap source and destination, and for entity tagging being allowed on it.
- Full recharacterize service suite (19 tests) passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)