### PR TITLE
Fix account sub-type dropdown defaulting to first option

### DIFF
--- a/api/tests/e2e/test_settings_playwright.py
+++ b/api/tests/e2e/test_settings_playwright.py
@@ -81,6 +81,9 @@ class SettingsSmokeTest(LiveServerTestCase):
         selected_name = self.page.inner_text("tr.row.selected .td-name")
         self.assertEqual(selected_name, "Federal Taxes")
 
+        # Sub-type preselects the saved value, not the first option for the type
+        self.assertEqual(self.page.input_value("select[name='sub_type']"), "tax")
+
         # Type -> Sub-type dependency: switch Type to Income, sub-type options change
         self.page.select_option("select[name='type']", "income")
         self.page.wait_for_timeout(100)

--- a/ledger/templates/api/entry_forms/account-form.html
+++ b/ledger/templates/api/entry_forms/account-form.html
@@ -51,7 +51,7 @@
         <label class="label">Sub-type</label>
         <select class="select" name="sub_type" x-model="subtype">
           <template x-for="opt in subtypeOptions()" :key="opt.value">
-            <option :value="opt.value" x-text="opt.label"></option>
+            <option :value="opt.value" x-text="opt.label" :selected="opt.value === subtype"></option>
           </template>
         </select>
         {% for e in form.sub_type.errors %}<div class="field-error">{{ e }}</div>{% endfor %}


### PR DESCRIPTION
## Problem

In the Account Settings form, editing an account whose saved sub-type isn't the first option for its type displayed the wrong value. For Expense accounts this meant **Tax** and **Interest Expense** accounts showed **Operating** on load.

## Cause

The sub-type `<select>` uses Alpine `x-model="subtype"` while its `<option>`s are rendered by a `<template x-for>`. `x-model` evaluated and tried to apply the saved value *before* `x-for` had created any options — a no-op on an empty select. When the options appeared, the browser defaulted `selectedIndex` to `0` (the first option), and the `x-model` effect never re-ran. The Alpine state was correct; only the visible selection was wrong.

## Fix

Bind `:selected="opt.value === subtype"` on each option so the correct one is marked selected as `x-for` creates it, independent of `x-model` timing. This generalizes to any saved sub-type, not just the Expense cases.

## Testing

Extended the settings e2e test to assert the Expense/Tax edit form preselects `tax`. The assertion fails before the fix (`'operating' != 'tax'`) and passes after.

🤖 Generated with [Claude Code](https://claude.com/claude-code)