### PR TITLE
Add view-only queries, CSV export, and inline pagination to recharacterize

### DIFF
--- a/api/services/gemini_services.py
+++ b/api/services/gemini_services.py
@@ -387,7 +387,7 @@ entity (untagged), otherwise false or null>,
     "entry_type": "<'debit', 'credit', or null for either>"
   }},
   "action": {{
-    "type": "<'set_entity' | 'clear_entity' | 'change_account'>",
+    "type": "<'set_entity' | 'clear_entity' | 'change_account' | 'view'>",
     "entity": "<exact entity name (only for set_entity)>",
     "to_account": "<exact account name (only for change_account)>"
   }}
@@ -399,6 +399,10 @@ in a catalog, do not guess — ask them to clarify in "reply" and return an empt
 operations list.
 - A filter must have at least one non-null field. Never produce an operation \
 that would match everything.
+- When the user only wants to SEE or LIST items without changing anything \
+("show me", "list", "what are", "let me see"), use "view": emit an operation \
+with the appropriate filter and "action.type" of "view" (no "entity" or \
+"to_account"). A view operation still needs at least one filter field.
 - When the user targets items with no entity ("empty entity", "untagged", \
 "missing entity", "no entity"), set "entity_is_empty" to true (do NOT also set \
 "entity"). This counts as a valid filter on its own.

--- a/api/services/recharacterize_services.py
+++ b/api/services/recharacterize_services.py
@@ -17,6 +17,7 @@ import logging
 from dataclasses import dataclass, field
 from typing import Any, Dict, List, Optional, Tuple
 
+from django.core.paginator import Paginator
 from django.db import transaction as db_transaction
 from django.db.models import QuerySet
 
@@ -47,6 +48,11 @@ VALID_ENTRY_TYPES = {
 ACTION_SET_ENTITY = "set_entity"
 ACTION_CLEAR_ENTITY = "clear_entity"
 ACTION_CHANGE_ACCOUNT = "change_account"
+# A view operation only inspects the matched items; it never mutates the ledger,
+# so it carries no Apply button and is skipped by apply_plan.
+ACTION_VIEW = "view"
+
+MUTATING_ACTIONS = {ACTION_SET_ENTITY, ACTION_CLEAR_ENTITY, ACTION_CHANGE_ACCOUNT}
 
 SAMPLE_LIMIT = 25
 
@@ -59,6 +65,11 @@ def is_swap_blocked_account(account: Account) -> bool:
         account.special_type in SWAP_BLOCKED_SPECIAL_TYPES
         or account.sub_type in SWAP_BLOCKED_SUB_TYPES
     )
+
+
+def _is_mutation(action_kind: Optional[str]) -> bool:
+    """True when the action changes the ledger (vs. a view-only inspection)."""
+    return action_kind in MUTATING_ACTIONS
 
 
 def _resolve_named(model, name: Optional[str], label: str):
@@ -226,6 +237,10 @@ def _evaluate_operation(operation: Dict[str, Any]) -> EvaluatedOperation:
         )
     elif result.action_kind == ACTION_CLEAR_ENTITY:
         result.action_summary = "clear the entity"
+    elif result.action_kind == ACTION_VIEW:
+        # View-only: no entity/account to resolve and nothing to mutate. The
+        # filter guard above still requires at least one criterion.
+        result.action_summary = "view matching items (no changes)"
     elif result.action_kind == ACTION_CHANGE_ACCOUNT:
         if filter_account is None:
             result.errors.append(
@@ -293,62 +308,99 @@ def _evaluate_operation(operation: Dict[str, Any]) -> EvaluatedOperation:
 
 
 @dataclass
+class PageResult:
+    """One page of an operation's matched items, for inline paging.
+
+    The adjacent page numbers are derivable (page ± 1, gated by
+    ``has_previous``/``has_next``), so the template computes them rather than
+    mirroring them here.
+    """
+
+    op_index: int
+    rows: List[Dict[str, Any]]
+    page: int
+    num_pages: int
+    total: int
+    has_previous: bool
+    has_next: bool
+
+
+@dataclass
 class OperationPreview:
     index: int
     criteria: List[Dict[str, str]]
     action_summary: str
     affected_count: int
-    sample: List[Dict[str, Any]]
-    has_more: bool
+    page: Optional[PageResult]
     blocked: bool
     error: Optional[str]
+    mutates: bool = False
 
 
 @dataclass
 class PlanPreview:
     operations: List[OperationPreview]
     total_affected: int
+    total_changes: int
     has_blocks: bool
     can_apply: bool
 
 
-def _build_sample(evaluation: EvaluatedOperation) -> List[Dict[str, Any]]:
-    rows = []
-    for item in evaluation.queryset[:SAMPLE_LIMIT]:
-        transaction = getattr(item.journal_entry, "transaction", None)
-        description = (
-            transaction.description if transaction else item.journal_entry.description
-        )
-        entity_before = item.entity.name if item.entity else "—"
-        # Default to "no change", then let the action override its column, so an
-        # unrecognized action shows the item untouched rather than misprojecting.
-        entity_after = entity_before
-        account_after = item.account.name
-        if evaluation.action_kind == ACTION_SET_ENTITY:
-            entity_after = evaluation.target_entity.name
-        elif evaluation.action_kind == ACTION_CLEAR_ENTITY:
-            entity_after = "—"
-        elif evaluation.action_kind == ACTION_CHANGE_ACCOUNT:
-            account_after = evaluation.to_account.name
-        rows.append(
-            {
-                "date": item.journal_entry.date,
-                "description": description,
-                "type": item.type,
-                "amount": item.amount,
-                "account_before": item.account.name,
-                "account_after": account_after,
-                "entity_before": entity_before,
-                "entity_after": entity_after,
-            }
-        )
-    return rows
+def _project_row(item: JournalEntryItem, evaluation: EvaluatedOperation) -> Dict[str, Any]:
+    """Projects one matched item to its before/after row for preview and export."""
+    transaction = getattr(item.journal_entry, "transaction", None)
+    description = (
+        transaction.description if transaction else item.journal_entry.description
+    )
+    entity_before = item.entity.name if item.entity else "—"
+    # Default to "no change", then let the action override its column, so a
+    # view (or unrecognized action) shows the item untouched rather than
+    # misprojecting.
+    entity_after = entity_before
+    account_after = item.account.name
+    if evaluation.action_kind == ACTION_SET_ENTITY:
+        entity_after = evaluation.target_entity.name
+    elif evaluation.action_kind == ACTION_CLEAR_ENTITY:
+        entity_after = "—"
+    elif evaluation.action_kind == ACTION_CHANGE_ACCOUNT:
+        account_after = evaluation.to_account.name
+    return {
+        "date": item.journal_entry.date,
+        "description": description,
+        "type": item.type,
+        "amount": item.amount,
+        "account_before": item.account.name,
+        "account_after": account_after,
+        "entity_before": entity_before,
+        "entity_after": entity_after,
+    }
+
+
+def _page_result(
+    evaluation: EvaluatedOperation,
+    op_index: int,
+    page_number: int,
+    page_size: int = SAMPLE_LIMIT,
+) -> PageResult:
+    """Paginates an evaluated (non-blocked) operation's matched items."""
+    paginator = Paginator(evaluation.queryset, page_size)
+    page_obj = paginator.get_page(page_number)  # clamps invalid page numbers
+    return PageResult(
+        op_index=op_index,
+        rows=[_project_row(item, evaluation) for item in page_obj.object_list],
+        page=page_obj.number,
+        num_pages=paginator.num_pages,
+        total=paginator.count,
+        has_previous=page_obj.has_previous(),
+        has_next=page_obj.has_next(),
+    )
 
 
 def preview_plan(operations: List[Dict[str, Any]]) -> PlanPreview:
     """Validates every operation and computes its exact effect for review."""
     op_previews: List[OperationPreview] = []
     total_affected = 0
+    total_changes = 0
     has_blocks = False
 
     for index, operation in enumerate(operations):
@@ -361,36 +413,83 @@ def preview_plan(operations: List[Dict[str, Any]]) -> PlanPreview:
                     criteria=evaluation.criteria,
                     action_summary=evaluation.action_summary,
                     affected_count=0,
-                    sample=[],
-                    has_more=False,
+                    page=None,
                     blocked=True,
                     error=" ".join(evaluation.errors),
+                    mutates=False,
                 )
             )
             continue
 
-        affected_count = evaluation.queryset.count()
+        page = _page_result(evaluation, index, 1)
+        affected_count = page.total
         total_affected += affected_count
+        mutates = _is_mutation(evaluation.action_kind)
+        if mutates:
+            total_changes += affected_count
         op_previews.append(
             OperationPreview(
                 index=index,
                 criteria=evaluation.criteria,
                 action_summary=evaluation.action_summary,
                 affected_count=affected_count,
-                sample=_build_sample(evaluation),
-                has_more=affected_count > SAMPLE_LIMIT,
+                page=page,
                 blocked=False,
                 error=None,
+                mutates=mutates,
             )
         )
 
-    can_apply = bool(operations) and not has_blocks and total_affected > 0
+    # Apply is offered only when something will actually change, so a pure
+    # view-only plan never shows an Apply button.
+    can_apply = bool(operations) and not has_blocks and total_changes > 0
     return PlanPreview(
         operations=op_previews,
         total_affected=total_affected,
+        total_changes=total_changes,
         has_blocks=has_blocks,
         can_apply=can_apply,
     )
+
+
+def _evaluate_at(
+    operations: List[Dict[str, Any]], op_index: int
+) -> Optional[EvaluatedOperation]:
+    """Re-evaluates the operation at ``op_index`` from its dict (never trusts a
+    stale preview). Returns None for an out-of-range index or a blocked op."""
+    if op_index < 0 or op_index >= len(operations):
+        return None
+    evaluation = _evaluate_operation(operations[op_index])
+    return None if evaluation.blocked else evaluation
+
+
+def build_export_rows(
+    operations: List[Dict[str, Any]], op_index: int
+) -> List[Dict[str, Any]]:
+    """Projects every matched item for one operation (no SAMPLE_LIMIT slice), so
+    the export reflects the live ledger. Returns ``[]`` for an out-of-range index
+    or a blocked operation."""
+    evaluation = _evaluate_at(operations, op_index)
+    if evaluation is None:
+        return []
+    return [_project_row(item, evaluation) for item in evaluation.queryset]
+
+
+def build_page(
+    operations: List[Dict[str, Any]],
+    op_index: int,
+    page_number: int,
+    page_size: int = SAMPLE_LIMIT,
+) -> Optional[PageResult]:
+    """Projects one page of an operation's matched items for inline paging.
+
+    Out-of-range page numbers are clamped; a blocked or out-of-range operation
+    yields None.
+    """
+    evaluation = _evaluate_at(operations, op_index)
+    if evaluation is None:
+        return None
+    return _page_result(evaluation, op_index, page_number, page_size)
 
 
 # --- Apply ------------------------------------------------------------------
@@ -435,6 +534,9 @@ def apply_plan(operations: List[Dict[str, Any]]) -> ApplyResult:
             updated_count += evaluation.queryset.update(
                 account=evaluation.to_account
             )
+        elif evaluation.action_kind == ACTION_VIEW:
+            # View is read-only; a mixed plan may include one, so skip it here.
+            pass
 
     return ApplyResult(success=True, updated_count=updated_count)
 

--- a/api/tests/services/test_recharacterize_services.py
+++ b/api/tests/services/test_recharacterize_services.py
@@ -7,7 +7,10 @@ from django.test import TestCase
 
 from api.models import Account, JournalEntryItem
 from api.services.recharacterize_services import (
+    SAMPLE_LIMIT,
     apply_plan,
+    build_export_rows,
+    build_page,
     preview_plan,
     run_turn,
 )
@@ -379,6 +382,184 @@ class RecharacterizeServicesTest(TestCase):
         tagged.refresh_from_db()
         self.assertEqual(untagged.entity, self.ally_bank)
         self.assertEqual(tagged.entity, other_entity)  # already tagged, untouched
+
+    # --- view-only operations -----------------------------------------------
+
+    def test_view_op_previews_without_changes_and_hides_apply(self):
+        ops = [
+            {
+                "filter": self._verizon_2025_checking_debit_filter(),
+                "action": {"type": "view"},
+            }
+        ]
+        preview = preview_plan(ops)
+        self.assertFalse(preview.has_blocks)
+        self.assertFalse(preview.can_apply)  # nothing to apply for a view
+        self.assertEqual(preview.total_changes, 0)
+        self.assertEqual(preview.total_affected, 2)
+
+        op = preview.operations[0]
+        self.assertFalse(op.mutates)
+        self.assertEqual(op.affected_count, 2)
+        # Preview page rows show no before/after diff.
+        for row in op.page.rows:
+            self.assertEqual(row["account_before"], row["account_after"])
+            self.assertEqual(row["entity_before"], row["entity_after"])
+
+    def test_view_op_is_noop_on_apply(self):
+        ops = [
+            {
+                "filter": self._verizon_2025_checking_debit_filter(),
+                "action": {"type": "view"},
+            }
+        ]
+        result = apply_plan(ops)
+        self.assertTrue(result.success)
+        self.assertEqual(result.updated_count, 0)
+        self.d1.refresh_from_db()
+        self.assertIsNone(self.d1.entity)
+
+    def test_mixed_view_and_mutation_counts_only_changes(self):
+        ops = [
+            {
+                "filter": self._verizon_2025_checking_debit_filter(),
+                "action": {"type": "view"},
+            },
+            {
+                "filter": {"description_contains": "Verizon", "account": "Groceries"},
+                "action": {"type": "set_entity", "entity": "Ally Bank"},
+            },
+        ]
+        preview = preview_plan(ops)
+        self.assertTrue(preview.can_apply)
+        self.assertFalse(preview.operations[0].mutates)
+        self.assertTrue(preview.operations[1].mutates)
+        # Only the mutating op's 3 grocery debits count toward changes.
+        self.assertEqual(preview.total_changes, 3)
+
+        result = apply_plan(ops)
+        self.assertTrue(result.success)
+        self.assertEqual(result.updated_count, 3)
+
+    # --- CSV export ---------------------------------------------------------
+
+    def test_export_returns_all_rows_beyond_sample_limit(self):
+        export_acct = AccountFactory(
+            name="Export Test",
+            type=Account.Type.EXPENSE,
+            sub_type=Account.SubType.OPERATING,
+            is_closed=False,
+        )
+        total = SAMPLE_LIMIT + 3
+        for i in range(total):
+            make_entry(
+                "Bulk export",
+                datetime.date(2025, 7, 1),
+                export_acct,
+                self.checking,
+            )
+        ops = [
+            {
+                "filter": {"account": "Export Test"},
+                "action": {"type": "view"},
+            }
+        ]
+        rows = build_export_rows(ops, 0)
+        self.assertEqual(len(rows), total)  # full universe, not just SAMPLE_LIMIT
+        first = rows[0]
+        self.assertIn("account_before", first)
+        self.assertIn("entity_after", first)
+
+    def test_export_reflects_proposed_changes(self):
+        ops = [
+            {
+                "filter": {"description_contains": "Verizon", "account": "Groceries"},
+                "action": {"type": "change_account", "to_account": "Dining"},
+            }
+        ]
+        rows = build_export_rows(ops, 0)
+        self.assertTrue(rows)
+        for row in rows:
+            self.assertEqual(row["account_before"], "Groceries")
+            self.assertEqual(row["account_after"], "Dining")
+
+    # --- inline pagination --------------------------------------------------
+
+    def _make_bulk_view_ops(self, total):
+        export_acct = AccountFactory(
+            name="Paged Test",
+            type=Account.Type.EXPENSE,
+            sub_type=Account.SubType.OPERATING,
+            is_closed=False,
+        )
+        for _ in range(total):
+            make_entry(
+                "Bulk paged",
+                datetime.date(2025, 7, 1),
+                export_acct,
+                self.checking,
+            )
+        return [{"filter": {"account": "Paged Test"}, "action": {"type": "view"}}]
+
+    def test_build_page_first_page_and_metadata(self):
+        total = SAMPLE_LIMIT + 3
+        ops = self._make_bulk_view_ops(total)
+        page = build_page(ops, 0, 1)
+        self.assertEqual(len(page.rows), SAMPLE_LIMIT)
+        self.assertEqual(page.total, total)
+        self.assertEqual(page.num_pages, 2)
+        self.assertEqual(page.page, 1)
+        self.assertFalse(page.has_previous)
+        self.assertTrue(page.has_next)
+
+    def test_build_page_last_page_has_remainder(self):
+        total = SAMPLE_LIMIT + 3
+        ops = self._make_bulk_view_ops(total)
+        page = build_page(ops, 0, 2)
+        self.assertEqual(len(page.rows), 3)
+        self.assertTrue(page.has_previous)
+        self.assertFalse(page.has_next)
+
+    def test_build_page_clamps_out_of_range_page(self):
+        ops = self._make_bulk_view_ops(SAMPLE_LIMIT + 3)
+        page = build_page(ops, 0, 99)
+        self.assertIsNotNone(page)
+        self.assertEqual(page.page, page.num_pages)  # clamped to last page
+
+    def test_build_page_none_for_blocked_or_out_of_range_op(self):
+        blocked_ops = [
+            {
+                "filter": {"account": "Ally Checking"},
+                "action": {"type": "set_entity", "entity": "Nonexistent Bank"},
+            }
+        ]
+        self.assertIsNone(build_page(blocked_ops, 0, 1))
+        self.assertIsNone(build_page(blocked_ops, 5, 1))
+        self.assertIsNone(build_page([], 0, 1))
+
+    def test_build_page_reflects_proposed_changes(self):
+        ops = [
+            {
+                "filter": {"description_contains": "Verizon", "account": "Groceries"},
+                "action": {"type": "change_account", "to_account": "Dining"},
+            }
+        ]
+        page = build_page(ops, 0, 1)
+        self.assertTrue(page.rows)
+        for row in page.rows:
+            self.assertEqual(row["account_before"], "Groceries")
+            self.assertEqual(row["account_after"], "Dining")
+
+    def test_export_empty_for_blocked_or_out_of_range(self):
+        blocked_ops = [
+            {
+                "filter": {"account": "Ally Checking"},
+                "action": {"type": "set_entity", "entity": "Nonexistent Bank"},
+            }
+        ]
+        self.assertEqual(build_export_rows(blocked_ops, 0), [])
+        self.assertEqual(build_export_rows(blocked_ops, 5), [])
+        self.assertEqual(build_export_rows([], 0), [])
 
     # --- turn orchestration (model mocked) ----------------------------------
 

--- a/api/tests/views/test_recharacterize_views.py
+++ b/api/tests/views/test_recharacterize_views.py
@@ -162,3 +162,107 @@ class RecharacterizeViewsTest(TestCase):
         resp = self.client.post(reverse("recharacterize-retry"))
         self.assertEqual(resp.status_code, 200)
         self.assertContains(resp, "recharacterize-main")
+
+    @patch("api.services.recharacterize_services.gemini_services.call_gemini_conversation")
+    def test_view_only_message_shows_export_link_and_no_apply(self, mock_call):
+        mock_call.return_value = json.dumps(
+            {
+                "reply": "Here are your Verizon debits.",
+                "operations": [
+                    {
+                        "filter": {"account": "Ally Checking", "entry_type": "debit"},
+                        "action": {"type": "view"},
+                    }
+                ],
+            }
+        )
+        resp = self.client.post(
+            reverse("recharacterize-message"), {"message": "show me verizon debits"}
+        )
+        self.assertEqual(resp.status_code, 200)
+        self.assertContains(resp, "Export all")
+        self.assertNotContains(resp, "Apply (")  # view-only: no Apply button
+
+    @patch("api.services.recharacterize_services.gemini_services.call_gemini_conversation")
+    def test_export_streams_csv_of_matched_items(self, mock_call):
+        mock_call.return_value = json.dumps(
+            {
+                "reply": "Here you go.",
+                "operations": [
+                    {
+                        "filter": {"account": "Ally Checking", "entry_type": "debit"},
+                        "action": {"type": "view"},
+                    }
+                ],
+            }
+        )
+        # Populate the session with a proposed plan.
+        self.client.post(
+            reverse("recharacterize-message"), {"message": "show me debits"}
+        )
+
+        resp = self.client.get(reverse("recharacterize-export"), {"op": "0"})
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(resp["Content-Type"], "text/csv")
+        self.assertIn("attachment", resp["Content-Disposition"])
+        body = resp.content.decode()
+        self.assertIn("Account Before", body)  # header row
+        self.assertIn("Ally Checking", body)  # the matched item
+
+    def test_export_with_no_session_returns_header_only_csv(self):
+        resp = self.client.get(reverse("recharacterize-export"), {"op": "0"})
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(resp["Content-Type"], "text/csv")
+        body = resp.content.decode().strip().splitlines()
+        self.assertEqual(len(body), 1)  # header only, no data rows
+
+    @patch("api.services.recharacterize_services.gemini_services.call_gemini_conversation")
+    def test_page_endpoint_returns_paginated_fragment(self, mock_call):
+        # 30 matching debits so the preview sample (25) has more to expand.
+        for i in range(30):
+            txn = TransactionFactory(
+                description=f"Verizon {i}",
+                date=datetime.date(2025, 4, 1),
+                is_closed=True,
+            )
+            je = JournalEntryFactory(transaction=txn, date=txn.date)
+            JournalEntryItemFactory(
+                journal_entry=je,
+                account=self.checking,
+                type=JournalEntryItem.JournalEntryType.DEBIT,
+                amount=Decimal("10.00"),
+            )
+        mock_call.return_value = json.dumps(
+            {
+                "reply": "Here are your debits.",
+                "operations": [
+                    {
+                        "filter": {"account": "Ally Checking", "entry_type": "debit"},
+                        "action": {"type": "view"},
+                    }
+                ],
+            }
+        )
+        resp = self.client.post(
+            reverse("recharacterize-message"), {"message": "show debits"}
+        )
+        # With >1 page the preview shows the pager inline (no "View all" gate).
+        self.assertContains(resp, "Page 1 of")
+        self.assertContains(resp, "Next")
+        self.assertContains(resp, reverse("recharacterize-page"))
+
+        # Page 1 fragment paginates with a Next control.
+        resp = self.client.get(
+            reverse("recharacterize-page"), {"op": "0", "page": "1"}
+        )
+        self.assertEqual(resp.status_code, 200)
+        self.assertContains(resp, "affected-region-0")
+        self.assertContains(resp, "Page 1 of")
+        self.assertContains(resp, "Next")
+
+    def test_page_endpoint_with_no_session_renders_empty(self):
+        resp = self.client.get(
+            reverse("recharacterize-page"), {"op": "0", "page": "1"}
+        )
+        self.assertEqual(resp.status_code, 200)
+        self.assertContains(resp, "No items to show")

--- a/api/views/recharacterize_helpers.py
+++ b/api/views/recharacterize_helpers.py
@@ -8,7 +8,7 @@ from typing import Dict, List, Optional
 
 from django.template.loader import render_to_string
 
-from api.services.recharacterize_services import PlanPreview
+from api.services.recharacterize_services import PageResult, PlanPreview
 from api.utils import friendly_error_message, short_error_label
 
 
@@ -38,6 +38,14 @@ def render_main(
     return render_to_string(
         "api/components/recharacterize-main.html",
         {"messages": messages, "preview": preview, "flash": flash, "error": error},
+    )
+
+
+def render_affected_page(page: Optional[PageResult]) -> str:
+    """Renders the swappable, paginated table region for one operation."""
+    return render_to_string(
+        "api/tables/recharacterize-affected-page.html",
+        {"page": page},
     )
 
 

--- a/api/views/recharacterize_views.py
+++ b/api/views/recharacterize_views.py
@@ -6,6 +6,8 @@ via recharacterize_helpers. The conversation and the latest proposed plan live
 in the session; apply always re-validates from the stored plan.
 """
 
+import csv
+
 from django.contrib.auth.mixins import LoginRequiredMixin
 from django.http import HttpResponse
 from django.views import View
@@ -24,6 +26,14 @@ def _get_state(request) -> dict:
 def _save_state(request, messages, operations) -> None:
     request.session[SESSION_KEY] = {"messages": messages, "operations": operations}
     request.session.modified = True
+
+
+def _parse_op_index(request) -> int:
+    """Reads the ``op`` query param as an int, or -1 when absent/invalid."""
+    try:
+        return int(request.GET.get("op", ""))
+    except (TypeError, ValueError):
+        return -1
 
 
 def _render_unchanged(messages, operations) -> str:
@@ -133,6 +143,81 @@ class RecharacterizeApplyView(LoginRequiredMixin, View):
         _save_state(request, messages=messages, operations=[])
         html = recharacterize_helpers.render_main(messages, preview=None, flash=flash)
         return HttpResponse(html)
+
+
+class RecharacterizePageView(LoginRequiredMixin, View):
+    """Returns one paginated page of an operation's matched items.
+
+    Lets the user expand past the 25-row preview sample and page through the full
+    matched set inline (read-only; no mutation).
+    """
+
+    login_url = "/login/"
+
+    def get(self, request):
+        state = _get_state(request)
+        operations = state["operations"]
+
+        op_index = _parse_op_index(request)
+        try:
+            page_number = int(request.GET.get("page", "1"))
+        except (TypeError, ValueError):
+            page_number = 1
+
+        page = recharacterize_services.build_page(operations, op_index, page_number)
+        html = recharacterize_helpers.render_affected_page(page)
+        return HttpResponse(html)
+
+
+class RecharacterizeExportView(LoginRequiredMixin, View):
+    """Streams every matched item for one operation as a CSV download.
+
+    The preview table is capped at SAMPLE_LIMIT rows; this exposes the full
+    matched universe (with proposed before/after columns) for an operation.
+    """
+
+    login_url = "/login/"
+
+    def get(self, request):
+        state = _get_state(request)
+        operations = state["operations"]
+
+        op_index = _parse_op_index(request)
+        rows = recharacterize_services.build_export_rows(operations, op_index)
+
+        response = HttpResponse(
+            content_type="text/csv",
+            headers={
+                "Content-Disposition": 'attachment; filename="recharacterize.csv"'
+            },
+        )
+        writer = csv.writer(response)
+        writer.writerow(
+            [
+                "Date",
+                "Description",
+                "Type",
+                "Amount",
+                "Account Before",
+                "Account After",
+                "Entity Before",
+                "Entity After",
+            ]
+        )
+        for row in rows:
+            writer.writerow(
+                [
+                    row["date"],
+                    row["description"],
+                    row["type"],
+                    row["amount"],
+                    row["account_before"],
+                    row["account_after"],
+                    row["entity_before"],
+                    row["entity_after"],
+                ]
+            )
+        return response
 
 
 class RecharacterizeResetView(LoginRequiredMixin, View):

--- a/ledger/static/css/app.css
+++ b/ledger/static/css/app.css
@@ -590,6 +590,9 @@ h4, h5 { font-size: var(--fs-md); font-weight: 600; margin: 0 0 var(--space-2); 
 .criteria-label { color: var(--text-4); }
 .criteria-value { color: var(--text-1); font-weight: 600; text-align: right; }
 
+/* Paginated affected-items table */
+.pager { display: flex; align-items: center; gap: var(--space-3); }
+
 /* 14. ---- Mobile reflow (breakpoint: 760px) ------------------------------
    Single-column everywhere; nav collapses to a toggle panel; multi-column
    grids stack; tables can switch to the stacked .list. */

--- a/ledger/templates/api/components/recharacterize-preview.html
+++ b/ledger/templates/api/components/recharacterize-preview.html
@@ -26,13 +26,16 @@
         {% else %}
             <div class="mt-2">
                 <strong>{{ op.affected_count }}</strong>
-                item{{ op.affected_count|pluralize }} will change.
+                item{{ op.affected_count|pluralize }}
+                {% if op.mutates %}will change{% else %}match{% endif %}.
             </div>
-            {% if op.sample %}
-                {% include "api/tables/recharacterize-affected-table.html" with rows=op.sample %}
-                {% if op.has_more %}
-                <p class="muted">Showing the first {{ op.sample|length }}.</p>
-                {% endif %}
+            {% if op.page.rows %}
+                {% include "api/tables/recharacterize-affected-page.html" with page=op.page %}
+                <p class="mt-2">
+                    <a href="{% url 'recharacterize-export' %}?op={{ op.index }}">
+                        Export all {{ op.affected_count }} as CSV
+                    </a>
+                </p>
             {% endif %}
         {% endif %}
     </div>
@@ -49,8 +52,8 @@
             hx-post="{% url 'recharacterize-apply' %}"
             hx-target="#recharacterize-main"
             hx-swap="outerHTML"
-            hx-confirm="Apply this plan to {{ preview.total_affected }} journal entry item{{ preview.total_affected|pluralize }}?">
-        Apply ({{ preview.total_affected }})
+            hx-confirm="Apply this plan to {{ preview.total_changes }} journal entry item{{ preview.total_changes|pluralize }}?">
+        Apply ({{ preview.total_changes }})
     </button>
     {% endif %}
 {% else %}

--- a/ledger/templates/api/tables/recharacterize-affected-page.html
+++ b/ledger/templates/api/tables/recharacterize-affected-page.html
@@ -1,0 +1,26 @@
+<div class="affected-region" id="affected-region-{{ page.op_index }}">
+    {% if page and page.rows %}
+        {% include "api/tables/recharacterize-affected-table.html" with rows=page.rows %}
+        {% if page.num_pages > 1 %}
+        <div class="pager mt-2">
+            {% if page.has_previous %}
+            <button type="button" class="btn btn-secondary btn-sm"
+                    hx-get="{% url 'recharacterize-page' %}?op={{ page.op_index }}&page={{ page.page|add:'-1' }}"
+                    hx-target="#affected-region-{{ page.op_index }}"
+                    hx-swap="outerHTML">Prev</button>
+            {% endif %}
+            <span class="muted">
+                Page {{ page.page }} of {{ page.num_pages }} ({{ page.total }} item{{ page.total|pluralize }})
+            </span>
+            {% if page.has_next %}
+            <button type="button" class="btn btn-secondary btn-sm"
+                    hx-get="{% url 'recharacterize-page' %}?op={{ page.op_index }}&page={{ page.page|add:'1' }}"
+                    hx-target="#affected-region-{{ page.op_index }}"
+                    hx-swap="outerHTML">Next</button>
+            {% endif %}
+        </div>
+        {% endif %}
+    {% else %}
+        <p class="muted">No items to show.</p>
+    {% endif %}
+</div>

--- a/ledger/urls.py
+++ b/ledger/urls.py
@@ -28,7 +28,9 @@ from api.views.journal_entry_views import (
 from api.views.reconciliation_views import ReconciliationTableView, ReconciliationView
 from api.views.recharacterize_views import (
     RecharacterizeApplyView,
+    RecharacterizeExportView,
     RecharacterizeMessageView,
+    RecharacterizePageView,
     RecharacterizeResetView,
     RecharacterizeRetryView,
     RecharacterizeView,
@@ -190,6 +192,16 @@ urlpatterns = [
         "recharacterize/reset/",
         RecharacterizeResetView.as_view(),
         name="recharacterize-reset",
+    ),
+    path(
+        "recharacterize/export/",
+        RecharacterizeExportView.as_view(),
+        name="recharacterize-export",
+    ),
+    path(
+        "recharacterize/page/",
+        RecharacterizePageView.as_view(),
+        name="recharacterize-page",
     ),
     # Tagging balances
     path(


### PR DESCRIPTION
## Context

When recharacterizing, you often want to *view* a set of journal entry items before deciding what to do — to dial in your criteria. Previously every LLM-proposed operation had to carry a mutating action (`set_entity` / `clear_entity` / `change_account`), and the preview was hard-capped at 25 rows with no way to see the rest.

## What's new

- **View-only operations** — a new `view` action inspects matched items without changing anything (e.g. "Show me all my Verizon debit entries"). The Apply button is hidden unless a plan contains a mutating operation (`can_apply` now keys off a new `total_changes`).
- **Per-table CSV export** — each non-blocked operation gets an "Export all N as CSV" link that downloads its *full* matched universe (not just the 25-row sample), with proposed before/after columns.
- **Inline pagination** — the preview renders the matched set paginated (page size 25) and pages inline via HTMX; the pager appears only when there's more than one page.

## Implementation notes

- Row projection is shared across preview, export, and paging (`_project_row`).
- Read-only inspection (`build_page` / `build_export_rows`) re-evaluates operations from the stored plan rather than trusting a stale preview, and `_evaluate_at` centralizes the index/blocked guard.
- `view` ops are explicitly skipped in `apply_plan` (a mixed plan may include one).
- New endpoints: `recharacterize/page/` and `recharacterize/export/`.

## Testing

`uv run python manage.py test api.tests.services.test_recharacterize_services api.tests.views.test_recharacterize_views` — 42 tests pass, covering view-only previews, the Apply gate, CSV export (full universe / before-after / blocked), and pagination (metadata, clamping, None for blocked/out-of-range).

🤖 Generated with [Claude Code](https://claude.com/claude-code)