### PR TITLE
Let Amortizations tab tables grow to full height

### DIFF
--- a/ledger/static/css/app.css
+++ b/ledger/static/css/app.css
@@ -331,6 +331,7 @@ h4, h5 { font-size: var(--fs-md); font-weight: 600; margin: 0 0 var(--space-2); 
 .table-scroll { max-height: 340px; overflow: auto; }
 .table-scroll-sm { max-height: 200px; }
 .table-scroll-lg { max-height: 480px; }
+.table-x-scroll { overflow-x: auto; }
 .table { width: 100%; border-collapse: collapse; }
 .table th {
   padding: var(--space-2) var(--space-3);

--- a/ledger/templates/api/entry_forms/amortize-form.html
+++ b/ledger/templates/api/entry_forms/amortize-form.html
@@ -1,7 +1,7 @@
 {% load humanize %}
 <div class="grid grid-2">
     <div>
-        <div id="amortization-transactions-table" class="table-scroll table-scroll-sm">
+        <div id="amortization-transactions-table" class="table-x-scroll">
             <table class="table">
                 <thead>
                     <tr>

--- a/ledger/templates/api/tables/amortization-table.html
+++ b/ledger/templates/api/tables/amortization-table.html
@@ -1,7 +1,7 @@
 {% load humanize %}
 {% if amortizations %}
 <h4 class="card-title mb-3">Open Schedules</h4>
-<div id="amortization-table" class="table-scroll">
+<div id="amortization-table" class="table-x-scroll">
     <table class="table">
         <thead>
             <tr>

--- a/ledger/templates/api/tables/unattached-prepaids.html
+++ b/ledger/templates/api/tables/unattached-prepaids.html
@@ -1,7 +1,7 @@
 {% load humanize %}
 {% if journal_entry_items %}
 <h4 class="card-title mb-3">Unattached Prepaid Expenses</h4>
-<div id="transactions-table" class="table-scroll table-scroll-sm">
+<div id="transactions-table" class="table-x-scroll">
     <table class="table">
         <thead>
             <tr>


### PR DESCRIPTION
## What

The Amortizations page tables were wrapped in `.table-scroll` (`max-height: 340px; overflow: auto;`), so any schedule past the ~340px fold was clipped inside the scroll box. With the scrollbar easy to miss, those rows looked like they were missing entirely (e.g. a depreciation schedule that was actually present in the queryset and rendered HTML all along).

The Amortizations page doesn't need to reserve vertical space for anything else, so its tables can simply grow to fit all rows.

## Changes

- Add a reusable `.table-x-scroll { overflow-x: auto; }` utility to `app.css` (horizontal scroll only, no height cap).
- Apply it to the three Amortizations-page tables: Open Schedules, Unattached Prepaid Expenses, and the amortize-form booked-transactions list.
- Existing `.table-scroll` / `-sm` / `-lg` utilities are left untouched, so all other pages keep their height caps.

No backend/model/migration changes — this was purely a display-clipping issue.

## Verification

- Open the Amortizations tab: full Open Schedules list renders with no inner scrollbar; previously-clipped rows are now visible.
- Spot-check another page using `.table-scroll` (e.g. Transactions): height cap/scroll unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)