### PR TITLE
Add graceful Gemini failure handling to recharacterization

### DIFF
--- a/api/services/recharacterize_services.py
+++ b/api/services/recharacterize_services.py
@@ -447,6 +447,9 @@ class TurnResult:
     reply: str
     operations: List[Dict[str, Any]]
     error: Optional[str] = None
+    # True when the Gemini call/parse raised — distinguishes a transient service
+    # failure (retry) from a model reply the user should act on or rephrase.
+    failed: bool = False
 
 
 def _build_catalogs() -> Tuple[List[str], List[str], List[str]]:
@@ -479,13 +482,12 @@ def run_turn(messages: List[Dict[str, str]]) -> TurnResult:
         data = gemini_services._loads_gemini_json(raw)
     except Exception as exc:  # noqa: BLE001 - degrade gracefully for the UI
         logger.exception("Recharacterize turn failed")
+        # No reply text: the UI renders a typed error banner + Retry from `error`.
         return TurnResult(
-            reply=(
-                "Sorry — I couldn't process that. Please try rephrasing your "
-                "request."
-            ),
+            reply="",
             operations=[],
             error=str(exc),
+            failed=True,
         )
 
     reply = data.get("reply") or ""

--- a/api/tests/services/test_recharacterize_services.py
+++ b/api/tests/services/test_recharacterize_services.py
@@ -399,13 +399,16 @@ class RecharacterizeServicesTest(TestCase):
         self.assertEqual(turn.reply, "Sure, here's the plan.")
         self.assertEqual(len(turn.operations), 1)
         self.assertIsNone(turn.error)
+        self.assertFalse(turn.failed)
 
     @patch("api.services.recharacterize_services.gemini_services.call_gemini_conversation")
     def test_run_turn_degrades_on_model_error(self, mock_call):
-        mock_call.side_effect = RuntimeError("boom")
+        mock_call.side_effect = RuntimeError("503 UNAVAILABLE")
         turn = run_turn([{"role": "user", "text": "hi"}])
         self.assertEqual(turn.operations, [])
-        self.assertIsNotNone(turn.error)
+        self.assertEqual(turn.reply, "")
+        self.assertTrue(turn.failed)
+        self.assertIn("503", turn.error)
 
     def test_apply_is_atomic_one_bad_op_aborts_all(self):
         ops = [

--- a/api/tests/test_utils.py
+++ b/api/tests/test_utils.py
@@ -1,0 +1,22 @@
+from django.test import SimpleTestCase
+
+from api.utils import friendly_error_message, short_error_label
+
+
+class ErrorLabelTest(SimpleTestCase):
+    def test_short_error_label_classifies(self):
+        self.assertEqual(short_error_label("503 UNAVAILABLE"), "server busy (503)")
+        self.assertEqual(
+            short_error_label("429 RESOURCE_EXHAUSTED"), "rate limited (429)"
+        )
+        self.assertEqual(short_error_label("KeyError: 'x'"), "processing error")
+        self.assertEqual(short_error_label(""), "")
+
+    def test_friendly_error_message_steers_toward_retry(self):
+        self.assertIn("overloaded", friendly_error_message("503 UNAVAILABLE"))
+        self.assertIn("rate limited", friendly_error_message("429 RESOURCE_EXHAUSTED"))
+        # Generic (and empty) errors offer both retry and rephrase.
+        generic = friendly_error_message("KeyError: 'x'")
+        self.assertIn("retry", generic)
+        self.assertIn("rephrase", generic)
+        self.assertIn("retry", friendly_error_message(""))

--- a/api/tests/views/test_recharacterize_views.py
+++ b/api/tests/views/test_recharacterize_views.py
@@ -90,3 +90,75 @@ class RecharacterizeViewsTest(TestCase):
         resp = self.client.post(reverse("recharacterize-reset"))
         self.assertEqual(resp.status_code, 200)
         self.assertContains(resp, "No messages yet")
+
+    @patch("api.services.recharacterize_services.gemini_services.call_gemini_conversation")
+    def test_failed_turn_shows_error_banner_and_retry(self, mock_call):
+        mock_call.side_effect = RuntimeError("429 RESOURCE_EXHAUSTED")
+        resp = self.client.post(
+            reverse("recharacterize-message"), {"message": "tag ally checking"}
+        )
+        self.assertEqual(resp.status_code, 200)
+        # Typed banner + Retry affordance, and no canned assistant reply bubble.
+        self.assertContains(resp, "rate limited (429)")
+        self.assertContains(resp, "Retry")
+        self.assertContains(resp, reverse("recharacterize-retry"))
+        self.assertNotContains(resp, "chat-msg-assistant")
+        # The user message is kept so Retry can re-send it.
+        self.assertContains(resp, "tag ally checking")
+
+    @patch("api.services.recharacterize_services.gemini_services.call_gemini_conversation")
+    def test_failed_turn_preserves_prior_plan(self, mock_call):
+        # First turn succeeds and proposes a plan.
+        mock_call.return_value = json.dumps(
+            {
+                "reply": "Plan ready.",
+                "operations": [
+                    {
+                        "filter": {"account": "Ally Checking", "entry_type": "debit"},
+                        "action": {"type": "set_entity", "entity": "Ally Bank"},
+                    }
+                ],
+            }
+        )
+        self.client.post(reverse("recharacterize-message"), {"message": "tag it"})
+        # Second turn fails — the previously proposed plan must survive.
+        mock_call.side_effect = RuntimeError("503 UNAVAILABLE")
+        resp = self.client.post(
+            reverse("recharacterize-message"), {"message": "actually..."}
+        )
+        self.assertContains(resp, "server busy (503)")
+        self.assertContains(resp, "set entity")  # prior preview still shown
+        self.assertEqual(
+            len(self.client.session["recharacterize"]["operations"]), 1
+        )
+
+    @patch("api.services.recharacterize_services.gemini_services.call_gemini_conversation")
+    def test_retry_after_failure_succeeds(self, mock_call):
+        # A failed turn leaves the user message as the trailing entry.
+        mock_call.side_effect = RuntimeError("503 UNAVAILABLE")
+        self.client.post(
+            reverse("recharacterize-message"), {"message": "tag ally checking debits"}
+        )
+        # Retry: the service now responds successfully.
+        mock_call.side_effect = None
+        mock_call.return_value = json.dumps(
+            {
+                "reply": "I'll set entity Ally Bank.",
+                "operations": [
+                    {
+                        "filter": {"account": "Ally Checking", "entry_type": "debit"},
+                        "action": {"type": "set_entity", "entity": "Ally Bank"},
+                    }
+                ],
+            }
+        )
+        resp = self.client.post(reverse("recharacterize-retry"))
+        self.assertEqual(resp.status_code, 200)
+        self.assertContains(resp, "I&#x27;ll set entity Ally Bank.")
+        self.assertContains(resp, "Apply")
+        self.assertNotContains(resp, "server busy (503)")
+
+    def test_retry_with_no_pending_message_just_renders(self):
+        resp = self.client.post(reverse("recharacterize-retry"))
+        self.assertEqual(resp.status_code, 200)
+        self.assertContains(resp, "recharacterize-main")

--- a/api/utils.py
+++ b/api/utils.py
@@ -88,3 +88,24 @@ def short_error_label(error_message: str) -> str:
     if not msg:
         return ""
     return "processing error"
+
+
+def friendly_error_message(error_message: str) -> str:
+    """A full-sentence, recovery-oriented message for a Gemini/processing error.
+
+    Companion to ``short_error_label`` (which gives the compact badge). Used where
+    a synchronous flow shows the failure inline and offers a retry, so the copy
+    steers the user toward retrying for transient errors rather than rephrasing.
+    """
+    msg = error_message or ""
+    if "503" in msg or "UNAVAILABLE" in msg:
+        return (
+            "The AI service is temporarily overloaded. Your message wasn't lost — "
+            "wait a moment and retry."
+        )
+    if "429" in msg or "RESOURCE_EXHAUSTED" in msg:
+        return "The AI service is rate limited right now. Wait a moment and retry."
+    return (
+        "Something went wrong reaching the AI service. You can retry, or rephrase "
+        "your request."
+    )

--- a/api/utils.py
+++ b/api/utils.py
@@ -74,20 +74,35 @@ def is_last_day_of_month(date):
     return date == last_day_of_month
 
 
+def _classify_error(error_message: str) -> str:
+    """Classifies a Gemini/processing error string into a stable kind.
+
+    Single source of truth for the 503/429/generic split so the compact label
+    and the friendly message can't drift apart. Returns "overload",
+    "rate_limit", "empty" (no error text), or "generic".
+    """
+    msg = error_message or ""
+    if "503" in msg or "UNAVAILABLE" in msg:
+        return "overload"
+    if "429" in msg or "RESOURCE_EXHAUSTED" in msg:
+        return "rate_limit"
+    if not msg:
+        return "empty"
+    return "generic"
+
+
 def short_error_label(error_message: str) -> str:
     """Compact, human-friendly label for a stored Gemini/processing error.
 
     Shared by the document (S3File) and utility-bill (UtilityBill) failure
     surfaces so the two stay in sync.
     """
-    msg = error_message or ""
-    if "503" in msg or "UNAVAILABLE" in msg:
-        return "server busy (503)"
-    if "429" in msg or "RESOURCE_EXHAUSTED" in msg:
-        return "rate limited (429)"
-    if not msg:
-        return ""
-    return "processing error"
+    return {
+        "overload": "server busy (503)",
+        "rate_limit": "rate limited (429)",
+        "empty": "",
+        "generic": "processing error",
+    }[_classify_error(error_message)]
 
 
 def friendly_error_message(error_message: str) -> str:
@@ -97,15 +112,16 @@ def friendly_error_message(error_message: str) -> str:
     a synchronous flow shows the failure inline and offers a retry, so the copy
     steers the user toward retrying for transient errors rather than rephrasing.
     """
-    msg = error_message or ""
-    if "503" in msg or "UNAVAILABLE" in msg:
-        return (
-            "The AI service is temporarily overloaded. Your message wasn't lost — "
-            "wait a moment and retry."
-        )
-    if "429" in msg or "RESOURCE_EXHAUSTED" in msg:
-        return "The AI service is rate limited right now. Wait a moment and retry."
-    return (
+    generic = (
         "Something went wrong reaching the AI service. You can retry, or rephrase "
         "your request."
     )
+    return {
+        "overload": (
+            "The AI service is temporarily overloaded. Your message wasn't lost — "
+            "wait a moment and retry."
+        ),
+        "rate_limit": "The AI service is rate limited right now. Wait a moment and retry.",
+        "empty": generic,
+        "generic": generic,
+    }[_classify_error(error_message)]

--- a/api/views/recharacterize_helpers.py
+++ b/api/views/recharacterize_helpers.py
@@ -45,10 +45,12 @@ def render_page(
     messages: List[Dict[str, str]],
     preview: Optional[PlanPreview] = None,
     flash: Optional[str] = None,
-    error: Optional[Dict[str, str]] = None,
 ) -> str:
-    """Renders the full-page content fragment (heading + main region)."""
+    """Renders the full-page content fragment (heading + main region).
+
+    A fresh page never carries an error, so render_main's ``error`` defaults.
+    """
     return render_to_string(
         "api/views/recharacterize.html",
-        {"main": render_main(messages, preview, flash, error)},
+        {"main": render_main(messages, preview, flash)},
     )

--- a/api/views/recharacterize_helpers.py
+++ b/api/views/recharacterize_helpers.py
@@ -9,17 +9,35 @@ from typing import Dict, List, Optional
 from django.template.loader import render_to_string
 
 from api.services.recharacterize_services import PlanPreview
+from api.utils import friendly_error_message, short_error_label
+
+
+def build_turn_error(error_message: Optional[str]) -> Optional[Dict[str, str]]:
+    """Assembles the template context for a failed Gemini turn.
+
+    Returns None when there is no error. Otherwise a dict with a compact
+    ``label`` (badge), a recovery-oriented ``message``, and the full ``detail``
+    for a tooltip — mirroring the paystub/bill failure surface.
+    """
+    if not error_message:
+        return None
+    return {
+        "label": short_error_label(error_message),
+        "message": friendly_error_message(error_message),
+        "detail": error_message,
+    }
 
 
 def render_main(
     messages: List[Dict[str, str]],
     preview: Optional[PlanPreview] = None,
     flash: Optional[str] = None,
+    error: Optional[Dict[str, str]] = None,
 ) -> str:
     """Renders the swappable #recharacterize-main region (chat + preview)."""
     return render_to_string(
         "api/components/recharacterize-main.html",
-        {"messages": messages, "preview": preview, "flash": flash},
+        {"messages": messages, "preview": preview, "flash": flash, "error": error},
     )
 
 
@@ -27,9 +45,10 @@ def render_page(
     messages: List[Dict[str, str]],
     preview: Optional[PlanPreview] = None,
     flash: Optional[str] = None,
+    error: Optional[Dict[str, str]] = None,
 ) -> str:
     """Renders the full-page content fragment (heading + main region)."""
     return render_to_string(
         "api/views/recharacterize.html",
-        {"main": render_main(messages, preview, flash)},
+        {"main": render_main(messages, preview, flash, error)},
     )

--- a/api/views/recharacterize_views.py
+++ b/api/views/recharacterize_views.py
@@ -26,6 +26,30 @@ def _save_state(request, messages, operations) -> None:
     request.session.modified = True
 
 
+def _run_turn_and_render(request, messages, operations) -> str:
+    """Runs one Gemini turn against ``messages`` and renders the main region.
+
+    Shared by the message and retry views. ``operations`` is the plan already in
+    the session: on a failed turn it is preserved (so a transient error never
+    discards a proposed plan) and surfaced as a typed error banner with a Retry;
+    on success the model's new plan replaces it.
+    """
+    turn = recharacterize_services.run_turn(messages)
+
+    if turn.failed:
+        # Keep the trailing user message so Retry can re-send it; don't add a
+        # misleading assistant bubble. Hold onto the previously proposed plan.
+        _save_state(request, messages=messages, operations=operations)
+        preview = recharacterize_services.preview_plan(operations)
+        error = recharacterize_helpers.build_turn_error(turn.error)
+        return recharacterize_helpers.render_main(messages, preview, error=error)
+
+    messages.append({"role": "assistant", "text": turn.reply})
+    preview = recharacterize_services.preview_plan(turn.operations)
+    _save_state(request, messages=messages, operations=turn.operations)
+    return recharacterize_helpers.render_main(messages, preview)
+
+
 class RecharacterizeView(LoginRequiredMixin, View):
     """Full page. A GET starts a fresh session."""
 
@@ -53,14 +77,29 @@ class RecharacterizeMessageView(LoginRequiredMixin, View):
             return HttpResponse(html)
 
         messages.append({"role": "user", "text": user_text})
+        html = _run_turn_and_render(request, messages, state["operations"])
+        return HttpResponse(html)
 
-        turn = recharacterize_services.run_turn(messages)
-        messages.append({"role": "assistant", "text": turn.reply})
 
-        preview = recharacterize_services.preview_plan(turn.operations)
-        _save_state(request, messages=messages, operations=turn.operations)
+class RecharacterizeRetryView(LoginRequiredMixin, View):
+    """Re-runs the last turn after a transient Gemini failure.
 
-        html = recharacterize_helpers.render_main(messages, preview)
+    Re-sends the trailing (unanswered) user message — no new message is appended.
+    """
+
+    login_url = "/login/"
+
+    def post(self, request):
+        state = _get_state(request)
+        messages = state["messages"]
+
+        if not messages or messages[-1]["role"] != "user":
+            # Nothing to retry (no unanswered user turn); just re-render.
+            preview = recharacterize_services.preview_plan(state["operations"])
+            html = recharacterize_helpers.render_main(messages, preview)
+            return HttpResponse(html)
+
+        html = _run_turn_and_render(request, messages, state["operations"])
         return HttpResponse(html)
 
 

--- a/api/views/recharacterize_views.py
+++ b/api/views/recharacterize_views.py
@@ -26,6 +26,12 @@ def _save_state(request, messages, operations) -> None:
     request.session.modified = True
 
 
+def _render_unchanged(messages, operations) -> str:
+    """Re-renders the main region without running a turn (state untouched)."""
+    preview = recharacterize_services.preview_plan(operations)
+    return recharacterize_helpers.render_main(messages, preview)
+
+
 def _run_turn_and_render(request, messages, operations) -> str:
     """Runs one Gemini turn against ``messages`` and renders the main region.
 
@@ -72,9 +78,7 @@ class RecharacterizeMessageView(LoginRequiredMixin, View):
 
         user_text = (request.POST.get("message") or "").strip()
         if not user_text:
-            preview = recharacterize_services.preview_plan(state["operations"])
-            html = recharacterize_helpers.render_main(messages, preview)
-            return HttpResponse(html)
+            return HttpResponse(_render_unchanged(messages, state["operations"]))
 
         messages.append({"role": "user", "text": user_text})
         html = _run_turn_and_render(request, messages, state["operations"])
@@ -95,9 +99,7 @@ class RecharacterizeRetryView(LoginRequiredMixin, View):
 
         if not messages or messages[-1]["role"] != "user":
             # Nothing to retry (no unanswered user turn); just re-render.
-            preview = recharacterize_services.preview_plan(state["operations"])
-            html = recharacterize_helpers.render_main(messages, preview)
-            return HttpResponse(html)
+            return HttpResponse(_render_unchanged(messages, state["operations"]))
 
         html = _run_turn_and_render(request, messages, state["operations"])
         return HttpResponse(html)

--- a/ledger/templates/api/components/recharacterize-main.html
+++ b/ledger/templates/api/components/recharacterize-main.html
@@ -8,6 +8,16 @@
             {% endfor %}
         </div>
 
+        {% if error %}
+        <div class="alert alert-danger mt-3" role="alert">
+            <div title="{{ error.detail }}">❌ {{ error.label }} — {{ error.message }}</div>
+            <button type="button" class="btn btn-secondary btn-sm mt-2"
+                    hx-post="{% url 'recharacterize-retry' %}"
+                    hx-target="#recharacterize-main"
+                    hx-swap="outerHTML">↻ Retry</button>
+        </div>
+        {% endif %}
+
         <form id="chat-form" class="mt-3"
               hx-post="{% url 'recharacterize-message' %}"
               hx-target="#recharacterize-main"

--- a/ledger/urls.py
+++ b/ledger/urls.py
@@ -30,6 +30,7 @@ from api.views.recharacterize_views import (
     RecharacterizeApplyView,
     RecharacterizeMessageView,
     RecharacterizeResetView,
+    RecharacterizeRetryView,
     RecharacterizeView,
 )
 from api.views.search_views import SearchBulkUpdateView, SearchContentView, SearchView
@@ -179,6 +180,11 @@ urlpatterns = [
         "recharacterize/apply/",
         RecharacterizeApplyView.as_view(),
         name="recharacterize-apply",
+    ),
+    path(
+        "recharacterize/retry/",
+        RecharacterizeRetryView.as_view(),
+        name="recharacterize-retry",
     ),
     path(
         "recharacterize/reset/",


### PR DESCRIPTION
## Context

The agentic recharacterization chat calls Gemini synchronously each turn. Not all calls succeed — rate limits (429), server overload (503), and transient network errors happen. Today `run_turn` catches the exception and stores `error`, but the view **discards it** and renders a generic *"try rephrasing"* assistant bubble. That's wrong advice (for a 429/503 the fix is to *retry*, not rephrase) and offers no recovery beyond re-typing.

This borrows the existing paystub/utility-bill failure pattern — typed error vocabulary + compact label + one-click Retry — **without** the async/status-field/polling machinery, since recharacterize is synchronous and session-based (no model or migration).

## Changes

- **Service** (`recharacterize_services.py`): `TurnResult` gains a `failed` flag; `run_turn` returns it on any call/parse exception (with an empty reply — the UI now renders a typed banner).
- **Shared vocabulary** (`utils.py`): new `friendly_error_message()` next to `short_error_label()`, mapping 503/429/generic to recovery-oriented copy.
- **Views**: factored a shared `_run_turn_and_render()`. A failed turn **preserves any previously proposed plan**, keeps the user's message (so Retry re-sends it), and surfaces the error instead of a misleading reply. New `RecharacterizeRetryView` re-sends the unanswered message.
- **Helpers/template/URL**: `render_main` gains an `error` param + `build_turn_error()`; `recharacterize-main.html` renders `❌ {label} — {message}` (full error in a `title=` tooltip) with a **↻ Retry** button.

## Tests

All green (28 passed):
- `test_utils.py` (new): both error-helper mappings.
- Service: asserts `failed=True`, empty reply, error preserved.
- Views: failed turn shows banner + Retry and no assistant bubble; prior plan survives a failed turn; Retry after failure succeeds; retry with nothing pending just re-renders.

## Note

A failed turn intentionally keeps the user's message in session history so Retry can re-send it. If the user instead types a *new* message after a failure, the conversation sent to Gemini will have two consecutive user turns — Gemini handles this fine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)