### PR TITLE
Break entity income view into sub_type sections, sorted by amount

### DIFF
--- a/api/services/statement_services.py
+++ b/api/services/statement_services.py
@@ -9,7 +9,7 @@ go through services with atomic transactions.
 from dataclasses import dataclass
 from datetime import date, timedelta
 from decimal import Decimal
-from typing import Any, Dict, List, Optional
+from typing import Any, Callable, Dict, Iterator, List, Optional, Tuple
 
 from django.db.models import Case, DecimalField, F, Sum, When
 
@@ -49,13 +49,27 @@ class StatementSummary:
 
 
 @dataclass
+class EntitySubTypeSummary:
+    """A statement section (sub_type) broken out by entity."""
+
+    name: str
+    total: Decimal
+    balances: List[EntityBalance]
+
+
+@dataclass
 class EntityIncomeSummary:
-    """Income statement summary organized by entity instead of by account."""
+    """Income statement summary organized by entity instead of by account.
+
+    Income and expense are each split into their sub_type sections (Salary,
+    Operating, Tax, …), and within a section entities are sorted by amount
+    descending so the largest sources/uses surface first.
+    """
 
     income_total: Decimal
-    income_balances: List[EntityBalance]
+    income_sub_types: List[EntitySubTypeSummary]
     expense_total: Decimal
-    expense_balances: List[EntityBalance]
+    expense_sub_types: List[EntitySubTypeSummary]
     net_income: Decimal
 
 
@@ -112,6 +126,27 @@ def filter_closed_accounts(balances: List[Balance]) -> List[Balance]:
     return result
 
 
+def _iter_sub_type_sections(
+    balances: List[Any],
+    account_type: str,
+    sub_type_key: Callable[[Any], str],
+) -> Iterator[Tuple[Any, List[Any]]]:
+    """Yield ``(sub_type, members)`` for each sub_type of ``account_type``.
+
+    Buckets ``balances`` once by sub_type, then walks
+    ``Account.SUBTYPE_TO_TYPE_MAP`` so sections come out in canonical order
+    (sub_types with no members yield an empty list). ``sub_type_key`` extracts
+    a balance's sub_type value, which differs between the by-account
+    (``balance.account.sub_type``) and by-entity (``balance.sub_type``) paths.
+    """
+    buckets: Dict[str, List[Any]] = {}
+    for balance in balances:
+        buckets.setdefault(sub_type_key(balance), []).append(balance)
+
+    for sub_type in Account.SUBTYPE_TO_TYPE_MAP[account_type]:
+        yield sub_type, buckets.get(sub_type.value, [])
+
+
 def build_statement_summary(statement: Any) -> StatementSummary:
     """
     Build a hierarchical summary from a statement's balances.
@@ -131,15 +166,9 @@ def build_statement_summary(statement: Any) -> StatementSummary:
         type_total = Decimal("0")
         sub_type_summaries: List[SubTypeSummary] = []
 
-        for sub_type in Account.SUBTYPE_TO_TYPE_MAP[account_type]:
-            # Filter balances for this sub_type
-            balances = [
-                balance
-                for balance in statement.balances
-                if balance.account.sub_type == sub_type
-            ]
-
-            # Calculate sub_type total
+        for sub_type, balances in _iter_sub_type_sections(
+            statement.balances, account_type, lambda b: b.account.sub_type
+        ):
             sub_type_total = sum(
                 (balance.amount for balance in balances), Decimal("0")
             )
@@ -166,12 +195,30 @@ def build_statement_summary(statement: Any) -> StatementSummary:
     return StatementSummary(account_types=account_types)
 
 
-def _sort_entity_balances(balances: List[EntityBalance]) -> List[EntityBalance]:
-    """Sort entity balances by name, keeping the Unassigned bucket last."""
-    return sorted(
-        balances,
-        key=lambda balance: (balance.entity_id is None, balance.name.lower()),
-    )
+def _build_entity_sub_type_summaries(
+    balances: List[EntityBalance],
+    account_type: str,
+) -> List[EntitySubTypeSummary]:
+    """Group entity balances into the sections of one account type.
+
+    Walks the type's sub_types in their canonical order, skipping sections with
+    no activity. Within each section entities are sorted by amount descending
+    so the biggest sources/uses appear first.
+    """
+    summaries: List[EntitySubTypeSummary] = []
+    for sub_type, members in _iter_sub_type_sections(
+        balances, account_type, lambda b: b.sub_type
+    ):
+        if not members:
+            continue
+        sorted_members = sorted(members, key=lambda b: b.amount, reverse=True)
+        total = sum((balance.amount for balance in sorted_members), Decimal("0"))
+        summaries.append(
+            EntitySubTypeSummary(
+                name=sub_type.label, total=total, balances=sorted_members
+            )
+        )
+    return summaries
 
 
 def build_entity_income_summary(
@@ -181,36 +228,37 @@ def build_entity_income_summary(
     Build an income statement summary grouped by entity.
 
     Splits the statement's entity-level balances into income and expense
-    sections (each sorted by name, Unassigned last) and totals them. Net
-    income is income_total - expense_total, which reconciles to the
-    by-account income statement's net income.
+    sections (Salary, Operating, Tax, …), breaking each section out by entity
+    sorted by amount descending. Net income is income_total - expense_total,
+    which reconciles to the by-account income statement's net income.
 
     Args:
         income_statement: IncomeStatement for the period
 
     Returns:
-        EntityIncomeSummary with per-entity income/expense balances and totals
+        EntityIncomeSummary with per-entity, per-section income/expense totals
     """
-    income_balances: List[EntityBalance] = []
-    expense_balances: List[EntityBalance] = []
-    for balance in income_statement.get_entity_balances():
-        if balance.account_type == Account.Type.INCOME:
-            income_balances.append(balance)
-        else:
-            expense_balances.append(balance)
+    balances = income_statement.get_entity_balances()
+
+    income_sub_types = _build_entity_sub_type_summaries(
+        balances, Account.Type.INCOME
+    )
+    expense_sub_types = _build_entity_sub_type_summaries(
+        balances, Account.Type.EXPENSE
+    )
 
     income_total = sum(
-        (balance.amount for balance in income_balances), Decimal("0")
+        (section.total for section in income_sub_types), Decimal("0")
     )
     expense_total = sum(
-        (balance.amount for balance in expense_balances), Decimal("0")
+        (section.total for section in expense_sub_types), Decimal("0")
     )
 
     return EntityIncomeSummary(
         income_total=income_total,
-        income_balances=_sort_entity_balances(income_balances),
+        income_sub_types=income_sub_types,
         expense_total=expense_total,
-        expense_balances=_sort_entity_balances(expense_balances),
+        expense_sub_types=expense_sub_types,
         net_income=income_total - expense_total,
     )
 
@@ -255,6 +303,29 @@ def find_unbalanced_journal_entries() -> UnbalancedEntriesResult:
     )
 
 
+def _build_detail_items(
+    queryset: Any,
+    label_fn: Callable[[JournalEntryItem], str],
+) -> List[JournalEntryItem]:
+    """Materialize statement detail items with signed amounts and labels.
+
+    Applies the shared select_related/ordering, then sets ``amount_signed``
+    (via the account's debit/credit convention) and ``display_label`` (from
+    ``label_fn``) on each item.
+    """
+    journal_entry_items = list(
+        queryset.select_related(
+            "journal_entry__transaction", "account", "entity"
+        ).order_by("journal_entry__date")
+    )
+
+    for entry in journal_entry_items:
+        entry.amount_signed = entry.get_signed_amount()
+        entry.display_label = label_fn(entry)
+
+    return journal_entry_items
+
+
 def get_statement_detail_items(
     account_id: int,
     from_date: str,
@@ -276,33 +347,23 @@ def get_statement_detail_items(
     Returns:
         StatementDetailData with signed journal entry items
     """
-    journal_entry_items = list(
+    journal_entry_items = _build_detail_items(
         JournalEntryItem.objects.filter(
             account__pk=account_id,
             journal_entry__date__gte=from_date,
             journal_entry__date__lte=to_date,
             amount__gt=0,
-        )
-        .select_related("journal_entry__transaction", "account", "entity")
-        .order_by("journal_entry__date")
-    )
-
-    # Apply signing logic
-    for entry in journal_entry_items:
-        entry.amount_signed = entry.get_signed_amount()
-
+        ),
         # Prefer the human-readable entity name; fall back to the raw
         # transaction description when the item has no entity.
-        entry.display_label = (
+        label_fn=lambda entry: (
             entry.entity.name
             if entry.entity
             else entry.journal_entry.transaction.description
-        )
+        ),
+    )
 
-    # Get the account
-    account = None
-    if journal_entry_items:
-        account = journal_entry_items[0].account
+    account = journal_entry_items[0].account if journal_entry_items else None
 
     return StatementDetailData(
         journal_entry_items=journal_entry_items,
@@ -312,22 +373,22 @@ def get_statement_detail_items(
 
 def get_statement_detail_items_by_entity(
     entity_id: Optional[int],
-    account_type: str,
+    sub_type: str,
     from_date: str,
     to_date: str,
 ) -> StatementDetailData:
     """
     Get journal entry items for an entity within a statement section.
 
-    Parallels get_statement_detail_items but pivots on entity + account type
-    (income or expense). entity_id of None selects the Unassigned bucket
-    (items with no entity). Applies the same income-debit / expense-credit
-    sign rules, and labels each row with its account name (the entity is
-    fixed in this view).
+    Parallels get_statement_detail_items but pivots on entity + account
+    sub_type (Salary, Operating, Tax, …). entity_id of None selects the
+    Unassigned bucket (items with no entity). Applies the same income-debit /
+    expense-credit sign rules, and labels each row with its account name (the
+    entity is fixed in this view).
 
     Args:
         entity_id: The entity ID, or None for the Unassigned bucket
-        account_type: "income" or "expense"
+        sub_type: The account sub_type identifying the section
         from_date: Start date (string, YYYY-MM-DD)
         to_date: End date (string, YYYY-MM-DD)
 
@@ -335,7 +396,7 @@ def get_statement_detail_items_by_entity(
         StatementDetailData with signed journal entry items
     """
     queryset = JournalEntryItem.objects.filter(
-        account__type=account_type,
+        account__sub_type=sub_type,
         journal_entry__date__gte=from_date,
         journal_entry__date__lte=to_date,
         amount__gt=0,
@@ -345,17 +406,11 @@ def get_statement_detail_items_by_entity(
     else:
         queryset = queryset.filter(entity__pk=entity_id)
 
-    journal_entry_items = list(
-        queryset.select_related(
-            "journal_entry__transaction", "account", "entity"
-        ).order_by("journal_entry__date")
-    )
-
-    for entry in journal_entry_items:
-        entry.amount_signed = entry.get_signed_amount()
-
+    journal_entry_items = _build_detail_items(
+        queryset,
         # The entity is fixed for this view, so surface the account instead.
-        entry.display_label = entry.account.name
+        label_fn=lambda entry: entry.account.name,
+    )
 
     return StatementDetailData(journal_entry_items=journal_entry_items)
 

--- a/api/statement.py
+++ b/api/statement.py
@@ -61,7 +61,7 @@ class Balance:
 
 
 EntityBalance = namedtuple(
-    "EntityBalance", ["entity_id", "name", "amount", "account_type"]
+    "EntityBalance", ["entity_id", "name", "amount", "sub_type"]
 )
 
 
@@ -478,19 +478,21 @@ class IncomeStatement(Statement):
         """Aggregate income/expense activity by entity instead of by account.
 
         Mirrors the DB-aggregation style of ``Statement.get_balances`` but
-        groups on the journal entry item's ``entity`` (and account type so the
-        correct debit/credit signing is applied). Items with no entity are
-        bucketed under "Unassigned". Returns a flat list of ``EntityBalance``
-        records carrying the account type, so callers can split income from
-        expense and have the per-section totals reconcile to the by-account
-        Income/Expense totals.
+        groups on the journal entry item's ``entity`` and account sub_type so
+        callers can break each section (Salary, Operating, Tax, …) out by
+        entity with the correct debit/credit signing applied. Items with no
+        entity are bucketed under "Unassigned". Returns a flat list of
+        ``EntityBalance`` records carrying the sub_type, so the per-section
+        totals reconcile to the by-account Income/Expense totals.
         """
         ACCOUNT_TYPES = ["income", "expense"]
         aggregates = JournalEntryItem.objects.filter(
             account__type__in=ACCOUNT_TYPES,
             journal_entry__date__gte=self.start_date,
             journal_entry__date__lte=self.end_date,
-        ).values("entity", "entity__name", "account__type").annotate(
+        ).values(
+            "entity", "entity__name", "account__type", "account__sub_type"
+        ).annotate(
             **_debit_credit_total_annotations()
         )
 
@@ -507,7 +509,7 @@ class IncomeStatement(Statement):
                     entity_id=aggregate["entity"],
                     name=aggregate["entity__name"] or "Unassigned",
                     amount=amount,
-                    account_type=account_type,
+                    sub_type=aggregate["account__sub_type"],
                 )
             )
 

--- a/api/tests/services/test_statement_services.py
+++ b/api/tests/services/test_statement_services.py
@@ -543,9 +543,13 @@ class BuildEntityIncomeSummaryTest(TestCase):
         return statement, build_entity_income_summary(statement)
 
     def test_groups_income_and_expense_by_entity(self):
-        """Income/expense activity should be totaled per entity."""
-        income_account = AccountFactory(type=Account.Type.INCOME)
-        expense_account = AccountFactory(type=Account.Type.EXPENSE)
+        """Income/expense activity should be totaled per entity within sections."""
+        income_account = AccountFactory(
+            type=Account.Type.INCOME, sub_type=Account.SubType.SALARY
+        )
+        expense_account = AccountFactory(
+            type=Account.Type.EXPENSE, sub_type=Account.SubType.OPERATING
+        )
         entity_a = EntityFactory(name="Acme")
         entity_b = EntityFactory(name="Beta")
 
@@ -571,37 +575,75 @@ class BuildEntityIncomeSummaryTest(TestCase):
         self.assertEqual(summary.expense_total, Decimal("1000"))
         self.assertEqual(summary.net_income, Decimal("7000"))
 
-        income_by_name = {b.name: b.amount for b in summary.income_balances}
+        salary = summary.income_sub_types[0]
+        self.assertEqual(salary.name, Account.SubType.SALARY.label)
+        self.assertEqual(salary.total, Decimal("8000"))
+        income_by_name = {b.name: b.amount for b in salary.balances}
         self.assertEqual(income_by_name, {"Acme": Decimal("5000"), "Beta": Decimal("3000")})
-        expense_by_name = {b.name: b.amount for b in summary.expense_balances}
+
+        operating = summary.expense_sub_types[0]
+        self.assertEqual(operating.name, Account.SubType.OPERATING.label)
+        expense_by_name = {b.name: b.amount for b in operating.balances}
         self.assertEqual(expense_by_name, {"Acme": Decimal("1000")})
 
-    def test_buckets_items_without_entity_as_unassigned_last(self):
-        """Items with no entity bucket into 'Unassigned', sorted last."""
-        income_account = AccountFactory(type=Account.Type.INCOME)
+    def test_sections_split_by_sub_type_in_canonical_order(self):
+        """Each sub_type becomes its own section, ordered per the type map."""
+        salary_account = AccountFactory(
+            type=Account.Type.INCOME, sub_type=Account.SubType.SALARY
+        )
+        dividends_account = AccountFactory(
+            type=Account.Type.INCOME, sub_type=Account.SubType.DIVIDENDS_AND_INTEREST
+        )
         entity_a = EntityFactory(name="Acme")
 
         self._make_item(
-            income_account, None, Decimal("400"),
+            dividends_account, entity_a, Decimal("200"),
             JournalEntryItem.JournalEntryType.CREDIT,
         )
         self._make_item(
-            income_account, entity_a, Decimal("600"),
+            salary_account, entity_a, Decimal("900"),
             JournalEntryItem.JournalEntryType.CREDIT,
         )
 
         _, summary = self._summary()
 
-        names = [b.name for b in summary.income_balances]
-        self.assertEqual(names, ["Acme", "Unassigned"])
-        unassigned = summary.income_balances[-1]
-        self.assertIsNone(unassigned.entity_id)
-        self.assertEqual(unassigned.amount, Decimal("400"))
+        section_names = [s.name for s in summary.income_sub_types]
+        self.assertEqual(
+            section_names,
+            [Account.SubType.SALARY.label, Account.SubType.DIVIDENDS_AND_INTEREST.label],
+        )
+
+    def test_sorts_entities_within_section_by_amount_descending(self):
+        """Entities (including Unassigned) sort by amount descending."""
+        income_account = AccountFactory(
+            type=Account.Type.INCOME, sub_type=Account.SubType.SALARY
+        )
+        entity_a = EntityFactory(name="Acme")
+
+        self._make_item(
+            income_account, entity_a, Decimal("400"),
+            JournalEntryItem.JournalEntryType.CREDIT,
+        )
+        self._make_item(
+            income_account, None, Decimal("600"),
+            JournalEntryItem.JournalEntryType.CREDIT,
+        )
+
+        _, summary = self._summary()
+
+        balances = summary.income_sub_types[0].balances
+        self.assertEqual([b.name for b in balances], ["Unassigned", "Acme"])
+        self.assertEqual([b.amount for b in balances], [Decimal("600"), Decimal("400")])
+        self.assertIsNone(balances[0].entity_id)
 
     def test_net_income_reconciles_to_account_view(self):
         """Entity net income should match the by-account income statement."""
-        income_account = AccountFactory(type=Account.Type.INCOME)
-        expense_account = AccountFactory(type=Account.Type.EXPENSE)
+        income_account = AccountFactory(
+            type=Account.Type.INCOME, sub_type=Account.SubType.SALARY
+        )
+        expense_account = AccountFactory(
+            type=Account.Type.EXPENSE, sub_type=Account.SubType.OPERATING
+        )
         entity_a = EntityFactory(name="Acme")
 
         self._make_item(
@@ -621,33 +663,37 @@ class BuildEntityIncomeSummaryTest(TestCase):
 class GetStatementDetailItemsByEntityTest(TestCase):
     """Tests for get_statement_detail_items_by_entity()."""
 
-    def test_filters_by_entity_and_account_type(self):
-        """Should return only items for the entity within the account type."""
-        income_account = AccountFactory(type=Account.Type.INCOME)
-        expense_account = AccountFactory(type=Account.Type.EXPENSE)
+    def test_filters_by_entity_and_sub_type(self):
+        """Should return only items for the entity within the section."""
+        salary_account = AccountFactory(
+            type=Account.Type.INCOME, sub_type=Account.SubType.SALARY
+        )
+        dividends_account = AccountFactory(
+            type=Account.Type.INCOME, sub_type=Account.SubType.DIVIDENDS_AND_INTEREST
+        )
         entity_a = EntityFactory(name="Acme")
         entity_b = EntityFactory(name="Beta")
         entry = JournalEntryFactory(date=date(2024, 6, 15))
 
-        # Match: entity A on income
+        # Match: entity A in the salary section
         JournalEntryItemFactory(
-            journal_entry=entry, account=income_account, entity=entity_a,
+            journal_entry=entry, account=salary_account, entity=entity_a,
             amount=Decimal("5000"), type=JournalEntryItem.JournalEntryType.CREDIT,
         )
         # Wrong entity
         JournalEntryItemFactory(
-            journal_entry=entry, account=income_account, entity=entity_b,
+            journal_entry=entry, account=salary_account, entity=entity_b,
             amount=Decimal("3000"), type=JournalEntryItem.JournalEntryType.CREDIT,
         )
-        # Wrong account type
+        # Wrong sub_type
         JournalEntryItemFactory(
-            journal_entry=entry, account=expense_account, entity=entity_a,
-            amount=Decimal("100"), type=JournalEntryItem.JournalEntryType.DEBIT,
+            journal_entry=entry, account=dividends_account, entity=entity_a,
+            amount=Decimal("100"), type=JournalEntryItem.JournalEntryType.CREDIT,
         )
 
         result = get_statement_detail_items_by_entity(
             entity_id=entity_a.pk,
-            account_type="income",
+            sub_type=Account.SubType.SALARY,
             from_date="2024-01-01",
             to_date="2024-12-31",
         )
@@ -656,11 +702,13 @@ class GetStatementDetailItemsByEntityTest(TestCase):
         item = result.journal_entry_items[0]
         self.assertEqual(item.entity.pk, entity_a.pk)
         self.assertEqual(item.amount_signed, Decimal("5000"))
-        self.assertEqual(item.display_label, income_account.name)
+        self.assertEqual(item.display_label, salary_account.name)
 
     def test_signs_income_debits_negative(self):
         """INCOME debits should reduce income (negative signed amount)."""
-        income_account = AccountFactory(type=Account.Type.INCOME)
+        income_account = AccountFactory(
+            type=Account.Type.INCOME, sub_type=Account.SubType.SALARY
+        )
         entity_a = EntityFactory(name="Acme")
         entry = JournalEntryFactory(date=date(2024, 6, 15))
         JournalEntryItemFactory(
@@ -670,7 +718,7 @@ class GetStatementDetailItemsByEntityTest(TestCase):
 
         result = get_statement_detail_items_by_entity(
             entity_id=entity_a.pk,
-            account_type="income",
+            sub_type=Account.SubType.SALARY,
             from_date="2024-01-01",
             to_date="2024-12-31",
         )
@@ -679,7 +727,9 @@ class GetStatementDetailItemsByEntityTest(TestCase):
 
     def test_unassigned_bucket_selects_null_entity(self):
         """entity_id of None should return items with no entity."""
-        income_account = AccountFactory(type=Account.Type.INCOME)
+        income_account = AccountFactory(
+            type=Account.Type.INCOME, sub_type=Account.SubType.SALARY
+        )
         entity_a = EntityFactory(name="Acme")
         entry = JournalEntryFactory(date=date(2024, 6, 15))
         JournalEntryItemFactory(
@@ -693,7 +743,7 @@ class GetStatementDetailItemsByEntityTest(TestCase):
 
         result = get_statement_detail_items_by_entity(
             entity_id=None,
-            account_type="income",
+            sub_type=Account.SubType.SALARY,
             from_date="2024-01-01",
             to_date="2024-12-31",
         )
@@ -703,7 +753,9 @@ class GetStatementDetailItemsByEntityTest(TestCase):
 
     def test_filters_by_date_range(self):
         """Should exclude items outside the date range."""
-        income_account = AccountFactory(type=Account.Type.INCOME)
+        income_account = AccountFactory(
+            type=Account.Type.INCOME, sub_type=Account.SubType.SALARY
+        )
         entity_a = EntityFactory(name="Acme")
 
         in_range = JournalEntryFactory(date=date(2024, 6, 15))
@@ -719,7 +771,7 @@ class GetStatementDetailItemsByEntityTest(TestCase):
 
         result = get_statement_detail_items_by_entity(
             entity_id=entity_a.pk,
-            account_type="income",
+            sub_type=Account.SubType.SALARY,
             from_date="2024-01-01",
             to_date="2024-12-31",
         )

--- a/api/views/statement_views.py
+++ b/api/views/statement_views.py
@@ -48,13 +48,13 @@ class StatementEntityDetailView(LoginRequiredMixin, View):
 
     def get(self, request, *args, **kwargs):
         entity_id = request.GET.get("entity_id") or None
-        account_type = request.GET.get("account_type")
+        sub_type = request.GET.get("sub_type")
         from_date = request.GET.get("from_date")
         to_date = request.GET.get("to_date")
 
         detail_data = statement_services.get_statement_detail_items_by_entity(
             entity_id=entity_id,
-            account_type=account_type,
+            sub_type=sub_type,
             from_date=from_date,
             to_date=to_date,
         )

--- a/ledger/templates/api/content/income-by-entity-content.html
+++ b/ledger/templates/api/content/income-by-entity-content.html
@@ -9,38 +9,12 @@
         <div class="grid grid-2">
             <div>
                 <h4>Income: ${{ summary.income_total|floatformat:"0"|intcomma }}</h4>
-                <table class="table">
-                    <tbody>
-                        {% for balance in summary.income_balances %}
-                        <tr
-                            class="clickable-row"
-                            hx-get="{% url 'statement-entity-detail' %}?entity_id={{ balance.entity_id|default_if_none:'' }}&account_type=income&from_date={{ from_date|date:"Y-m-d" }}&to_date={{ to_date|date:"Y-m-d" }}"
-                            hx-target="#detail"
-                        >
-                            <td class="td-name">{{ balance.name }}</td>
-                            <td class="right">${{ balance.amount|floatformat:"0"|intcomma }}</td>
-                        </tr>
-                        {% endfor %}
-                    </tbody>
-                </table>
+                {% include "api/content/income-by-entity-section.html" with sections=summary.income_sub_types %}
             </div>
 
             <div>
                 <h4>Expenses: ${{ summary.expense_total|floatformat:"0"|intcomma }}</h4>
-                <table class="table">
-                    <tbody>
-                        {% for balance in summary.expense_balances %}
-                        <tr
-                            class="clickable-row"
-                            hx-get="{% url 'statement-entity-detail' %}?entity_id={{ balance.entity_id|default_if_none:'' }}&account_type=expense&from_date={{ from_date|date:"Y-m-d" }}&to_date={{ to_date|date:"Y-m-d" }}"
-                            hx-target="#detail"
-                        >
-                            <td class="td-name">{{ balance.name }}</td>
-                            <td class="right">${{ balance.amount|floatformat:"0"|intcomma }}</td>
-                        </tr>
-                        {% endfor %}
-                    </tbody>
-                </table>
+                {% include "api/content/income-by-entity-section.html" with sections=summary.expense_sub_types %}
             </div>
         </div>
     </div>

--- a/ledger/templates/api/content/income-by-entity-section.html
+++ b/ledger/templates/api/content/income-by-entity-section.html
@@ -1,0 +1,21 @@
+{% load humanize %}
+{% for section in sections %}
+<table class="table mb-3">
+    <tbody>
+        <tr>
+            <td class="td-strong">{{ section.name }}</td>
+            <td class="right td-strong">${{ section.total|floatformat:"0"|intcomma }}</td>
+        </tr>
+        {% for balance in section.balances %}
+        <tr
+            class="clickable-row"
+            hx-get="{% url 'statement-entity-detail' %}?entity_id={{ balance.entity_id|default_if_none:'' }}&sub_type={{ balance.sub_type }}&from_date={{ from_date|date:"Y-m-d" }}&to_date={{ to_date|date:"Y-m-d" }}"
+            hx-target="#detail"
+        >
+            <td class="td-name">{{ balance.name }}</td>
+            <td class="right">${{ balance.amount|floatformat:"0"|intcomma }}</td>
+        </tr>
+        {% endfor %}
+    </tbody>
+</table>
+{% endfor %}


### PR DESCRIPTION
Follow-up to #389.

## Summary
- The **By Entity** income view now mirrors the by-account layout: Income and Expenses are each split into their **sub_type sections** (Salary, Operating, Tax, …) with a bold section header + total, and entity line items underneath.
- Within each section, entities are **sorted by amount descending** so the biggest sources of income and expenditure surface first (the old "Unassigned always last" rule is gone — it now sorts by amount like any other row).
- Drill-down now filters by **sub_type** rather than account type, so clicking an entity row scopes to that exact section.

## Cleanup (from /simplify)
- New `_iter_sub_type_sections` helper buckets balances once and walks `SUBTYPE_TO_TYPE_MAP`; both `build_statement_summary` (by-account) and the entity builder now share this canonical section-ordering spine instead of re-implementing it.
- Dropped the unused `EntityBalance.account_type` field (grouping/display are driven entirely by `sub_type`).
- Extracted the duplicated detail-query loop into `_build_detail_items(queryset, label_fn)`.
- Factored the repeated entity section markup into an `income-by-entity-section.html` partial.

## Testing
- `uv run python manage.py test` — 525 tests pass.
- `uv run python manage.py check` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)