### PR TITLE
Add Entity management page to Settings

### DIFF
--- a/api/forms.py
+++ b/api/forms.py
@@ -655,6 +655,18 @@ class AccountForm(forms.ModelForm):
         return cleaned_data
 
 
+class EntityForm(forms.ModelForm):
+    """User-facing form for creating/editing entities via the Settings page.
+
+    The model's ``unique=True`` on ``name`` gives duplicate-name validation for
+    free (surfaced on the ``name`` field during ``is_valid()``).
+    """
+
+    class Meta:
+        model = Entity
+        fields = ["name", "is_closed"]
+
+
 class UtilityBillRuleForm(forms.ModelForm):
     """User-facing form for creating/editing utility-bill rules via Settings.
 

--- a/api/services/entity_services.py
+++ b/api/services/entity_services.py
@@ -6,15 +6,24 @@ and tagging/untagging operations.
 """
 
 from dataclasses import dataclass
-from datetime import date
+from datetime import date, timedelta
 from decimal import Decimal
-from typing import List, Optional
+from typing import Any, Dict, List, Optional
 
 from django.db import transaction as db_transaction
-from django.db.models import Case, DecimalField, F, Max, Sum, Value, When
+from django.db.models import Case, Count, DecimalField, F, Max, Q, Sum, Value, When
 from django.db.models.functions import Abs
 
 from api.models import Account, Entity, JournalEntryItem
+from api.services import crud
+
+
+@dataclass
+class EntityResult:
+    """Result of an entity create/update/delete operation."""
+    success: bool
+    entity: Optional[Entity] = None
+    error: Optional[str] = None
 
 
 @dataclass
@@ -327,3 +336,69 @@ def tag_journal_entry_item(journal_entry_item_id: int, entity_id: int) -> None:
     entity = Entity.objects.get(pk=entity_id)
     journal_entry_item.entity = entity
     journal_entry_item.save()
+
+
+# --- Entity CRUD for the Settings page (mirrors account_services) -------------
+
+
+TAG_USAGE_WINDOW_DAYS = 90
+
+
+def get_entities() -> List[Entity]:
+    """Returns all entities (open first, then alphabetical) annotated with:
+
+    - ``account_count``: number of accounts that default to the entity.
+    - ``recent_tag_count``: number of journal entry items tagged with the entity
+      whose journal entry dates fall within the last ``TAG_USAGE_WINDOW_DAYS``
+      days (a rolling usage metric).
+
+    ``distinct=True`` on both counts keeps them correct despite the cross-join
+    between the two related sets.
+    """
+    cutoff = date.today() - timedelta(days=TAG_USAGE_WINDOW_DAYS)
+    return list(
+        Entity.objects.annotate(
+            account_count=Count("accounts", distinct=True),
+            recent_tag_count=Count(
+                "journal_entry_items",
+                filter=Q(journal_entry_items__journal_entry__date__gte=cutoff),
+                distinct=True,
+            ),
+        ).order_by("is_closed", "name")
+    )
+
+
+ENTITY_FIELDS = ("name", "is_closed")
+
+
+def save_entity(
+    cleaned_data: Dict[str, Any], instance: Optional[Entity] = None
+) -> EntityResult:
+    """Creates or updates an entity from validated form data.
+
+    The caller (view) validates the form and passes ``form.cleaned_data``;
+    ``instance`` is the entity being edited (None to create). Returns an
+    EntityResult; on any DB error the transaction rolls back.
+    """
+    entity, error = crud.save_model(Entity, ENTITY_FIELDS, cleaned_data, instance)
+    return EntityResult(success=error is None, entity=entity, error=error)
+
+
+def delete_entity(entity_id: int) -> EntityResult:
+    """Deletes an entity, gracefully blocking when it is still referenced.
+
+    Entities are PROTECT-referenced by amortizations, loans, bill rules, paystub
+    values, etc. Rather than 500ing on a ProtectedError, we return a friendly
+    message so the UI can display it inline.
+    """
+    entity, error = crud.delete_model(
+        Entity,
+        entity_id,
+        not_found="Entity not found.",
+        protected=lambda e: (
+            f"Can't delete '{e.name}' — it's still used by other "
+            "records (accounts, amortizations, loans, paystub values, etc.). "
+            "Close it instead to archive it."
+        ),
+    )
+    return EntityResult(success=error is None, entity=entity, error=error)

--- a/api/tests/services/test_entity_services.py
+++ b/api/tests/services/test_entity_services.py
@@ -1,14 +1,17 @@
+from datetime import date, timedelta
 from decimal import Decimal
 
 from django.test import TestCase
 
 from api.models import Account, Entity, JournalEntryItem
 from api.services.entity_services import (
+    TAG_USAGE_WINDOW_DAYS,
     EntityBalance,
     EntityHistoryData,
     EntityHistoryItem,
     GroupedEntityBalances,
     UntaggedItemsData,
+    get_entities,
     get_entities_balances,
     get_entity_history,
     get_grouped_entities_balances,
@@ -22,6 +25,50 @@ from api.tests.testing_factories import (
     JournalEntryFactory,
     JournalEntryItemFactory,
 )
+
+
+class GetEntitiesTest(TestCase):
+    """Tests for get_entities() — the Settings list query with annotations."""
+
+    def test_orders_open_first_then_by_name(self):
+        EntityFactory(name="Bravo", is_closed=False)
+        EntityFactory(name="Alpha", is_closed=True)
+        EntityFactory(name="Charlie", is_closed=False)
+
+        names = [e.name for e in get_entities()]
+        self.assertEqual(names, ["Bravo", "Charlie", "Alpha"])
+
+    def test_account_count_annotation(self):
+        entity = EntityFactory()
+        AccountFactory(entity=entity)
+        AccountFactory(entity=entity)
+        EntityFactory()  # unrelated entity with no accounts
+
+        by_id = {e.id: e for e in get_entities()}
+        self.assertEqual(by_id[entity.id].account_count, 2)
+
+    def test_recent_tag_count_counts_only_last_90_days(self):
+        entity = EntityFactory()
+        recent = JournalEntryFactory(date=date.today() - timedelta(days=10))
+        on_edge = JournalEntryFactory(
+            date=date.today() - timedelta(days=TAG_USAGE_WINDOW_DAYS)
+        )
+        stale = JournalEntryFactory(
+            date=date.today() - timedelta(days=TAG_USAGE_WINDOW_DAYS + 1)
+        )
+        JournalEntryItemFactory(journal_entry=recent, entity=entity)
+        JournalEntryItemFactory(journal_entry=on_edge, entity=entity)
+        JournalEntryItemFactory(journal_entry=stale, entity=entity)
+        # An item tagged to a different entity must not be counted.
+        JournalEntryItemFactory(journal_entry=recent, entity=EntityFactory())
+
+        by_id = {e.id: e for e in get_entities()}
+        self.assertEqual(by_id[entity.id].recent_tag_count, 2)
+
+    def test_recent_tag_count_zero_when_untagged(self):
+        entity = EntityFactory()
+        by_id = {e.id: e for e in get_entities()}
+        self.assertEqual(by_id[entity.id].recent_tag_count, 0)
 
 
 class GetEntitiesBalancesTest(TestCase):

--- a/api/tests/views/test_entity_settings_views.py
+++ b/api/tests/views/test_entity_settings_views.py
@@ -1,0 +1,107 @@
+"""Tests for the Entities Settings section HTMX views."""
+
+from django.urls import reverse
+
+from api.models import Entity
+from api.tests.test_helpers import HTMXViewTestCase
+from api.tests.testing_factories import (
+    AccountFactory,
+    EntityFactory,
+    LoanFactory,
+)
+
+
+class EntitySettingsViewTest(HTMXViewTestCase):
+    def test_requires_login(self):
+        self.client.logout()
+        response = self.client.get(reverse("settings-entities"))
+        self.assertEqual(response.status_code, 302)
+        self.assertIn("/login/", response.url)
+
+    def test_panel_loads_and_lists_entities(self):
+        entity = EntityFactory(name="Listed Entity")
+        # Two accounts default to this entity -> account count of 2.
+        AccountFactory(entity=entity)
+        AccountFactory(entity=entity)
+
+        response = self.client.get(reverse("settings-entities"))
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, "Listed Entity")
+        self.assertContains(response, "Entities")
+        # The account count column is rendered.
+        self.assertContains(response, "2 accounts")
+        # The 90-day tag usage column is rendered and sortable.
+        self.assertContains(response, "Tags (90d)")
+        self.assertContains(response, 'data-sort-t90')
+
+    def test_new_entity_form_view(self):
+        response = self.client.get(reverse("settings-entity-new-form"))
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, "New entity")
+        # No Delete button on a blank create form.
+        self.assertNotContains(response, 'value="delete"')
+
+    def test_entity_form_view_loads_entity(self):
+        entity = EntityFactory(name="Editable Entity")
+        response = self.client.get(
+            reverse("settings-entity-form", args=[entity.id])
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, "Editable Entity")
+        self.assertContains(response, 'value="delete"')
+
+    def test_create_entity(self):
+        data = {"action": "save", "name": "New Bank", "is_closed": ""}
+        response = self.client.post(reverse("settings-entities"), data=data)
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue(Entity.objects.filter(name="New Bank").exists())
+        self.assertContains(response, "Entity created.")
+
+    def test_create_closed_entity(self):
+        data = {"action": "save", "name": "Closed Co", "is_closed": "on"}
+        response = self.client.post(reverse("settings-entities"), data=data)
+        self.assertEqual(response.status_code, 200)
+        entity = Entity.objects.get(name="Closed Co")
+        self.assertTrue(entity.is_closed)
+
+    def test_update_entity(self):
+        entity = EntityFactory(name="Before")
+        data = {"action": "save", "name": "After", "is_closed": "on"}
+        response = self.client.post(
+            reverse("settings-entity", args=[entity.id]), data=data
+        )
+        self.assertEqual(response.status_code, 200)
+        entity.refresh_from_db()
+        self.assertEqual(entity.name, "After")
+        self.assertTrue(entity.is_closed)
+
+    def test_delete_unused_entity(self):
+        entity = EntityFactory()
+        response = self.client.post(
+            reverse("settings-entity", args=[entity.id]),
+            data={"action": "delete"},
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertFalse(Entity.objects.filter(pk=entity.id).exists())
+
+    def test_delete_protected_entity_shows_message(self):
+        entity = EntityFactory(name="Busy Entity")
+        # Loan.entity is PROTECT, so the delete is blocked.
+        LoanFactory(entity=entity)
+
+        response = self.client.post(
+            reverse("settings-entity", args=[entity.id]),
+            data={"action": "delete"},
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, "Can&#x27;t delete")
+        self.assertTrue(Entity.objects.filter(pk=entity.id).exists())
+
+    def test_duplicate_name_shows_form_error(self):
+        EntityFactory(name="Acme")
+        data = {"action": "save", "name": "Acme", "is_closed": ""}
+        response = self.client.post(reverse("settings-entities"), data=data)
+        self.assertEqual(response.status_code, 200)
+        # Only the original entity exists; the duplicate is rejected.
+        self.assertEqual(Entity.objects.filter(name="Acme").count(), 1)
+        self.assertContains(response, "already exists")

--- a/api/views/entity_settings_helpers.py
+++ b/api/views/entity_settings_helpers.py
@@ -1,0 +1,78 @@
+"""
+Helper functions for rendering the Entities Settings section (entity config
+CRUD).
+
+These pure functions take data and return HTML strings via render_to_string.
+They contain no database writes and no business logic. Mirrors
+bill_settings_helpers.
+"""
+
+from typing import Any, Dict, List, Optional
+
+from django.template.loader import render_to_string
+
+from api.forms import EntityForm
+from api.models import Entity
+
+
+def render_entities_content(
+    entities: List[Entity],
+    entity_form_html: str,
+    selected_id: Optional[int] = None,
+) -> str:
+    """Combines the header + table + form into the swappable Entities fragment."""
+    return render_to_string(
+        "api/content/entities-content.html",
+        {
+            "entities": entities,
+            "total": len(entities),
+            "selected_id": selected_id,
+            "entity_form": entity_form_html,
+        },
+    )
+
+
+def _entity_form_values(
+    entity: Optional[Entity], form: Optional[EntityForm]
+) -> Dict[str, Any]:
+    """Resolves the field values to display: submitted data on a bound (invalid)
+    form, else the entity being edited, else blank-create defaults."""
+    if form is not None and form.is_bound:
+        data = form.data
+        return {
+            "name": data.get("name", ""),
+            "is_closed": "is_closed" in data,
+        }
+    if entity is not None:
+        return {
+            "name": entity.name,
+            "is_closed": entity.is_closed,
+        }
+    return {
+        "name": "",
+        "is_closed": False,
+    }
+
+
+def render_entity_form(
+    entity: Optional[Entity] = None,
+    change: Optional[str] = None,
+    error: Optional[str] = None,
+    form: Optional[EntityForm] = None,
+) -> str:
+    """Renders the entity add/edit form HTML.
+
+    Args:
+        entity: Existing entity being edited (None for the create form).
+        change: Type of change just performed ("create"/"update"/"delete").
+        error: A friendly error message to display inline (e.g. delete blocked).
+        form: A bound form carrying validation errors to redisplay.
+    """
+    context = {
+        "entity": entity,
+        "change": change,
+        "error": error,
+        "form": form,
+        "values": _entity_form_values(entity, form),
+    }
+    return render_to_string("api/entry_forms/entity-form.html", context)

--- a/api/views/entity_settings_views.py
+++ b/api/views/entity_settings_views.py
@@ -1,0 +1,122 @@
+"""
+Views for the Entities Settings section.
+
+Loaded as an HTML fragment into the Settings shell. Provides config CRUD over
+the Entity model (mirrors BillRulesView/Accounts).
+
+Views parse requests, call services for business logic, and call helpers for
+rendering. No database writes and no HTML building here.
+"""
+
+from typing import Optional
+
+from django.contrib.auth.mixins import LoginRequiredMixin
+from django.http import HttpResponse
+from django.shortcuts import get_object_or_404
+from django.views import View
+
+from api.forms import EntityForm
+from api.models import Entity
+from api.services import entity_services
+from api.views import entity_settings_helpers
+
+
+class EntitySettingsView(LoginRequiredMixin, View):
+    login_url = "/login/"
+    redirect_field_name = "next"
+
+    def _render_content(
+        self,
+        entity: Optional[Entity] = None,
+        change: Optional[str] = None,
+        error: Optional[str] = None,
+        form: Optional[EntityForm] = None,
+        selected_id: Optional[int] = None,
+    ) -> str:
+        """Builds the swappable Entities fragment (header + table + form)."""
+        entity_form_html = entity_settings_helpers.render_entity_form(
+            entity=entity,
+            change=change,
+            error=error,
+            form=form,
+        )
+        entities = entity_services.get_entities()
+        return entity_settings_helpers.render_entities_content(
+            entities=entities,
+            entity_form_html=entity_form_html,
+            selected_id=selected_id,
+        )
+
+    def get(self, request):
+        return HttpResponse(self._render_content())
+
+    def post(self, request, entity_id=None):
+        action = request.POST.get("action")
+
+        if action == "clear":
+            return HttpResponse(self._render_content())
+
+        if action == "delete":
+            result = entity_services.delete_entity(entity_id)
+            if result.success:
+                return HttpResponse(self._render_content(change="delete"))
+            return HttpResponse(
+                self._render_content(
+                    entity=result.entity,
+                    error=result.error,
+                    selected_id=result.entity.id if result.entity else None,
+                )
+            )
+
+        if entity_id:
+            entity = get_object_or_404(Entity, pk=entity_id)
+            form = EntityForm(request.POST, instance=entity)
+            change = "update"
+        else:
+            entity = None
+            form = EntityForm(request.POST)
+            change = "create"
+
+        if not form.is_valid():
+            return HttpResponse(
+                self._render_content(
+                    entity=entity,
+                    form=form,
+                    selected_id=entity.id if entity else None,
+                )
+            )
+
+        result = entity_services.save_entity(form.cleaned_data, instance=entity)
+        if not result.success:
+            return HttpResponse(
+                self._render_content(
+                    entity=entity,
+                    form=form,
+                    error=result.error,
+                    selected_id=entity.id if entity else None,
+                )
+            )
+
+        return HttpResponse(
+            self._render_content(
+                entity=result.entity,
+                change=change,
+                selected_id=result.entity.id,
+            )
+        )
+
+
+class EntityFormView(LoginRequiredMixin, View):
+    """Loads an entity (or a blank create form) into the edit form.
+
+    Used on table row clicks (existing entity) and the New Entity button (no
+    entity_id -> blank form).
+    """
+
+    login_url = "/login/"
+    redirect_field_name = "next"
+
+    def get(self, request, entity_id=None):
+        entity = get_object_or_404(Entity, pk=entity_id) if entity_id else None
+        form_html = entity_settings_helpers.render_entity_form(entity=entity)
+        return HttpResponse(form_html)

--- a/ledger/static/css/app.css
+++ b/ledger/static/css/app.css
@@ -342,6 +342,9 @@ h4, h5 { font-size: var(--fs-md); font-weight: 600; margin: 0 0 var(--space-2); 
 }
 .table th.center, .table td.center { text-align: center; }
 .table th.right,  .table td.right  { text-align: right; }
+.table th.th-sort { cursor: pointer; user-select: none; }
+.table th.th-sort:hover { color: var(--text-2); }
+.sort-caret { font-size: .8em; }
 .table td {
   padding: var(--space-2) var(--space-3);
   font-size: var(--fs-body);

--- a/ledger/templates/api/base.html
+++ b/ledger/templates/api/base.html
@@ -84,29 +84,70 @@
         }));
 
         // Live search + selection state shared by the Settings list fragments
-        // (Accounts, Loans, Bill Rules). Rows carry data-search; the desktop
-        // <tr data-search> set drives the visible count.
+        // (Accounts, Loans, Bill Rules, Entities). Rows carry data-search; the
+        // desktop <tr data-search> set drives the visible count.
         //
-        // Remembers each list's live query so it survives htmx innerHTML swaps
-        // (e.g. saving an account re-renders the fragment). Keyed by noun; lives
-        // for the page lifetime, so a full reload still starts clean.
-        const searchListQueries = {};
-        Alpine.data('searchList', (total, noun, selectedId = null) => ({
-            q: searchListQueries[noun] || '',
-            selectedId: selectedId,
-            total: total,
-            init() { this.$watch('q', v => { searchListQueries[noun] = v; }); },
-            matches(el) { return !this.q.trim() || el.dataset.search.includes(this.q.toLowerCase()); },
-            visible() {
-                if (!this.q.trim()) return this.total;
-                const needle = this.q.toLowerCase();
-                return Array.from(this.$root.querySelectorAll('tr[data-search]'))
-                    .filter(tr => tr.dataset.search.includes(needle)).length;
-            },
-            countLabel() {
-                return this.q.trim() ? (this.visible() + ' of ' + this.total) : (this.total + ' ' + noun);
-            },
-        }));
+        // Remembers each list's live query and active column sort so they survive
+        // htmx innerHTML swaps (e.g. saving an entity re-renders the fragment).
+        // Keyed by noun; lives for the page lifetime, so a full reload starts clean.
+        const searchListState = {};
+        Alpine.data('searchList', (total, noun, selectedId = null) => {
+            const saved = searchListState[noun] || (searchListState[noun] = {});
+            return {
+                q: saved.q || '',
+                selectedId: selectedId,
+                total: total,
+                sortKey: saved.sortKey || null,
+                sortDir: saved.sortDir || 'desc',
+                init() {
+                    // Persist query + sort to the page-lifetime store so they
+                    // survive htmx swaps; reactive props drive the live UI.
+                    this.$watch('q', v => { saved.q = v; });
+                    this.$watch('sortKey', v => { saved.sortKey = v; });
+                    this.$watch('sortDir', v => { saved.sortDir = v; });
+                    // An htmx swap re-renders the fragment in the server's default
+                    // order, so reorder the fresh rows to match the saved sort.
+                    this.applySort();
+                },
+                matches(el) { return !this.q.trim() || el.dataset.search.includes(this.q.toLowerCase()); },
+                visible() {
+                    if (!this.q.trim()) return this.total;
+                    const needle = this.q.toLowerCase();
+                    return Array.from(this.$root.querySelectorAll('tr[data-search]'))
+                        .filter(tr => tr.dataset.search.includes(needle)).length;
+                },
+                countLabel() {
+                    return this.q.trim() ? (this.visible() + ' of ' + this.total) : (this.total + ' ' + noun);
+                },
+                // Optional numeric column sorting, opt-in via clickable headers
+                // that call sortBy(key). Rows carry data-sort-<key>; containers to
+                // reorder (desktop tbody + mobile list) carry data-sortable. The
+                // active key/dir persist per noun so they survive htmx swaps.
+                sortBy(key) {
+                    if (this.sortKey === key) {
+                        this.sortDir = this.sortDir === 'asc' ? 'desc' : 'asc';
+                    } else {
+                        this.sortKey = key;
+                        this.sortDir = 'desc';
+                    }
+                    this.applySort();
+                },
+                applySort() {
+                    if (!this.sortKey) return;
+                    const attr = 'sort' + this.sortKey.charAt(0).toUpperCase() + this.sortKey.slice(1);
+                    const factor = this.sortDir === 'asc' ? 1 : -1;
+                    this.$root.querySelectorAll('[data-sortable]').forEach(container => {
+                        Array.from(container.children)
+                            .sort((a, b) => factor * ((parseFloat(a.dataset[attr]) || 0) - (parseFloat(b.dataset[attr]) || 0)))
+                            .forEach(row => container.appendChild(row));
+                    });
+                },
+                sortCaret(key) {
+                    if (this.sortKey !== key) return '';
+                    return this.sortDir === 'asc' ? ' ▲' : ' ▼';
+                },
+            };
+        });
     });
     </script>
 

--- a/ledger/templates/api/content/entities-content.html
+++ b/ledger/templates/api/content/entities-content.html
@@ -1,0 +1,79 @@
+<div x-data="searchList({{ total }}, 'entities', {{ selected_id|default:'null' }})">
+
+  <div class="card-head">
+    <div class="card-head-left">
+      <h2 class="card-title">Entities</h2>
+      <span class="card-count" x-text="countLabel()"></span>
+    </div>
+    <div class="card-head-right">
+      {% include "api/components/search-box.html" with placeholder="Search entities" %}
+      <button class="btn btn-primary"
+              @click="selectedId = null"
+              hx-get="{% url 'settings-entity-new-form' %}"
+              hx-target="#entity-form-div">New Entity</button>
+    </div>
+  </div>
+
+  <div class="table-scroll has-list">
+  <table class="table">
+    <thead>
+      <tr>
+        <th>Name</th>
+        <th class="center th-sort" @click="sortBy('accounts')">
+          Accounts<span class="sort-caret" x-text="sortCaret('accounts')"></span>
+        </th>
+        <th class="center th-sort" @click="sortBy('t90')">
+          Tags (90d)<span class="sort-caret" x-text="sortCaret('t90')"></span>
+        </th>
+        <th class="center">Closed</th>
+      </tr>
+    </thead>
+    <tbody data-sortable>
+      {% for entity in entities %}
+      <tr class="row"
+          data-search="{{ entity.name|lower }}"
+          data-sort-accounts="{{ entity.account_count }}"
+          data-sort-t90="{{ entity.recent_tag_count }}"
+          :class="{ selected: selectedId === {{ entity.id }} }"
+          x-show="matches($el)"
+          @click="selectedId = {{ entity.id }}"
+          hx-get="{% url 'settings-entity-form' entity.id %}"
+          hx-target="#entity-form-div">
+        <td class="td-name">{{ entity.name }}</td>
+        <td class="td-muted center">{{ entity.account_count }}</td>
+        <td class="td-muted center">{{ entity.recent_tag_count }}</td>
+        <td class="td-muted center">{% if entity.is_closed %}Yes{% else %}No{% endif %}</td>
+      </tr>
+      {% endfor %}
+    </tbody>
+  </table>
+  </div>
+
+  <div class="list" data-sortable>
+    {% for entity in entities %}
+    <div class="lrow"
+         data-search="{{ entity.name|lower }}"
+         data-sort-accounts="{{ entity.account_count }}"
+         data-sort-t90="{{ entity.recent_tag_count }}"
+         :class="{ selected: selectedId === {{ entity.id }} }"
+         x-show="matches($el)"
+         @click="selectedId = {{ entity.id }}"
+         hx-get="{% url 'settings-entity-form' entity.id %}"
+         hx-target="#entity-form-div">
+      <div class="lrow-top">
+        <span class="lname">{{ entity.name }}</span>
+        <span class="lmeta-right">{{ entity.account_count }} account{{ entity.account_count|pluralize }}</span>
+      </div>
+      <div class="lmeta">{{ entity.recent_tag_count }} tag{{ entity.recent_tag_count|pluralize }} · 90d · {% if entity.is_closed %}Closed{% else %}Open{% endif %}</div>
+    </div>
+    {% endfor %}
+  </div>
+
+  <div class="table-empty" x-show="visible() === 0" x-cloak>
+    No entities match "<span x-text="q"></span>".
+  </div>
+
+  <div id="entity-form-div">
+    {{ entity_form }}
+  </div>
+</div>

--- a/ledger/templates/api/entry_forms/entity-form.html
+++ b/ledger/templates/api/entry_forms/entity-form.html
@@ -1,0 +1,51 @@
+<div class="form">
+
+  <div class="form-header">
+    {% if entity %}Edit · {{ entity.name }}{% else %}New entity{% endif %}
+  </div>
+
+  {% if change == "create" %}
+    <div class="alert alert-success">Entity created.</div>
+  {% elif change == "update" %}
+    <div class="alert alert-success">Entity updated.</div>
+  {% elif change == "delete" %}
+    <div class="alert alert-success">Entity deleted.</div>
+  {% endif %}
+  {% if error %}
+    <div class="alert alert-danger">{{ error }}</div>
+  {% endif %}
+  {% if form.non_field_errors %}
+    <div class="alert alert-danger">{{ form.non_field_errors }}</div>
+  {% endif %}
+
+  <form method="post"
+        {% if entity %}hx-post="{% url 'settings-entity' entity.id %}"{% else %}hx-post="{% url 'settings-entities' %}"{% endif %}
+        hx-target="#entities-content"
+        hx-swap="innerHTML">
+    {% csrf_token %}
+
+    <div class="grid grid-wide-first grid-end">
+      <div>
+        <label class="label">Name</label>
+        <input class="input" name="name" value="{{ values.name }}" placeholder="Entity name" />
+        {% for e in form.name.errors %}<div class="field-error">{{ e }}</div>{% endfor %}
+      </div>
+      <div class="checks">
+        <label class="check">
+          <input type="checkbox" name="is_closed" {% if values.is_closed %}checked{% endif %} />Closed
+        </label>
+      </div>
+    </div>
+
+    <div class="actions">
+      <button type="submit" name="action" value="save" class="btn btn-primary">{% if entity %}Save{% else %}Create{% endif %}</button>
+      {% if entity %}
+      <button type="submit" name="action" value="delete" class="btn btn-danger">Delete</button>
+      {% endif %}
+      <button type="button" class="btn btn-ghost"
+              @click="selectedId = null"
+              hx-get="{% url 'settings-entity-new-form' %}"
+              hx-target="#entity-form-div">Clear</button>
+    </div>
+  </form>
+</div>

--- a/ledger/templates/api/views/settings.html
+++ b/ledger/templates/api/views/settings.html
@@ -2,7 +2,6 @@
         section: 'Accounts',
         sections: ['Accounts', 'Bill Rules', 'Utility Bills', 'Loans', 'Entities', 'Paystubs', 'Auto Tags', 'CSV Profiles'],
         stubs: {
-          'Entities': 'Counterparties money moves to and from — banks, employers, landlords.',
           'Paystubs': 'Saved paystub templates parsed via AWS Textract.',
           'Auto Tags': 'Rules that auto-categorize incoming transactions.',
           'CSV Profiles': 'Column mappings for each bank\'s CSV export format.'
@@ -40,6 +39,14 @@
       <div x-show="section === 'Utility Bills'">
         <div id="bills-content"
              hx-get="{% url 'settings-bills' %}" hx-trigger="load">
+          <div class="table-empty">Loading…</div>
+        </div>
+      </div>
+
+      <!-- Entities (functional, lazy-loaded) -->
+      <div x-show="section === 'Entities'">
+        <div id="entities-content"
+             hx-get="{% url 'settings-entities' %}" hx-trigger="load">
           <div class="table-empty">Loading…</div>
         </div>
       </div>

--- a/ledger/urls.py
+++ b/ledger/urls.py
@@ -8,6 +8,7 @@ from api.views.amortization_views import (
     AmortizationView,
     AmortizeFormView,
 )
+from api.views.entity_settings_views import EntityFormView, EntitySettingsView
 from api.views.entity_views import (
     EntityGroupedBalancesView,
     EntityHistoryTable,
@@ -252,6 +253,27 @@ urlpatterns = [
         name="settings-bill-rule-form",
     ),
     path("settings/bills/", BillsView.as_view(), name="settings-bills"),
+    # Settings — entities (config CRUD)
+    path(
+        "settings/entities/",
+        EntitySettingsView.as_view(),
+        name="settings-entities",
+    ),
+    path(
+        "settings/entities/new/form/",
+        EntityFormView.as_view(),
+        name="settings-entity-new-form",
+    ),
+    path(
+        "settings/entities/<int:entity_id>/",
+        EntitySettingsView.as_view(),
+        name="settings-entity",
+    ),
+    path(
+        "settings/entities/<int:entity_id>/form/",
+        EntityFormView.as_view(),
+        name="settings-entity-form",
+    ),
     # Settings — loans (amortization-schedule config CRUD + schedule view)
     path(
         "settings/loans/",


### PR DESCRIPTION
## Summary

Makes the **Entities** section of Settings a real CRUD surface. It was previously a placeholder stub; now you can list, create, rename, close, and delete entities — mirroring the existing **Bill Rules** pattern (View → Helper → Form → Service → shared `crud` helpers).

## What's included

- **Service** (`entity_services.py`): `get_entities()` annotates each entity with `account_count` and `recent_tag_count` (a rolling 90-day count of journal-entry-item taggings, windowed on the entry date); `save_entity`/`delete_entity` go through the shared `crud.save_model`/`crud.delete_model` helpers, with a friendly "close it instead" message when a PROTECT reference blocks deletion.
- **View/Form/Helper/Templates**: `EntitySettingsView` + `EntityFormView`, `EntityForm`, `entity_settings_helpers`, and the `entities-content` / `entity-form` templates; four `settings/entities/*` routes.
- **Settings shell**: the Entities stub is replaced with a lazy-loaded HTMX panel.
- **Sortable columns**: opt-in numeric column sorting added to the shared `searchList` Alpine component. The **Accounts** and **Tags (90d)** columns are sortable, and both the search query and the active sort persist across HTMX fragment swaps (e.g. after saving/editing an entity). Other lists (Accounts, Bill Rules, Loans) are unaffected — sorting is opt-in via clickable headers.

## Testing

- New `GetEntitiesTest` (service) covering ordering, account count, and the 90-day window boundary.
- New `test_entity_settings_views.py` covering login gate, list rendering (incl. counts and the sortable Tags column), create/update/delete, PROTECT-blocked delete, and duplicate-name validation.
- Full suite: **528 tests passing**.

Note: the column-sort persistence is client-side JS, so it isn't exercised by the Django suite — worth a quick manual confirm in the browser.

🤖 Generated with [Claude Code](https://claude.com/claude-code)