### PR TITLE
Apply recharacterize operations one at a time

### DIFF
--- a/api/services/recharacterize_services.py
+++ b/api/services/recharacterize_services.py
@@ -49,7 +49,7 @@ ACTION_SET_ENTITY = "set_entity"
 ACTION_CLEAR_ENTITY = "clear_entity"
 ACTION_CHANGE_ACCOUNT = "change_account"
 # A view operation only inspects the matched items; it never mutates the ledger,
-# so it carries no Apply button and is skipped by apply_plan.
+# so it carries no Apply button and cannot be applied.
 ACTION_VIEW = "view"
 
 MUTATING_ACTIONS = {ACTION_SET_ENTITY, ACTION_CLEAR_ENTITY, ACTION_CHANGE_ACCOUNT}
@@ -339,11 +339,9 @@ class OperationPreview:
 
 @dataclass
 class PlanPreview:
+    # Each operation carries its own blocked/mutates/affected_count state and its
+    # own Apply button, so the plan holds no aggregate gate or totals.
     operations: List[OperationPreview]
-    total_affected: int
-    total_changes: int
-    has_blocks: bool
-    can_apply: bool
 
 
 def _project_row(item: JournalEntryItem, evaluation: EvaluatedOperation) -> Dict[str, Any]:
@@ -399,14 +397,10 @@ def _page_result(
 def preview_plan(operations: List[Dict[str, Any]]) -> PlanPreview:
     """Validates every operation and computes its exact effect for review."""
     op_previews: List[OperationPreview] = []
-    total_affected = 0
-    total_changes = 0
-    has_blocks = False
 
     for index, operation in enumerate(operations):
         evaluation = _evaluate_operation(operation)
         if evaluation.blocked:
-            has_blocks = True
             op_previews.append(
                 OperationPreview(
                     index=index,
@@ -422,34 +416,23 @@ def preview_plan(operations: List[Dict[str, Any]]) -> PlanPreview:
             continue
 
         page = _page_result(evaluation, index, 1)
-        affected_count = page.total
-        total_affected += affected_count
-        mutates = _is_mutation(evaluation.action_kind)
-        if mutates:
-            total_changes += affected_count
         op_previews.append(
             OperationPreview(
                 index=index,
                 criteria=evaluation.criteria,
                 action_summary=evaluation.action_summary,
-                affected_count=affected_count,
+                affected_count=page.total,
                 page=page,
                 blocked=False,
                 error=None,
-                mutates=mutates,
+                mutates=_is_mutation(evaluation.action_kind),
             )
         )
 
-    # Apply is offered only when something will actually change, so a pure
-    # view-only plan never shows an Apply button.
-    can_apply = bool(operations) and not has_blocks and total_changes > 0
-    return PlanPreview(
-        operations=op_previews,
-        total_affected=total_affected,
-        total_changes=total_changes,
-        has_blocks=has_blocks,
-        can_apply=can_apply,
-    )
+    # Each mutating operation carries its own Apply button (see the preview
+    # template), so there is no plan-wide apply gate; a blocked or view-only op
+    # simply shows no button without affecting its siblings.
+    return PlanPreview(operations=op_previews)
 
 
 def _evaluate_at(
@@ -499,46 +482,49 @@ def build_page(
 class ApplyResult:
     success: bool
     updated_count: int = 0
+    action_summary: str = ""
     error: Optional[str] = None
 
 
 @db_transaction.atomic
-def apply_plan(operations: List[Dict[str, Any]]) -> ApplyResult:
-    """Re-validates and applies every operation atomically.
+def apply_operation(operations: List[Dict[str, Any]], op_index: int) -> ApplyResult:
+    """Re-validates and applies a single operation, leaving the rest untouched.
 
-    Re-evaluates from the operation dicts (never trusts a stale preview). If any
-    operation is blocked, the whole plan aborts with no writes.
+    Re-evaluates from the operation dict (never trusts a stale preview) so the
+    write reflects the live ledger. Operations are applied one at a time, so a
+    blocked sibling never prevents committing this one; the user resolves and
+    applies each independently.
     """
-    if not operations:
+    if op_index < 0 or op_index >= len(operations):
         return ApplyResult(success=False, error="There is nothing to apply.")
 
-    evaluations = []
-    for operation in operations:
-        evaluation = _evaluate_operation(operation)
-        if evaluation.blocked:
-            return ApplyResult(
-                success=False,
-                error="Plan blocked: " + " ".join(evaluation.errors),
-            )
-        evaluations.append(evaluation)
+    evaluation = _evaluate_operation(operations[op_index])
+    if evaluation.blocked:
+        return ApplyResult(
+            success=False,
+            error="Operation blocked: " + " ".join(evaluation.errors),
+        )
 
-    updated_count = 0
-    for evaluation in evaluations:
-        if evaluation.action_kind == ACTION_SET_ENTITY:
-            updated_count += evaluation.queryset.update(
-                entity=evaluation.target_entity
-            )
-        elif evaluation.action_kind == ACTION_CLEAR_ENTITY:
-            updated_count += evaluation.queryset.update(entity=None)
-        elif evaluation.action_kind == ACTION_CHANGE_ACCOUNT:
-            updated_count += evaluation.queryset.update(
-                account=evaluation.to_account
-            )
-        elif evaluation.action_kind == ACTION_VIEW:
-            # View is read-only; a mixed plan may include one, so skip it here.
-            pass
+    if not _is_mutation(evaluation.action_kind):
+        # A view-only operation has nothing to commit.
+        return ApplyResult(
+            success=False, error="This operation does not change anything."
+        )
 
-    return ApplyResult(success=True, updated_count=updated_count)
+    if evaluation.action_kind == ACTION_SET_ENTITY:
+        updated_count = evaluation.queryset.update(entity=evaluation.target_entity)
+    elif evaluation.action_kind == ACTION_CLEAR_ENTITY:
+        updated_count = evaluation.queryset.update(entity=None)
+    elif evaluation.action_kind == ACTION_CHANGE_ACCOUNT:
+        updated_count = evaluation.queryset.update(account=evaluation.to_account)
+    else:  # pragma: no cover - mutation guard above keeps this unreachable
+        return ApplyResult(success=False, error="This operation cannot be applied.")
+
+    return ApplyResult(
+        success=True,
+        updated_count=updated_count,
+        action_summary=evaluation.action_summary,
+    )
 
 
 # --- Chat turn orchestration ------------------------------------------------

--- a/api/tests/services/test_recharacterize_services.py
+++ b/api/tests/services/test_recharacterize_services.py
@@ -8,7 +8,7 @@ from django.test import TestCase
 from api.models import Account, JournalEntryItem
 from api.services.recharacterize_services import (
     SAMPLE_LIMIT,
-    apply_plan,
+    apply_operation,
     build_export_rows,
     build_page,
     preview_plan,
@@ -117,10 +117,10 @@ class RecharacterizeServicesTest(TestCase):
             }
         ]
         preview = preview_plan(ops)
-        self.assertTrue(preview.can_apply)
-        self.assertEqual(preview.total_affected, 2)
+        self.assertTrue(preview.operations[0].mutates)
+        self.assertEqual(preview.operations[0].affected_count, 2)
 
-        result = apply_plan(ops)
+        result = apply_operation(ops, 0)
         self.assertTrue(result.success)
         self.assertEqual(result.updated_count, 2)
 
@@ -140,7 +140,7 @@ class RecharacterizeServicesTest(TestCase):
                 "action": {"type": "clear_entity"},
             }
         ]
-        result = apply_plan(ops)
+        result = apply_operation(ops, 0)
         self.assertTrue(result.success)
         self.assertEqual(result.updated_count, 1)
         self.d1.refresh_from_db()
@@ -156,7 +156,7 @@ class RecharacterizeServicesTest(TestCase):
                 "action": {"type": "set_entity", "entity": "Ally Bank"},
             }
         ]
-        self.assertTrue(apply_plan(ops).success)
+        self.assertTrue(apply_operation(ops, 0).success)
         after = self.groceries.get_balance(end, start)
         self.assertEqual(before, after)
 
@@ -170,8 +170,8 @@ class RecharacterizeServicesTest(TestCase):
             }
         ]
         preview = preview_plan(ops)
-        self.assertTrue(preview.can_apply)
-        result = apply_plan(ops)
+        self.assertTrue(preview.operations[0].mutates)
+        result = apply_operation(ops, 0)
         self.assertTrue(result.success)
         self.assertEqual(result.updated_count, 3)  # all 3 Verizon grocery debits
         self.assertFalse(
@@ -186,9 +186,9 @@ class RecharacterizeServicesTest(TestCase):
             }
         ]
         preview = preview_plan(ops)
-        self.assertTrue(preview.has_blocks)
-        self.assertFalse(preview.can_apply)
-        self.assertFalse(apply_plan(ops).success)
+        self.assertTrue(preview.operations[0].blocked)
+        self.assertTrue(preview.operations[0].blocked)
+        self.assertFalse(apply_operation(ops, 0).success)
 
     def test_account_swap_different_subtype_blocked(self):
         ops = [
@@ -198,8 +198,8 @@ class RecharacterizeServicesTest(TestCase):
             }
         ]
         preview = preview_plan(ops)
-        self.assertTrue(preview.has_blocks)
-        self.assertFalse(apply_plan(ops).success)
+        self.assertTrue(preview.operations[0].blocked)
+        self.assertFalse(apply_operation(ops, 0).success)
 
     def test_change_account_requires_source(self):
         ops = [
@@ -208,7 +208,7 @@ class RecharacterizeServicesTest(TestCase):
                 "action": {"type": "change_account", "to_account": "Dining"},
             }
         ]
-        self.assertTrue(preview_plan(ops).has_blocks)
+        self.assertTrue(preview_plan(ops).operations[0].blocked)
 
     # --- protected accounts -------------------------------------------------
 
@@ -226,8 +226,8 @@ class RecharacterizeServicesTest(TestCase):
                 "action": {"type": "change_account", "to_account": "Groceries"},
             }
         ]
-        self.assertTrue(preview_plan(ops).has_blocks)
-        self.assertFalse(apply_plan(ops).success)
+        self.assertTrue(preview_plan(ops).operations[0].blocked)
+        self.assertFalse(apply_operation(ops, 0).success)
         _ = unrealized
 
     def test_set_entity_includes_swap_blocked_items(self):
@@ -256,8 +256,8 @@ class RecharacterizeServicesTest(TestCase):
         ]
         # Entity tagging is allowed on every account, including swap-blocked ones.
         preview = preview_plan(ops)
-        self.assertFalse(preview.has_blocks)
-        result = apply_plan(ops)
+        self.assertFalse(preview.operations[0].blocked)
+        result = apply_operation(ops, 0)
         self.assertTrue(result.success)
 
         blocked_debit.refresh_from_db()
@@ -278,8 +278,8 @@ class RecharacterizeServicesTest(TestCase):
                 "action": {"type": "change_account", "to_account": "Other Equity"},
             }
         ]
-        self.assertTrue(preview_plan(from_ops).has_blocks)
-        self.assertFalse(apply_plan(from_ops).success)
+        self.assertTrue(preview_plan(from_ops).operations[0].blocked)
+        self.assertFalse(apply_operation(from_ops, 0).success)
         # Blocked as the swap destination.
         to_ops = [
             {
@@ -287,8 +287,8 @@ class RecharacterizeServicesTest(TestCase):
                 "action": {"type": "change_account", "to_account": "Starting Equity"},
             }
         ]
-        self.assertTrue(preview_plan(to_ops).has_blocks)
-        self.assertFalse(apply_plan(to_ops).success)
+        self.assertTrue(preview_plan(to_ops).operations[0].blocked)
+        self.assertFalse(apply_operation(to_ops, 0).success)
         _ = other_equity
 
     def test_set_entity_on_starting_equity_allowed(self):
@@ -304,8 +304,8 @@ class RecharacterizeServicesTest(TestCase):
                 "action": {"type": "set_entity", "entity": "Ally Bank"},
             }
         ]
-        self.assertFalse(preview_plan(ops).has_blocks)
-        self.assertTrue(apply_plan(ops).success)
+        self.assertFalse(preview_plan(ops).operations[0].blocked)
+        self.assertTrue(apply_operation(ops, 0).success)
         debit.refresh_from_db()
         self.assertEqual(debit.entity, self.ally_bank)
 
@@ -318,8 +318,8 @@ class RecharacterizeServicesTest(TestCase):
                 "action": {"type": "set_entity", "entity": "Nonexistent Bank"},
             }
         ]
-        self.assertTrue(preview_plan(ops).has_blocks)
-        self.assertFalse(apply_plan(ops).success)
+        self.assertTrue(preview_plan(ops).operations[0].blocked)
+        self.assertFalse(apply_operation(ops, 0).success)
 
     def test_account_name_with_whitespace_resolves(self):
         # The LLM is told to copy names verbatim but sometimes adds stray
@@ -330,7 +330,7 @@ class RecharacterizeServicesTest(TestCase):
                 "action": {"type": "set_entity", "entity": "Ally Bank"},
             }
         ]
-        self.assertFalse(preview_plan(ops).has_blocks)
+        self.assertFalse(preview_plan(ops).operations[0].blocked)
 
     def test_account_name_case_insensitive_resolves(self):
         ops = [
@@ -339,13 +339,13 @@ class RecharacterizeServicesTest(TestCase):
                 "action": {"type": "set_entity", "entity": "ally bank"},
             }
         ]
-        self.assertFalse(preview_plan(ops).has_blocks)
+        self.assertFalse(preview_plan(ops).operations[0].blocked)
 
     def test_empty_filter_blocked(self):
         ops = [
             {"filter": {}, "action": {"type": "set_entity", "entity": "Ally Bank"}}
         ]
-        self.assertTrue(preview_plan(ops).has_blocks)
+        self.assertTrue(preview_plan(ops).operations[0].blocked)
 
     def test_entity_is_empty_filter_targets_untagged_items(self):
         misc = AccountFactory(
@@ -372,10 +372,10 @@ class RecharacterizeServicesTest(TestCase):
             }
         ]
         preview = preview_plan(ops)
-        self.assertFalse(preview.has_blocks)  # "no entity" is a valid criterion
-        self.assertTrue(preview.can_apply)
+        self.assertFalse(preview.operations[0].blocked)  # "no entity" is a valid criterion
+        self.assertTrue(preview.operations[0].mutates)
 
-        result = apply_plan(ops)
+        result = apply_operation(ops, 0)
         self.assertTrue(result.success)
         self.assertEqual(result.updated_count, 1)  # only the untagged Misc debit
         untagged.refresh_from_db()
@@ -393,12 +393,10 @@ class RecharacterizeServicesTest(TestCase):
             }
         ]
         preview = preview_plan(ops)
-        self.assertFalse(preview.has_blocks)
-        self.assertFalse(preview.can_apply)  # nothing to apply for a view
-        self.assertEqual(preview.total_changes, 0)
-        self.assertEqual(preview.total_affected, 2)
-
         op = preview.operations[0]
+        self.assertFalse(op.blocked)
+        # A view-only op never carries an Apply button: it matches items but
+        # mutates nothing.
         self.assertFalse(op.mutates)
         self.assertEqual(op.affected_count, 2)
         # Preview page rows show no before/after diff.
@@ -406,15 +404,15 @@ class RecharacterizeServicesTest(TestCase):
             self.assertEqual(row["account_before"], row["account_after"])
             self.assertEqual(row["entity_before"], row["entity_after"])
 
-    def test_view_op_is_noop_on_apply(self):
+    def test_view_op_cannot_be_applied(self):
         ops = [
             {
                 "filter": self._verizon_2025_checking_debit_filter(),
                 "action": {"type": "view"},
             }
         ]
-        result = apply_plan(ops)
-        self.assertTrue(result.success)
+        result = apply_operation(ops, 0)
+        self.assertFalse(result.success)  # a view-only op has nothing to commit
         self.assertEqual(result.updated_count, 0)
         self.d1.refresh_from_db()
         self.assertIsNone(self.d1.entity)
@@ -431,13 +429,15 @@ class RecharacterizeServicesTest(TestCase):
             },
         ]
         preview = preview_plan(ops)
-        self.assertTrue(preview.can_apply)
         self.assertFalse(preview.operations[0].mutates)
         self.assertTrue(preview.operations[1].mutates)
-        # Only the mutating op's 3 grocery debits count toward changes.
-        self.assertEqual(preview.total_changes, 3)
+        # Only the mutating op's 3 grocery debits will change.
+        self.assertEqual(preview.operations[1].affected_count, 3)
 
-        result = apply_plan(ops)
+        # The view op (index 0) has nothing to commit; the mutating op (index 1)
+        # applies on its own.
+        self.assertFalse(apply_operation(ops, 0).success)
+        result = apply_operation(ops, 1)
         self.assertTrue(result.success)
         self.assertEqual(result.updated_count, 3)
 
@@ -591,7 +591,7 @@ class RecharacterizeServicesTest(TestCase):
         self.assertTrue(turn.failed)
         self.assertIn("503", turn.error)
 
-    def test_apply_is_atomic_one_bad_op_aborts_all(self):
+    def test_apply_one_at_a_time_good_op_commits_blocked_sibling_does_not(self):
         ops = [
             {
                 "filter": self._verizon_2025_checking_debit_filter(),
@@ -602,10 +602,25 @@ class RecharacterizeServicesTest(TestCase):
                 "action": {"type": "set_entity", "entity": "Nonexistent Bank"},
             },
         ]
-        result = apply_plan(ops)
-        self.assertFalse(result.success)
-        # First op's items must remain unchanged (no partial write).
+        # The good op (index 0) applies on its own.
+        result = apply_operation(ops, 0)
+        self.assertTrue(result.success)
         self.d1.refresh_from_db()
         self.d2.refresh_from_db()
-        self.assertIsNone(self.d1.entity)
-        self.assertIsNone(self.d2.entity)
+        self.assertEqual(self.d1.entity, self.ally_bank)
+        self.assertEqual(self.d2.entity, self.ally_bank)
+
+        # The blocked sibling (index 1) fails and writes nothing.
+        blocked = apply_operation(ops, 1)
+        self.assertFalse(blocked.success)
+        self.assertIn("blocked", blocked.error.lower())
+
+    def test_apply_out_of_range_index_is_noop(self):
+        ops = [
+            {
+                "filter": self._verizon_2025_checking_debit_filter(),
+                "action": {"type": "set_entity", "entity": "Ally Bank"},
+            }
+        ]
+        self.assertFalse(apply_operation(ops, 5).success)
+        self.assertFalse(apply_operation(ops, -1).success)

--- a/api/tests/views/test_recharacterize_views.py
+++ b/api/tests/views/test_recharacterize_views.py
@@ -73,18 +73,52 @@ class RecharacterizeViewsTest(TestCase):
         )
         self.assertEqual(resp.status_code, 200)
         self.assertContains(resp, "set entity")
-        self.assertContains(resp, "Apply")
+        self.assertContains(resp, "Apply (1)")  # per-operation Apply button
         # Criteria are laid out so the user can eyeball the parsed filter.
         self.assertContains(resp, "Matching items where:")
         self.assertContains(resp, "Ally Checking")
         self.assertContains(resp, "debits only")
 
-        # Apply -> the item now carries the entity.
-        resp = self.client.post(reverse("recharacterize-apply"))
+        # Apply operation 0 -> the item now carries the entity.
+        resp = self.client.post(reverse("recharacterize-apply") + "?op=0")
         self.assertEqual(resp.status_code, 200)
         self.assertContains(resp, "Updated 1 journal entry item")
         self.debit.refresh_from_db()
         self.assertEqual(self.debit.entity, self.ally_bank)
+        # The applied operation is removed from the plan; the rest remain.
+        self.assertEqual(self.client.session["recharacterize"]["operations"], [])
+
+    @patch("api.services.recharacterize_services.gemini_services.call_gemini_conversation")
+    def test_apply_one_operation_leaves_the_rest(self, mock_call):
+        other_entity = EntityFactory(name="Other Bank")
+        mock_call.return_value = json.dumps(
+            {
+                "reply": "Two operations.",
+                "operations": [
+                    {
+                        "filter": {"account": "Ally Checking", "entry_type": "debit"},
+                        "action": {"type": "set_entity", "entity": "Ally Bank"},
+                    },
+                    {
+                        "filter": {"account": "Ally Checking", "entry_type": "debit"},
+                        "action": {"type": "set_entity", "entity": "Other Bank"},
+                    },
+                ],
+            }
+        )
+        self.client.post(
+            reverse("recharacterize-message"), {"message": "two ops"}
+        )
+
+        # Apply only operation 0; operation 1 must survive for a later apply.
+        resp = self.client.post(reverse("recharacterize-apply") + "?op=0")
+        self.assertEqual(resp.status_code, 200)
+        self.debit.refresh_from_db()
+        self.assertEqual(self.debit.entity, self.ally_bank)
+        remaining = self.client.session["recharacterize"]["operations"]
+        self.assertEqual(len(remaining), 1)
+        self.assertEqual(remaining[0]["action"]["entity"], "Other Bank")
+        _ = other_entity
 
     def test_reset_clears_session(self):
         resp = self.client.post(reverse("recharacterize-reset"))

--- a/api/views/recharacterize_views.py
+++ b/api/views/recharacterize_views.py
@@ -116,7 +116,12 @@ class RecharacterizeRetryView(LoginRequiredMixin, View):
 
 
 class RecharacterizeApplyView(LoginRequiredMixin, View):
-    """Re-validates and applies the plan stored in the session."""
+    """Re-validates and applies a single operation from the stored plan.
+
+    Operations are applied one at a time: the ``op`` index selects which one.
+    On success that operation is dropped from the plan and the remaining ops are
+    re-previewed against the now-updated ledger.
+    """
 
     login_url = "/login/"
 
@@ -125,7 +130,8 @@ class RecharacterizeApplyView(LoginRequiredMixin, View):
         messages = state["messages"]
         operations = state["operations"]
 
-        result = recharacterize_services.apply_plan(operations)
+        op_index = _parse_op_index(request)
+        result = recharacterize_services.apply_operation(operations, op_index)
 
         if not result.success:
             # Surface the apply error as an assistant message so it's visible.
@@ -135,13 +141,23 @@ class RecharacterizeApplyView(LoginRequiredMixin, View):
             html = recharacterize_helpers.render_main(messages, preview)
             return HttpResponse(html)
 
-        flash = (
-            f"Applied. Updated {result.updated_count} journal entry "
-            f"item{'' if result.updated_count == 1 else 's'}."
+        # Drop the applied operation; the rest stay so they can be applied next.
+        remaining = operations[:op_index] + operations[op_index + 1 :]
+        # The confirmation lives in the chat log (consistent with every other
+        # turn); the remaining-ops preview re-renders below it.
+        messages.append(
+            {
+                "role": "assistant",
+                "text": (
+                    f"Applied: {result.action_summary}. Updated "
+                    f"{result.updated_count} journal entry "
+                    f"item{'' if result.updated_count == 1 else 's'}."
+                ),
+            }
         )
-        messages.append({"role": "assistant", "text": flash})
-        _save_state(request, messages=messages, operations=[])
-        html = recharacterize_helpers.render_main(messages, preview=None, flash=flash)
+        _save_state(request, messages=messages, operations=remaining)
+        preview = recharacterize_services.preview_plan(remaining) if remaining else None
+        html = recharacterize_helpers.render_main(messages, preview)
         return HttpResponse(html)
 
 

--- a/ledger/templates/api/components/recharacterize-preview.html
+++ b/ledger/templates/api/components/recharacterize-preview.html
@@ -37,25 +37,18 @@
                     </a>
                 </p>
             {% endif %}
+            {% if op.mutates and op.affected_count > 0 %}
+            <button type="button" class="btn btn-danger mt-2"
+                    hx-post="{% url 'recharacterize-apply' %}?op={{ op.index }}"
+                    hx-target="#recharacterize-main"
+                    hx-swap="outerHTML"
+                    hx-confirm="Apply this operation to {{ op.affected_count }} journal entry item{{ op.affected_count|pluralize }}?">
+                Apply ({{ op.affected_count }})
+            </button>
+            {% endif %}
         {% endif %}
     </div>
     {% endfor %}
-
-    {% if preview.has_blocks %}
-    <div class="alert alert-warning mt-2" role="alert">
-        Resolve the blocked operation{{ preview.operations|length|pluralize }} above before applying.
-    </div>
-    {% endif %}
-
-    {% if preview.can_apply %}
-    <button type="button" class="btn btn-danger mt-3"
-            hx-post="{% url 'recharacterize-apply' %}"
-            hx-target="#recharacterize-main"
-            hx-swap="outerHTML"
-            hx-confirm="Apply this plan to {{ preview.total_changes }} journal entry item{{ preview.total_changes|pluralize }}?">
-        Apply ({{ preview.total_changes }})
-    </button>
-    {% endif %}
 {% else %}
     <p class="muted">No changes proposed yet.</p>
 {% endif %}


### PR DESCRIPTION
## What

The recharacterize tool previously offered a **single Apply button** that committed every proposed operation atomically — and aborted the whole plan if any one operation was blocked. This replaces it with a **per-operation Apply button** so each operation can be applied individually.

## Changes

- **Service** (`recharacterize_services.py`): replaced `apply_plan(operations)` with `apply_operation(operations, op_index)`, which re-validates and commits a single operation against the live ledger. Dropped the now-unused `PlanPreview` aggregate fields (`has_blocks` / `total_changes` / `total_affected`) — their only consumers were the removed global button and blocked-ops banner.
- **View** (`recharacterize_views.py`): `RecharacterizeApplyView` applies the operation named by `?op=`, drops it from the session plan, and re-previews the remaining operations against the now-updated ledger. The confirmation is shown once, in the chat log.
- **Template** (`recharacterize-preview.html`): renders a per-operation Apply button (gated on `mutates && affected_count > 0`) instead of one plan-wide button. Blocked or view-only ops simply show no button without affecting siblings.

## Tests

Updated the service and view tests to the per-operation API, including coverage for applying one of several operations while leaving the rest, and out-of-range / view-only / blocked-sibling cases. All 44 recharacterize tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)