### PR TITLE
Show "Agent is thinking…" indicator during recharacterize turns

### DIFF
--- a/ledger/static/css/app.css
+++ b/ledger/static/css/app.css
@@ -572,6 +572,10 @@ h4, h5 { font-size: var(--fs-md); font-weight: 600; margin: 0 0 var(--space-2); 
 .chat-msg-assistant { align-self: flex-start; background: var(--surface); border: 1px solid var(--border); }
 .chat-role { display: block; font-size: var(--fs-sm); color: var(--text-muted); margin-bottom: var(--space-1); }
 .chat-text { font-size: var(--fs-md); white-space: pre-wrap; }
+/* Pending "Agent is thinking…" bubble: hidden until htmx flags the in-flight
+   request on its hx-indicator target. display:block keeps the flex align-self. */
+.chat-thinking { display: none; }
+.chat-thinking.htmx-request { display: block; }
 
 /* The two columns are adjacent .card siblings; cancel the stacked-card top
    margin so the chat and preview panels align at the top. */

--- a/ledger/static/css/app.css
+++ b/ledger/static/css/app.css
@@ -572,9 +572,10 @@ h4, h5 { font-size: var(--fs-md); font-weight: 600; margin: 0 0 var(--space-2); 
 .chat-msg-assistant { align-self: flex-start; background: var(--surface); border: 1px solid var(--border); }
 .chat-role { display: block; font-size: var(--fs-sm); color: var(--text-muted); margin-bottom: var(--space-1); }
 .chat-text { font-size: var(--fs-md); white-space: pre-wrap; }
-/* Pending "Agent is thinking…" bubble: hidden until htmx flags the in-flight
-   request on its hx-indicator target. display:block keeps the flex align-self. */
-.chat-thinking { display: none; }
+/* Pending "Agent is thinking…" bubble: styled like an assistant message but
+   kept off the .chat-msg-assistant class so it isn't mistaken for a real reply.
+   Hidden until htmx flags the in-flight request on its hx-indicator target. */
+.chat-thinking { display: none; align-self: flex-start; background: var(--surface); border: 1px solid var(--border); }
 .chat-thinking.htmx-request { display: block; }
 
 /* The two columns are adjacent .card siblings; cancel the stacked-card top

--- a/ledger/templates/api/components/recharacterize-main.html
+++ b/ledger/templates/api/components/recharacterize-main.html
@@ -1,4 +1,5 @@
-<div id="recharacterize-main" class="grid grid-2">
+<div id="recharacterize-main" class="grid grid-2"
+     hx-on::before-request="var l=document.getElementById('chat-log'); if(l){l.scrollTop=l.scrollHeight;}">
     <div class="card">
         <div id="chat-log" class="chat-log">
             {% for message in messages %}
@@ -6,6 +7,10 @@
             {% empty %}
                 <p class="muted">No messages yet. Describe the change you want to make.</p>
             {% endfor %}
+            <div id="chat-thinking" class="chat-msg chat-msg-assistant chat-thinking">
+                <span class="chat-role">Agent</span>
+                <div class="chat-text">⚙️ Thinking…</div>
+            </div>
         </div>
 
         {% if error %}
@@ -14,14 +19,18 @@
             <button type="button" class="btn btn-secondary btn-sm mt-2"
                     hx-post="{% url 'recharacterize-retry' %}"
                     hx-target="#recharacterize-main"
-                    hx-swap="outerHTML">↻ Retry</button>
+                    hx-swap="outerHTML"
+                    hx-indicator="#chat-thinking"
+                    hx-disabled-elt="this">↻ Retry</button>
         </div>
         {% endif %}
 
         <form id="chat-form" class="mt-3"
               hx-post="{% url 'recharacterize-message' %}"
               hx-target="#recharacterize-main"
-              hx-swap="outerHTML">
+              hx-swap="outerHTML"
+              hx-indicator="#chat-thinking"
+              hx-disabled-elt="find button[type=submit]">
             {% csrf_token %}
             <textarea name="message" class="textarea" rows="3"
                       placeholder="Describe the change…" required></textarea>

--- a/ledger/templates/api/components/recharacterize-main.html
+++ b/ledger/templates/api/components/recharacterize-main.html
@@ -7,7 +7,7 @@
             {% empty %}
                 <p class="muted">No messages yet. Describe the change you want to make.</p>
             {% endfor %}
-            <div id="chat-thinking" class="chat-msg chat-msg-assistant chat-thinking">
+            <div id="chat-thinking" class="chat-msg chat-thinking">
                 <span class="chat-role">Agent</span>
                 <div class="chat-text">⚙️ Thinking…</div>
             </div>


### PR DESCRIPTION
## What

Adds a "waiting for response" indicator to the recharacterize chat. The synchronous Gemini turn previously ran with no UI feedback — between clicking **Send** (or **Retry**) and the region swap, nothing showed a request was in flight.

This was worst on the **Retry** path: a repeated same-error failure looked identical to clicking nothing, so the user couldn't tell a round trip had happened.

## How

- A hidden `#chat-thinking` "⚙️ Thinking…" assistant bubble at the bottom of the chat log, shown via htmx's `hx-indicator` / `.htmx-request` pattern only while a Send/Retry request is active.
- The triggering button is disabled for the request duration (`hx-disabled-elt`), preventing double-clicks and visibly greying out.
- The pre-request scroll that reveals the bubble is declared once on the `#recharacterize-main` container (htmx events bubble) rather than duplicated per trigger.
- The indicator stays scoped to the two LLM-triggering elements (form + Retry) so pagination (Prev/Next) and Apply don't flash a misleading "thinking" bubble.

Reuses the existing htmx busy-indicator pattern from `bills-content.html`. No backend, view, or service changes.

## Testing

Front-end only (no Python touched). Verified manually:
- Send a message → "⚙️ Thinking…" bubble appears, Send disabled, both clear on swap.
- Force a failed turn → click **↻ Retry** → bubble flashes and Retry disables each attempt, so a repeated same-error failure still visibly shows a round trip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)