### PR TITLE
Tag unrealized gain/loss plug entries with account's default entity

### DIFF
--- a/api/models.py
+++ b/api/models.py
@@ -336,6 +336,7 @@ class Reconciliation(models.Model):
             type=gain_loss_entry_type,
             amount=abs(delta),
             account=GAIN_LOSS_ACCOUNT,
+            entity=self.account.entity,
         )
 
         JournalEntryItem.objects.create(
@@ -343,6 +344,7 @@ class Reconciliation(models.Model):
             type=account_entry_type,
             amount=abs(delta),
             account=self.account,
+            entity=self.account.entity,
         )
 
         transaction.close()

--- a/api/tests/models/test_reconciliation.py
+++ b/api/tests/models/test_reconciliation.py
@@ -3,7 +3,7 @@ from decimal import Decimal
 from django.test import TestCase
 from django.db.utils import IntegrityError
 from api.models import Reconciliation, Account, JournalEntryItem
-from api.tests.testing_factories import AccountFactory, TransactionFactory, JournalEntryFactory, JournalEntryItemFactory
+from api.tests.testing_factories import AccountFactory, EntityFactory, TransactionFactory, JournalEntryFactory, JournalEntryItemFactory
 
 class ReconciliationTests(TestCase):
 
@@ -90,3 +90,38 @@ class ReconciliationTests(TestCase):
         self.assertEqual(reconciliation.transaction.amount, Decimal('-50.00'))
         self.assertEqual(cash_account.get_balance(today), 50)
         self.assertEqual(unrealized_account.get_balance(today,start_date=today), Decimal('-50.00'))
+
+    def _plug_items_for_account_entity(self, entity):
+        today = datetime.date.today()
+        AccountFactory(
+            type=Account.Type.INCOME,
+            special_type=Account.SpecialType.UNREALIZED_GAINS_AND_LOSSES
+        )
+        investment_account = AccountFactory(
+            name='vanguard',
+            type=Account.Type.ASSET,
+            entity=entity
+        )
+        reconciliation = Reconciliation.objects.create(
+            account=investment_account,
+            date=today,
+            amount=Decimal('200.00')
+        )
+        reconciliation.plug_investment_change()
+
+        return JournalEntryItem.objects.filter(
+            journal_entry=reconciliation.transaction.journal_entry
+        )
+
+    def test_plug_tags_account_default_entity(self):
+        entity = EntityFactory()
+        items = self._plug_items_for_account_entity(entity)
+        self.assertEqual(items.count(), 2)
+        for item in items:
+            self.assertEqual(item.entity, entity)
+
+    def test_plug_without_default_entity_leaves_entity_null(self):
+        items = self._plug_items_for_account_entity(None)
+        self.assertEqual(items.count(), 2)
+        for item in items:
+            self.assertIsNone(item.entity)


### PR DESCRIPTION
## Summary

When the unrealized gains/losses feature is used as a "plug" (via `Reconciliation.plug_investment_change()`), the two created journal entry items were never tagged with an entity — even when the reconciled account (e.g. a Vanguard investment) had a default entity configured.

This sets `entity=self.account.entity` on both the gain/loss line and the reconciled-account line, mirroring how normal transactions auto-tag the entity from the account's default (`api/services/journal_entry_services.py`). Unrealized gains/losses now appear under the correct entity in entity-level income reports. When the account has no default entity, the field stays `None`, preserving prior behavior.

## Tests

Added `test_reconciliation.py` coverage:
- `test_plug_tags_account_default_entity` — both plug items get the account's default entity.
- `test_plug_without_default_entity_leaves_entity_null` — entity stays `None` when the account has none.

All reconciliation tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)