### PR TITLE
Apply recharacterize operations one at a time, with inline confirm

### DIFF
--- a/ledger/static/css/app.css
+++ b/ledger/static/css/app.css
@@ -298,6 +298,9 @@ h4, h5 { font-size: var(--fs-md); font-weight: 600; margin: 0 0 var(--space-2); 
 .btn-sm  { height: 22px; padding: 0 8px; font-size: var(--fs-sm); }
 .btn:disabled, .btn[disabled] { opacity: .6; cursor: default; }
 
+/* Inline confirm: Apply button swaps in place for Confirm/Cancel */
+.inline-confirm { display: inline-flex; align-items: center; gap: var(--space-2); }
+
 /* Segmented radio control (replaces Bootstrap btn-group-toggle; no JS needed) */
 .segmented { display: inline-flex; border: 1px solid var(--input-border); border-radius: var(--radius); overflow: hidden; }
 .segmented label {

--- a/ledger/templates/api/components/recharacterize-preview.html
+++ b/ledger/templates/api/components/recharacterize-preview.html
@@ -38,13 +38,25 @@
                 </p>
             {% endif %}
             {% if op.mutates and op.affected_count > 0 %}
-            <button type="button" class="btn btn-danger mt-2"
-                    hx-post="{% url 'recharacterize-apply' %}?op={{ op.index }}"
-                    hx-target="#recharacterize-main"
-                    hx-swap="outerHTML"
-                    hx-confirm="Apply this operation to {{ op.affected_count }} journal entry item{{ op.affected_count|pluralize }}?">
-                Apply ({{ op.affected_count }})
-            </button>
+            <div class="mt-2" x-data="{ confirming: false }">
+                <button type="button" class="btn btn-danger"
+                        x-show="!confirming"
+                        @click="confirming = true">
+                    Apply ({{ op.affected_count }})
+                </button>
+                <span class="inline-confirm" x-show="confirming" x-cloak>
+                    <button type="button" class="btn btn-danger"
+                            hx-post="{% url 'recharacterize-apply' %}?op={{ op.index }}"
+                            hx-target="#recharacterize-main"
+                            hx-swap="outerHTML">
+                        Confirm
+                    </button>
+                    <button type="button" class="btn btn-secondary"
+                            @click="confirming = false">
+                        Cancel
+                    </button>
+                </span>
+            </div>
             {% endif %}
         {% endif %}
     </div>


### PR DESCRIPTION
## Summary
- Apply recharacterize operations one at a time (per-operation Apply button, scoped by `?op=`)
- Replace htmx's native `hx-confirm` (unstyled, page-blocking `window.confirm()`) with an unobtrusive **inline confirm**: clicking **Apply** transforms the button in place into **Confirm** / **Cancel** via an Alpine `x-show` toggle — no overlay, no page dimming. **Confirm** issues the htmx request; **Cancel** reverts.

## Notes
- Inline confirm uses the codebase's established `x-show` + `x-cloak` Alpine convention; no new JS infra.
- One small `.inline-confirm` flex utility added to `app.css` (no inline styles).
- No backend change for the confirm UX — the POST target/payload is identical.

## Verification
- Open Recharacterize, run a prompt yielding a mutating operation; click **Apply** → inline **Confirm**/**Cancel** appears (no native dialog). **Cancel** reverts with no request; **Confirm** applies and re-renders.
- `uv run python manage.py test api.tests.views.test_recharacterize_views` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)