### PR TITLE
Add entity breakout toggle to income statement

### DIFF
--- a/api/models.py
+++ b/api/models.py
@@ -862,6 +862,19 @@ class JournalEntryItem(models.Model):
         self.entity = None
         self.save()
 
+    def get_signed_amount(self):
+        """This item's signed contribution to its account's balance.
+
+        Positive when the item increases the account's natural balance,
+        negative when it decreases it — the same debit/credit convention used
+        for aggregate balances in Account.get_balance_from_debit_and_credit.
+        """
+        debit = self.amount if self.type == self.JournalEntryType.DEBIT else 0
+        credit = self.amount if self.type == self.JournalEntryType.CREDIT else 0
+        return Account.get_balance_from_debit_and_credit(
+            self.account.type, debits=debit, credits=credit
+        )
+
 
 class AutoTag(models.Model):
     search_string = models.CharField(max_length=20)

--- a/api/services/statement_services.py
+++ b/api/services/statement_services.py
@@ -14,7 +14,13 @@ from typing import Any, Dict, List, Optional
 from django.db.models import Case, DecimalField, F, Sum, When
 
 from api.models import Account, JournalEntry, JournalEntryItem
-from api.statement import Balance, BalanceSheet, CashFlowStatement, IncomeStatement
+from api.statement import (
+    Balance,
+    BalanceSheet,
+    CashFlowStatement,
+    EntityBalance,
+    IncomeStatement,
+)
 
 
 @dataclass
@@ -40,6 +46,17 @@ class StatementSummary:
     """Hierarchical summary organized by account type/sub_type."""
 
     account_types: Dict[str, AccountTypeSummary]
+
+
+@dataclass
+class EntityIncomeSummary:
+    """Income statement summary organized by entity instead of by account."""
+
+    income_total: Decimal
+    income_balances: List[EntityBalance]
+    expense_total: Decimal
+    expense_balances: List[EntityBalance]
+    net_income: Decimal
 
 
 @dataclass
@@ -149,6 +166,55 @@ def build_statement_summary(statement: Any) -> StatementSummary:
     return StatementSummary(account_types=account_types)
 
 
+def _sort_entity_balances(balances: List[EntityBalance]) -> List[EntityBalance]:
+    """Sort entity balances by name, keeping the Unassigned bucket last."""
+    return sorted(
+        balances,
+        key=lambda balance: (balance.entity_id is None, balance.name.lower()),
+    )
+
+
+def build_entity_income_summary(
+    income_statement: IncomeStatement,
+) -> EntityIncomeSummary:
+    """
+    Build an income statement summary grouped by entity.
+
+    Splits the statement's entity-level balances into income and expense
+    sections (each sorted by name, Unassigned last) and totals them. Net
+    income is income_total - expense_total, which reconciles to the
+    by-account income statement's net income.
+
+    Args:
+        income_statement: IncomeStatement for the period
+
+    Returns:
+        EntityIncomeSummary with per-entity income/expense balances and totals
+    """
+    income_balances: List[EntityBalance] = []
+    expense_balances: List[EntityBalance] = []
+    for balance in income_statement.get_entity_balances():
+        if balance.account_type == Account.Type.INCOME:
+            income_balances.append(balance)
+        else:
+            expense_balances.append(balance)
+
+    income_total = sum(
+        (balance.amount for balance in income_balances), Decimal("0")
+    )
+    expense_total = sum(
+        (balance.amount for balance in expense_balances), Decimal("0")
+    )
+
+    return EntityIncomeSummary(
+        income_total=income_total,
+        income_balances=_sort_entity_balances(income_balances),
+        expense_total=expense_total,
+        expense_balances=_sort_entity_balances(expense_balances),
+        net_income=income_total - expense_total,
+    )
+
+
 def find_unbalanced_journal_entries() -> UnbalancedEntriesResult:
     """
     Find journal entries where total debits don't equal total credits.
@@ -223,7 +289,7 @@ def get_statement_detail_items(
 
     # Apply signing logic
     for entry in journal_entry_items:
-        entry.amount_signed = entry.amount
+        entry.amount_signed = entry.get_signed_amount()
 
         # Prefer the human-readable entity name; fall back to the raw
         # transaction description when the item has no entity.
@@ -232,20 +298,6 @@ def get_statement_detail_items(
             if entry.entity
             else entry.journal_entry.transaction.description
         )
-
-        # INCOME debits are negative (reduces income)
-        if (
-            entry.account.type == Account.Type.INCOME
-            and entry.type == JournalEntryItem.JournalEntryType.DEBIT
-        ):
-            entry.amount_signed *= -1
-
-        # EXPENSE credits are negative (reduces expense)
-        if (
-            entry.account.type == Account.Type.EXPENSE
-            and entry.type == JournalEntryItem.JournalEntryType.CREDIT
-        ):
-            entry.amount_signed *= -1
 
     # Get the account
     account = None
@@ -256,6 +308,56 @@ def get_statement_detail_items(
         journal_entry_items=journal_entry_items,
         account=account,
     )
+
+
+def get_statement_detail_items_by_entity(
+    entity_id: Optional[int],
+    account_type: str,
+    from_date: str,
+    to_date: str,
+) -> StatementDetailData:
+    """
+    Get journal entry items for an entity within a statement section.
+
+    Parallels get_statement_detail_items but pivots on entity + account type
+    (income or expense). entity_id of None selects the Unassigned bucket
+    (items with no entity). Applies the same income-debit / expense-credit
+    sign rules, and labels each row with its account name (the entity is
+    fixed in this view).
+
+    Args:
+        entity_id: The entity ID, or None for the Unassigned bucket
+        account_type: "income" or "expense"
+        from_date: Start date (string, YYYY-MM-DD)
+        to_date: End date (string, YYYY-MM-DD)
+
+    Returns:
+        StatementDetailData with signed journal entry items
+    """
+    queryset = JournalEntryItem.objects.filter(
+        account__type=account_type,
+        journal_entry__date__gte=from_date,
+        journal_entry__date__lte=to_date,
+        amount__gt=0,
+    )
+    if entity_id is None:
+        queryset = queryset.filter(entity__isnull=True)
+    else:
+        queryset = queryset.filter(entity__pk=entity_id)
+
+    journal_entry_items = list(
+        queryset.select_related(
+            "journal_entry__transaction", "account", "entity"
+        ).order_by("journal_entry__date")
+    )
+
+    for entry in journal_entry_items:
+        entry.amount_signed = entry.get_signed_amount()
+
+        # The entity is fixed for this view, so surface the account instead.
+        entry.display_label = entry.account.name
+
+    return StatementDetailData(journal_entry_items=journal_entry_items)
 
 
 def calculate_cash_flow_metrics(from_date: date, to_date: date) -> CashFlowMetrics:

--- a/api/statement.py
+++ b/api/statement.py
@@ -60,6 +60,31 @@ class Balance:
         self.type = type
 
 
+EntityBalance = namedtuple(
+    "EntityBalance", ["entity_id", "name", "amount", "account_type"]
+)
+
+
+def _debit_credit_total_annotations():
+    """Aggregation kwargs summing a queryset's amounts into debit/credit totals."""
+    return {
+        "debit_total": Sum(
+            Case(
+                When(type="debit", then="amount"),
+                output_field=DecimalField(),
+                default=Value(0),
+            )
+        ),
+        "credit_total": Sum(
+            Case(
+                When(type="credit", then="amount"),
+                output_field=DecimalField(),
+                default=Value(0),
+            )
+        ),
+    }
+
+
 class Metric:
     def __init__(self, name, value, metric_type="total"):
         self.name = name
@@ -106,20 +131,7 @@ class Statement:
 
         aggregates = list(
             aggregates.values("account__name").annotate(
-                debit_total=Sum(
-                    Case(
-                        When(type="debit", then="amount"),
-                        output_field=DecimalField(),
-                        default=Value(0),
-                    )
-                ),
-                credit_total=Sum(
-                    Case(
-                        When(type="credit", then="amount"),
-                        output_field=DecimalField(),
-                        default=Value(0),
-                    )
-                ),
+                **_debit_credit_total_annotations()
             )
         )
 
@@ -461,6 +473,45 @@ class IncomeStatement(Statement):
             )
         )
         self.summaries = self.get_summaries()
+
+    def get_entity_balances(self):
+        """Aggregate income/expense activity by entity instead of by account.
+
+        Mirrors the DB-aggregation style of ``Statement.get_balances`` but
+        groups on the journal entry item's ``entity`` (and account type so the
+        correct debit/credit signing is applied). Items with no entity are
+        bucketed under "Unassigned". Returns a flat list of ``EntityBalance``
+        records carrying the account type, so callers can split income from
+        expense and have the per-section totals reconcile to the by-account
+        Income/Expense totals.
+        """
+        ACCOUNT_TYPES = ["income", "expense"]
+        aggregates = JournalEntryItem.objects.filter(
+            account__type__in=ACCOUNT_TYPES,
+            journal_entry__date__gte=self.start_date,
+            journal_entry__date__lte=self.end_date,
+        ).values("entity", "entity__name", "account__type").annotate(
+            **_debit_credit_total_annotations()
+        )
+
+        entity_balances = []
+        for aggregate in aggregates:
+            account_type = aggregate["account__type"]
+            amount = Account.get_balance_from_debit_and_credit(
+                account_type,
+                debits=aggregate["debit_total"],
+                credits=aggregate["credit_total"],
+            )
+            entity_balances.append(
+                EntityBalance(
+                    entity_id=aggregate["entity"],
+                    name=aggregate["entity__name"] or "Unassigned",
+                    amount=amount,
+                    account_type=account_type,
+                )
+            )
+
+        return entity_balances
 
     def get_net_income(self):
         net_income = 0

--- a/api/tests/services/test_statement_services.py
+++ b/api/tests/services/test_statement_services.py
@@ -11,16 +11,19 @@ from django.test import TestCase
 from api.models import Account, JournalEntryItem
 from api.services.statement_services import (
     CashFlowMetrics,
+    EntityIncomeSummary,
     StatementDetailData,
     StatementSummary,
     UnbalancedEntriesResult,
+    build_entity_income_summary,
     build_statement_summary,
     calculate_cash_flow_metrics,
     filter_closed_accounts,
     find_unbalanced_journal_entries,
     get_statement_detail_items,
+    get_statement_detail_items_by_entity,
 )
-from api.statement import Balance
+from api.statement import Balance, IncomeStatement
 from api.tests.testing_factories import (
     AccountFactory,
     EntityFactory,
@@ -520,3 +523,206 @@ class CalculateCashFlowMetricsTest(TestCase):
 
         # Just verify we get a valid result
         self.assertIsInstance(result, CashFlowMetrics)
+
+
+class BuildEntityIncomeSummaryTest(TestCase):
+    """Tests for build_entity_income_summary()."""
+
+    def _make_item(self, account, entity, amount, entry_type):
+        entry = JournalEntryFactory(date=date(2024, 6, 15))
+        JournalEntryItemFactory(
+            journal_entry=entry,
+            account=account,
+            entity=entity,
+            amount=amount,
+            type=entry_type,
+        )
+
+    def _summary(self):
+        statement = IncomeStatement(end_date="2024-12-31", start_date="2024-01-01")
+        return statement, build_entity_income_summary(statement)
+
+    def test_groups_income_and_expense_by_entity(self):
+        """Income/expense activity should be totaled per entity."""
+        income_account = AccountFactory(type=Account.Type.INCOME)
+        expense_account = AccountFactory(type=Account.Type.EXPENSE)
+        entity_a = EntityFactory(name="Acme")
+        entity_b = EntityFactory(name="Beta")
+
+        # Income (credits increase income)
+        self._make_item(
+            income_account, entity_a, Decimal("5000"),
+            JournalEntryItem.JournalEntryType.CREDIT,
+        )
+        self._make_item(
+            income_account, entity_b, Decimal("3000"),
+            JournalEntryItem.JournalEntryType.CREDIT,
+        )
+        # Expense (debits increase expense)
+        self._make_item(
+            expense_account, entity_a, Decimal("1000"),
+            JournalEntryItem.JournalEntryType.DEBIT,
+        )
+
+        _, summary = self._summary()
+
+        self.assertIsInstance(summary, EntityIncomeSummary)
+        self.assertEqual(summary.income_total, Decimal("8000"))
+        self.assertEqual(summary.expense_total, Decimal("1000"))
+        self.assertEqual(summary.net_income, Decimal("7000"))
+
+        income_by_name = {b.name: b.amount for b in summary.income_balances}
+        self.assertEqual(income_by_name, {"Acme": Decimal("5000"), "Beta": Decimal("3000")})
+        expense_by_name = {b.name: b.amount for b in summary.expense_balances}
+        self.assertEqual(expense_by_name, {"Acme": Decimal("1000")})
+
+    def test_buckets_items_without_entity_as_unassigned_last(self):
+        """Items with no entity bucket into 'Unassigned', sorted last."""
+        income_account = AccountFactory(type=Account.Type.INCOME)
+        entity_a = EntityFactory(name="Acme")
+
+        self._make_item(
+            income_account, None, Decimal("400"),
+            JournalEntryItem.JournalEntryType.CREDIT,
+        )
+        self._make_item(
+            income_account, entity_a, Decimal("600"),
+            JournalEntryItem.JournalEntryType.CREDIT,
+        )
+
+        _, summary = self._summary()
+
+        names = [b.name for b in summary.income_balances]
+        self.assertEqual(names, ["Acme", "Unassigned"])
+        unassigned = summary.income_balances[-1]
+        self.assertIsNone(unassigned.entity_id)
+        self.assertEqual(unassigned.amount, Decimal("400"))
+
+    def test_net_income_reconciles_to_account_view(self):
+        """Entity net income should match the by-account income statement."""
+        income_account = AccountFactory(type=Account.Type.INCOME)
+        expense_account = AccountFactory(type=Account.Type.EXPENSE)
+        entity_a = EntityFactory(name="Acme")
+
+        self._make_item(
+            income_account, entity_a, Decimal("5000"),
+            JournalEntryItem.JournalEntryType.CREDIT,
+        )
+        self._make_item(
+            expense_account, None, Decimal("1200"),
+            JournalEntryItem.JournalEntryType.DEBIT,
+        )
+
+        statement, summary = self._summary()
+
+        self.assertEqual(summary.net_income, statement.net_income)
+
+
+class GetStatementDetailItemsByEntityTest(TestCase):
+    """Tests for get_statement_detail_items_by_entity()."""
+
+    def test_filters_by_entity_and_account_type(self):
+        """Should return only items for the entity within the account type."""
+        income_account = AccountFactory(type=Account.Type.INCOME)
+        expense_account = AccountFactory(type=Account.Type.EXPENSE)
+        entity_a = EntityFactory(name="Acme")
+        entity_b = EntityFactory(name="Beta")
+        entry = JournalEntryFactory(date=date(2024, 6, 15))
+
+        # Match: entity A on income
+        JournalEntryItemFactory(
+            journal_entry=entry, account=income_account, entity=entity_a,
+            amount=Decimal("5000"), type=JournalEntryItem.JournalEntryType.CREDIT,
+        )
+        # Wrong entity
+        JournalEntryItemFactory(
+            journal_entry=entry, account=income_account, entity=entity_b,
+            amount=Decimal("3000"), type=JournalEntryItem.JournalEntryType.CREDIT,
+        )
+        # Wrong account type
+        JournalEntryItemFactory(
+            journal_entry=entry, account=expense_account, entity=entity_a,
+            amount=Decimal("100"), type=JournalEntryItem.JournalEntryType.DEBIT,
+        )
+
+        result = get_statement_detail_items_by_entity(
+            entity_id=entity_a.pk,
+            account_type="income",
+            from_date="2024-01-01",
+            to_date="2024-12-31",
+        )
+
+        self.assertEqual(len(result.journal_entry_items), 1)
+        item = result.journal_entry_items[0]
+        self.assertEqual(item.entity.pk, entity_a.pk)
+        self.assertEqual(item.amount_signed, Decimal("5000"))
+        self.assertEqual(item.display_label, income_account.name)
+
+    def test_signs_income_debits_negative(self):
+        """INCOME debits should reduce income (negative signed amount)."""
+        income_account = AccountFactory(type=Account.Type.INCOME)
+        entity_a = EntityFactory(name="Acme")
+        entry = JournalEntryFactory(date=date(2024, 6, 15))
+        JournalEntryItemFactory(
+            journal_entry=entry, account=income_account, entity=entity_a,
+            amount=Decimal("200"), type=JournalEntryItem.JournalEntryType.DEBIT,
+        )
+
+        result = get_statement_detail_items_by_entity(
+            entity_id=entity_a.pk,
+            account_type="income",
+            from_date="2024-01-01",
+            to_date="2024-12-31",
+        )
+
+        self.assertEqual(result.journal_entry_items[0].amount_signed, Decimal("-200"))
+
+    def test_unassigned_bucket_selects_null_entity(self):
+        """entity_id of None should return items with no entity."""
+        income_account = AccountFactory(type=Account.Type.INCOME)
+        entity_a = EntityFactory(name="Acme")
+        entry = JournalEntryFactory(date=date(2024, 6, 15))
+        JournalEntryItemFactory(
+            journal_entry=entry, account=income_account, entity=None,
+            amount=Decimal("400"), type=JournalEntryItem.JournalEntryType.CREDIT,
+        )
+        JournalEntryItemFactory(
+            journal_entry=entry, account=income_account, entity=entity_a,
+            amount=Decimal("600"), type=JournalEntryItem.JournalEntryType.CREDIT,
+        )
+
+        result = get_statement_detail_items_by_entity(
+            entity_id=None,
+            account_type="income",
+            from_date="2024-01-01",
+            to_date="2024-12-31",
+        )
+
+        self.assertEqual(len(result.journal_entry_items), 1)
+        self.assertEqual(result.journal_entry_items[0].amount_signed, Decimal("400"))
+
+    def test_filters_by_date_range(self):
+        """Should exclude items outside the date range."""
+        income_account = AccountFactory(type=Account.Type.INCOME)
+        entity_a = EntityFactory(name="Acme")
+
+        in_range = JournalEntryFactory(date=date(2024, 6, 15))
+        JournalEntryItemFactory(
+            journal_entry=in_range, account=income_account, entity=entity_a,
+            amount=Decimal("5000"), type=JournalEntryItem.JournalEntryType.CREDIT,
+        )
+        out_of_range = JournalEntryFactory(date=date(2023, 6, 15))
+        JournalEntryItemFactory(
+            journal_entry=out_of_range, account=income_account, entity=entity_a,
+            amount=Decimal("9999"), type=JournalEntryItem.JournalEntryType.CREDIT,
+        )
+
+        result = get_statement_detail_items_by_entity(
+            entity_id=entity_a.pk,
+            account_type="income",
+            from_date="2024-01-01",
+            to_date="2024-12-31",
+        )
+
+        self.assertEqual(len(result.journal_entry_items), 1)
+        self.assertEqual(result.journal_entry_items[0].amount, Decimal("5000"))

--- a/api/views/statement_helpers.py
+++ b/api/views/statement_helpers.py
@@ -17,6 +17,7 @@ from api.forms import FromToDateForm
 from api.models import JournalEntry
 from api.services.statement_services import (
     CashFlowMetrics,
+    EntityIncomeSummary,
     StatementDetailData,
     StatementSummary,
 )
@@ -41,6 +42,7 @@ def render_statement_filter_form(
     statement_type: str,
     from_date: Optional[date],
     to_date: date,
+    group_by: str = "account",
 ) -> str:
     """
     Render the date filter form for statements.
@@ -49,6 +51,8 @@ def render_statement_filter_form(
         statement_type: Type of statement ("income", "balance", "cash")
         from_date: Start date (None for balance sheet)
         to_date: End date
+        group_by: Income statement grouping ("account" or "entity"); the
+            toggle and Filter button preserve this across submissions
 
     Returns:
         HTML string for the filter form
@@ -62,6 +66,7 @@ def render_statement_filter_form(
         "filter_form": FromToDateForm(initial=initial_data),
         "get_url": reverse("statements", args=(statement_type,)),
         "statement_type": statement_type,
+        "group_by": group_by,
     }
 
     return render_to_string("api/filter_forms/from-to-date-form.html", context)
@@ -99,6 +104,37 @@ def render_income_statement(
     }
 
     return render_to_string("api/content/income-content.html", context)
+
+
+def render_income_statement_by_entity(
+    summary: EntityIncomeSummary,
+    tax_rate: Optional[float],
+    savings_rate: Optional[float],
+    from_date: date,
+    to_date: date,
+) -> str:
+    """
+    Render the income statement grouped by entity.
+
+    Args:
+        summary: EntityIncomeSummary with per-entity income/expense balances
+        tax_rate: Effective tax rate (or None)
+        savings_rate: Savings rate (or None)
+        from_date: Start date
+        to_date: End date
+
+    Returns:
+        HTML string for the entity-grouped income statement
+    """
+    context = {
+        "summary": summary,
+        "tax_rate": tax_rate if tax_rate is not None else 0,
+        "savings_rate": savings_rate if savings_rate is not None else 0,
+        "from_date": from_date,
+        "to_date": to_date,
+    }
+
+    return render_to_string("api/content/income-by-entity-content.html", context)
 
 
 def render_balance_sheet(

--- a/api/views/statement_views.py
+++ b/api/views/statement_views.py
@@ -40,6 +40,29 @@ class StatementDetailView(LoginRequiredMixin, View):
         return HttpResponse(html)
 
 
+class StatementEntityDetailView(LoginRequiredMixin, View):
+    """View for entity drill-down in the entity-grouped income statement."""
+
+    login_url = "/login/"
+    redirect_field_name = "next"
+
+    def get(self, request, *args, **kwargs):
+        entity_id = request.GET.get("entity_id") or None
+        account_type = request.GET.get("account_type")
+        from_date = request.GET.get("from_date")
+        to_date = request.GET.get("to_date")
+
+        detail_data = statement_services.get_statement_detail_items_by_entity(
+            entity_id=entity_id,
+            account_type=account_type,
+            from_date=from_date,
+            to_date=to_date,
+        )
+
+        html = statement_helpers.render_statement_detail_table(detail_data)
+        return HttpResponse(html)
+
+
 class StatementView(LoginRequiredMixin, View):
     """Main view for financial statements."""
 
@@ -55,9 +78,16 @@ class StatementView(LoginRequiredMixin, View):
         else:
             from_date, to_date = self._get_default_dates()
 
+        group_by = request.GET.get("group_by", "account")
+
         # 2. Route to statement type handler
         if statement_type == "income":
-            statement_html = self._render_income_statement(from_date, to_date)
+            if group_by == "entity":
+                statement_html = self._render_income_statement_by_entity(
+                    from_date, to_date
+                )
+            else:
+                statement_html = self._render_income_statement(from_date, to_date)
             title = "Income Statement"
         elif statement_type == "balance":
             statement_html = self._render_balance_sheet(to_date)
@@ -71,6 +101,7 @@ class StatementView(LoginRequiredMixin, View):
             statement_type=statement_type,
             from_date=from_date,
             to_date=to_date,
+            group_by=group_by,
         )
 
         # 4. Return combined response
@@ -96,6 +127,19 @@ class StatementView(LoginRequiredMixin, View):
         summary = statement_services.build_statement_summary(income_statement)
 
         return statement_helpers.render_income_statement(
+            summary=summary,
+            tax_rate=income_statement.get_tax_rate(),
+            savings_rate=income_statement.get_savings_rate(),
+            from_date=from_date,
+            to_date=to_date,
+        )
+
+    def _render_income_statement_by_entity(self, from_date, to_date):
+        """Render income statement grouped by entity using services and helpers."""
+        income_statement = IncomeStatement(end_date=to_date, start_date=from_date)
+        summary = statement_services.build_entity_income_summary(income_statement)
+
+        return statement_helpers.render_income_statement_by_entity(
             summary=summary,
             tax_rate=income_statement.get_tax_rate(),
             savings_rate=income_statement.get_savings_rate(),

--- a/ledger/templates/api/content/income-by-entity-content.html
+++ b/ledger/templates/api/content/income-by-entity-content.html
@@ -1,0 +1,49 @@
+{% load humanize %}
+
+{% include "api/content/income-kpi-row.html" %}
+
+<div class="grid grid-main-side">
+    <div>
+        <h4>Net Income: ${{ summary.net_income|floatformat:"0"|intcomma }}</h4>
+
+        <div class="grid grid-2">
+            <div>
+                <h4>Income: ${{ summary.income_total|floatformat:"0"|intcomma }}</h4>
+                <table class="table">
+                    <tbody>
+                        {% for balance in summary.income_balances %}
+                        <tr
+                            class="clickable-row"
+                            hx-get="{% url 'statement-entity-detail' %}?entity_id={{ balance.entity_id|default_if_none:'' }}&account_type=income&from_date={{ from_date|date:"Y-m-d" }}&to_date={{ to_date|date:"Y-m-d" }}"
+                            hx-target="#detail"
+                        >
+                            <td class="td-name">{{ balance.name }}</td>
+                            <td class="right">${{ balance.amount|floatformat:"0"|intcomma }}</td>
+                        </tr>
+                        {% endfor %}
+                    </tbody>
+                </table>
+            </div>
+
+            <div>
+                <h4>Expenses: ${{ summary.expense_total|floatformat:"0"|intcomma }}</h4>
+                <table class="table">
+                    <tbody>
+                        {% for balance in summary.expense_balances %}
+                        <tr
+                            class="clickable-row"
+                            hx-get="{% url 'statement-entity-detail' %}?entity_id={{ balance.entity_id|default_if_none:'' }}&account_type=expense&from_date={{ from_date|date:"Y-m-d" }}&to_date={{ to_date|date:"Y-m-d" }}"
+                            hx-target="#detail"
+                        >
+                            <td class="td-name">{{ balance.name }}</td>
+                            <td class="right">${{ balance.amount|floatformat:"0"|intcomma }}</td>
+                        </tr>
+                        {% endfor %}
+                    </tbody>
+                </table>
+            </div>
+        </div>
+    </div>
+
+    <div id="detail"></div>
+</div>

--- a/ledger/templates/api/content/income-content.html
+++ b/ledger/templates/api/content/income-content.html
@@ -1,17 +1,7 @@
 {% load humanize %}
-{% load math_filters %}
 {{ filter_form }}
 
-<div class="kpi-row">
-    <div class="kpi">
-        <div class="kpi-value">{{ savings_rate|multiply:100|floatformat:1 }}%</div>
-        <div class="kpi-label">Savings Rate</div>
-    </div>
-    <div class="kpi">
-        <div class="kpi-value">{{ tax_rate|multiply:100|floatformat:1 }}%</div>
-        <div class="kpi-label">Tax Rate</div>
-    </div>
-</div>
+{% include "api/content/income-kpi-row.html" %}
 
 <div class="grid grid-main-side">
     <div>

--- a/ledger/templates/api/content/income-kpi-row.html
+++ b/ledger/templates/api/content/income-kpi-row.html
@@ -1,0 +1,11 @@
+{% load math_filters %}
+<div class="kpi-row">
+    <div class="kpi">
+        <div class="kpi-value">{{ savings_rate|multiply:100|floatformat:1 }}%</div>
+        <div class="kpi-label">Savings Rate</div>
+    </div>
+    <div class="kpi">
+        <div class="kpi-value">{{ tax_rate|multiply:100|floatformat:1 }}%</div>
+        <div class="kpi-label">Tax Rate</div>
+    </div>
+</div>

--- a/ledger/templates/api/filter_forms/from-to-date-form.html
+++ b/ledger/templates/api/filter_forms/from-to-date-form.html
@@ -3,6 +3,8 @@
     method="get"
     hx-get="{{ get_url }}"
     hx-target="#container"
+    hx-select="#container"
+    hx-swap="outerHTML show:window:top"
     hx-trigger="submit"
 >
     <div class="filter-bar">
@@ -24,7 +26,14 @@
         </div>
 
         <div class="fw-auto">
-            <button type="submit" class="btn btn-primary">Filter</button>
+            <button type="submit" class="btn btn-primary" name="group_by" value="{{ group_by }}">Filter</button>
         </div>
+
+        {% if statement_type == 'income' %}
+        <div class="fw-auto">
+            <button type="submit" name="group_by" value="account" class="btn {% if group_by == 'entity' %}btn-secondary{% else %}btn-primary{% endif %}">By Account</button>
+            <button type="submit" name="group_by" value="entity" class="btn {% if group_by == 'entity' %}btn-primary{% else %}btn-secondary{% endif %}">By Entity</button>
+        </div>
+        {% endif %}
     </div>
 </form>

--- a/ledger/urls.py
+++ b/ledger/urls.py
@@ -47,7 +47,11 @@ from api.views.loan_views import (
     LoanSettingsView,
 )
 from api.views.settings_views import AccountFormView, SettingsView
-from api.views.statement_views import StatementDetailView, StatementView
+from api.views.statement_views import (
+    StatementDetailView,
+    StatementEntityDetailView,
+    StatementView,
+)
 from api.views.tax_views import (
     ApplyTaxRecommendationView,
     TaxChargeFormView,
@@ -76,6 +80,11 @@ urlpatterns = [
     # Statements
     path(
         "statements/<str:statement_type>/", StatementView.as_view(), name="statements"
+    ),
+    path(
+        "statements/detail/entity/",
+        StatementEntityDetailView.as_view(),
+        name="statement-entity-detail",
     ),
     path(
         "statements/detail/<int:account_id>",


### PR DESCRIPTION
## Summary

Adds a **By Account / By Entity** toggle to the income statement. In entity mode, the Income and Expenses sections list each **entity** as a line item (items with no entity bucket into **Unassigned**) instead of accounts, keeping the same Net Income header. Entity rows are clickable and drill down into their underlying journal entry items, filtered to that section's account type.

The By Account view is unchanged.

## Changes

- **Aggregation** (`api/statement.py`): `IncomeStatement.get_entity_balances()` aggregates income/expense items by entity. Extracted a shared `_debit_credit_total_annotations()` helper, reused by `get_balances` and the new aggregation.
- **Services** (`api/services/statement_services.py`): `EntityIncomeSummary` + `build_entity_income_summary()` (per-entity totals, Unassigned last, net income reconciles to the by-account view); `get_statement_detail_items_by_entity()` for drill-down.
- **Model** (`api/models.py`): `JournalEntryItem.get_signed_amount()` centralizes the per-item debit/credit sign convention, delegating to `Account.get_balance_from_debit_and_credit`. Both detail functions reuse it, removing duplicated signing logic.
- **Views / routing**: `group_by` param on `StatementView`; new `StatementEntityDetailView` + `statement-entity-detail` URL.
- **Templates**: new `income-by-entity-content.html`; shared `income-kpi-row.html` partial; By Account/By Entity toggle in the statement filter form. Added `hx-select="#container"` to the filter form to fix a double-navbar bug on full-page swaps (matches the established nav pattern).

## Testing

- Added service tests for `build_entity_income_summary` (grouping, Unassigned ordering, net-income reconciliation) and `get_statement_detail_items_by_entity` (entity/type/date filtering, signing, Unassigned bucket).
- `python manage.py test api.tests.services.test_statement_services api.tests.statement api.tests.models` → 128 tests pass; `manage.py check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)