### PR TITLE
Space account form actions and preserve list filter on save

### DIFF
--- a/ledger/static/css/app.css
+++ b/ledger/static/css/app.css
@@ -423,7 +423,7 @@ h4, h5 { font-size: var(--fs-md); font-weight: 600; margin: 0 0 var(--space-2); 
 .check { display: inline-flex; align-items: center; gap: 7px; font-size: var(--fs-body); color: var(--text-1); cursor: pointer; }
 .check input { width: 14px; height: 14px; accent-color: var(--color-primary); cursor: pointer; margin: 0; }
 
-.actions { display: flex; gap: 9px; flex-wrap: wrap; }
+.actions { display: flex; gap: 9px; flex-wrap: wrap; margin-top: var(--space-4); }
 .field-error { font-size: var(--fs-sm); color: var(--color-danger); margin-top: var(--space-1); }
 
 /* Currency / prefixed input (replaces Bootstrap input-group) */

--- a/ledger/templates/api/base.html
+++ b/ledger/templates/api/base.html
@@ -86,10 +86,16 @@
         // Live search + selection state shared by the Settings list fragments
         // (Accounts, Loans, Bill Rules). Rows carry data-search; the desktop
         // <tr data-search> set drives the visible count.
+        //
+        // Remembers each list's live query so it survives htmx innerHTML swaps
+        // (e.g. saving an account re-renders the fragment). Keyed by noun; lives
+        // for the page lifetime, so a full reload still starts clean.
+        const searchListQueries = {};
         Alpine.data('searchList', (total, noun, selectedId = null) => ({
-            q: '',
+            q: searchListQueries[noun] || '',
             selectedId: selectedId,
             total: total,
+            init() { this.$watch('q', v => { searchListQueries[noun] = v; }); },
             matches(el) { return !this.q.trim() || el.dataset.search.includes(this.q.toLowerCase()); },
             visible() {
                 if (!this.q.trim()) return this.total;


### PR DESCRIPTION
## Summary

Two polish fixes to the Settings → Accounts page:

1. **Cramped action buttons** — the `.actions` row (Save / Delete / Clear) sat flush against the last field row. `.grid` only sets an internal `gap`, and `.actions` had no `margin-top`, so stacked form blocks had no vertical rhythm. Added `margin-top: var(--space-4)` to the shared `.actions` class, fixing every form that uses the `.grid` + `.actions` pattern consistently.

2. **Filter lost on save** — clicking a form button does `hx-post … hx-target="#settings-content" hx-swap="innerHTML"`, which re-renders the whole fragment including its `x-data="searchList(...)"` wrapper, resetting the live search query `q`. Now each list's query is persisted in a page-lifetime map keyed by `noun`, seeded on `init()` and synced via `$watch`, so it survives the swap. `selectedId` and `total` already flow correctly from the server on each re-render — only the client-owned query needed preserving. The shared `searchList` component means Accounts, Loans, and Bill Rules all benefit.

## Verification

Manual (no automated tests cover this CSS/Alpine behavior):
- Open Settings → Accounts; confirm a clear gap now sits between the field row and the action buttons.
- Filter to e.g. "taxes", edit a matching account, click Save — the filter, count label, and row selection all persist through the re-render. Repeat with Delete.

🤖 Generated with [Claude Code](https://claude.com/claude-code)