### PR TITLE
Add Prefills + Doc Searches settings section

### DIFF
--- a/api/forms.py
+++ b/api/forms.py
@@ -16,6 +16,7 @@ from api.models import (
     Account,
     Amortization,
     CSVProfile,
+    DocSearch,
     Entity,
     JournalEntry,
     JournalEntryItem,
@@ -665,6 +666,51 @@ class EntityForm(forms.ModelForm):
     class Meta:
         model = Entity
         fields = ["name", "is_closed"]
+
+
+class PrefillForm(forms.ModelForm):
+    """User-facing form for creating/editing prefills via the Settings page.
+
+    A prefill is a named template; Doc Searches (and Prefill Items) hang off it.
+    Mirrors ``EntityForm``.
+    """
+
+    class Meta:
+        model = Prefill
+        fields = ["name", "is_closed"]
+
+
+class DocSearchForm(forms.ModelForm):
+    """User-facing form for creating/editing a prefill's Doc Searches.
+
+    ``prefill`` is intentionally excluded — the view/service scopes each Doc
+    Search to its parent prefill. The either/or field rules (keyword vs
+    table row/column; account+type vs selection) are not re-implemented here:
+    ``ModelForm._post_clean`` calls ``DocSearch.clean()`` (api/models.py), so
+    those surface as ``non_field_errors`` automatically.
+    """
+
+    account = forms.ModelChoiceField(
+        queryset=Account.objects.filter(is_closed=False).order_by("name"),
+        required=False,
+    )
+    entity = forms.ModelChoiceField(
+        queryset=Entity.objects.all().order_by("name"),
+        required=False,
+    )
+
+    class Meta:
+        model = DocSearch
+        fields = [
+            "keyword",
+            "table_name",
+            "row",
+            "column",
+            "account",
+            "journal_entry_item_type",
+            "selection",
+            "entity",
+        ]
 
 
 class UtilityBillRuleForm(forms.ModelForm):

--- a/api/services/prefill_services.py
+++ b/api/services/prefill_services.py
@@ -1,0 +1,144 @@
+"""
+Service layer for Prefill and Doc Search config CRUD (Settings page).
+
+A Prefill is a reusable template. Its Doc Searches tell the paystub/document
+parser where to find each value on a document and which account/metadata field
+it maps to. This module exposes the list/create/update/delete operations the
+Settings UI needs, delegating writes to the shared ``crud`` helpers.
+
+Mirrors ``entity_services`` (single-model config CRUD) plus a nested child
+(Doc Search) scoped to its parent prefill, following ``loan_services``.
+"""
+
+from dataclasses import dataclass
+from typing import Any, Dict, List, Optional, Tuple
+
+from django.db.models import Count
+
+from api.models import Account, DocSearch, Entity, Prefill
+from api.services import crud
+
+
+@dataclass
+class PrefillResult:
+    """Result of a prefill create/update/delete operation."""
+    success: bool
+    prefill: Optional[Prefill] = None
+    error: Optional[str] = None
+
+
+@dataclass
+class DocSearchResult:
+    """Result of a doc search create/update/delete operation."""
+    success: bool
+    doc_search: Optional[DocSearch] = None
+    error: Optional[str] = None
+
+
+# --- Prefill CRUD -------------------------------------------------------------
+
+
+def get_prefills() -> List[Prefill]:
+    """Returns all prefills (open first, then alphabetical) annotated with
+    ``docsearch_count`` — the number of Doc Searches attached to each."""
+    return list(
+        Prefill.objects.annotate(
+            docsearch_count=Count("docsearch"),
+        ).order_by("is_closed", "name")
+    )
+
+
+PREFILL_FIELDS = ("name", "is_closed")
+
+
+def save_prefill(
+    cleaned_data: Dict[str, Any], instance: Optional[Prefill] = None
+) -> PrefillResult:
+    """Creates or updates a prefill from validated form data. ``instance`` is
+    the prefill being edited (None to create)."""
+    prefill, error = crud.save_model(
+        Prefill, PREFILL_FIELDS, cleaned_data, instance
+    )
+    return PrefillResult(success=error is None, prefill=prefill, error=error)
+
+
+def delete_prefill(prefill_id: int) -> PrefillResult:
+    """Deletes a prefill, gracefully blocking when it is still referenced.
+
+    Prefills are PROTECT-referenced by Doc Searches, S3 files, and transactions,
+    so rather than 500ing on a ProtectedError we return a friendly message the
+    UI can display inline and suggest closing instead.
+    """
+    prefill, error = crud.delete_model(
+        Prefill,
+        prefill_id,
+        not_found="Prefill not found.",
+        protected=lambda p: (
+            f"Can't delete '{p.name}' — it's still used by other records "
+            "(doc searches, uploaded documents, or transactions). "
+            "Close it instead to archive it."
+        ),
+    )
+    return PrefillResult(success=error is None, prefill=prefill, error=error)
+
+
+# --- Doc Search CRUD (scoped to a prefill) ------------------------------------
+
+
+def get_docsearches(prefill_id: int) -> List[DocSearch]:
+    """Returns the Doc Searches for a prefill, ordered by pk."""
+    return list(
+        DocSearch.objects.filter(prefill_id=prefill_id)
+        .select_related("account", "entity")
+        .order_by("pk")
+    )
+
+
+def get_docsearch_form_options() -> Tuple[List[Account], List[Entity]]:
+    """Returns the DB-backed dropdown options for the Doc Search form: open
+    accounts and all entities. Static choice lists (type, selection) live in the
+    helper, matching ``get_bill_rule_form_options``."""
+    accounts = list(Account.objects.filter(is_closed=False).order_by("name"))
+    entities = list(Entity.objects.all().order_by("name"))
+    return accounts, entities
+
+
+DOC_SEARCH_FIELDS = (
+    "keyword",
+    "table_name",
+    "row",
+    "column",
+    "account",
+    "journal_entry_item_type",
+    "selection",
+    "entity",
+)
+
+
+def save_docsearch(
+    prefill: Prefill,
+    cleaned_data: Dict[str, Any],
+    instance: Optional[DocSearch] = None,
+) -> DocSearchResult:
+    """Creates or updates a Doc Search under ``prefill``. New rows get the
+    parent FK before the fields are copied over."""
+    instance = instance or DocSearch(prefill=prefill)
+    doc_search, error = crud.save_model(
+        DocSearch, DOC_SEARCH_FIELDS, cleaned_data, instance
+    )
+    return DocSearchResult(
+        success=error is None, doc_search=doc_search, error=error
+    )
+
+
+def delete_docsearch(docsearch_id: int) -> DocSearchResult:
+    """Deletes a Doc Search by pk."""
+    doc_search, error = crud.delete_model(
+        DocSearch,
+        docsearch_id,
+        not_found="Doc search not found.",
+        protected="Can't delete this doc search — it's still referenced.",
+    )
+    return DocSearchResult(
+        success=error is None, doc_search=doc_search, error=error
+    )

--- a/api/tests/services/test_prefill_services.py
+++ b/api/tests/services/test_prefill_services.py
@@ -1,0 +1,242 @@
+"""Tests for prefill_services — the Settings CRUD over Prefills and Doc Searches."""
+
+from django.test import TestCase
+
+from api.forms import DocSearchForm
+from api.models import Account, DocSearch, JournalEntryItem, Prefill
+from api.services.prefill_services import (
+    DocSearchResult,
+    PrefillResult,
+    delete_docsearch,
+    delete_prefill,
+    get_docsearch_form_options,
+    get_docsearches,
+    get_prefills,
+    save_docsearch,
+    save_prefill,
+)
+from api.tests.testing_factories import (
+    AccountFactory,
+    EntityFactory,
+    PrefillFactory,
+)
+
+
+class GetPrefillsTest(TestCase):
+    """Tests for get_prefills() — the Settings list query with annotations."""
+
+    def test_orders_open_first_then_by_name(self):
+        PrefillFactory(name="Bravo", is_closed=False)
+        PrefillFactory(name="Alpha", is_closed=True)
+        PrefillFactory(name="Charlie", is_closed=False)
+
+        names = [p.name for p in get_prefills()]
+        self.assertEqual(names, ["Bravo", "Charlie", "Alpha"])
+
+    def test_docsearch_count_annotation(self):
+        prefill = PrefillFactory()
+        DocSearch.objects.create(prefill=prefill, keyword="Gross Pay")
+        DocSearch.objects.create(prefill=prefill, keyword="Net Pay")
+        PrefillFactory()  # unrelated prefill with no doc searches
+
+        by_id = {p.id: p for p in get_prefills()}
+        self.assertEqual(by_id[prefill.id].docsearch_count, 2)
+
+    def test_docsearch_count_zero_when_none(self):
+        prefill = PrefillFactory()
+        by_id = {p.id: p for p in get_prefills()}
+        self.assertEqual(by_id[prefill.id].docsearch_count, 0)
+
+
+class SavePrefillTest(TestCase):
+    """Tests for save_prefill() create/update."""
+
+    def test_creates_prefill(self):
+        result = save_prefill({"name": "ADP Paystub", "is_closed": False})
+
+        self.assertIsInstance(result, PrefillResult)
+        self.assertTrue(result.success)
+        self.assertEqual(result.prefill.name, "ADP Paystub")
+        self.assertEqual(Prefill.objects.count(), 1)
+
+    def test_updates_prefill(self):
+        prefill = PrefillFactory(name="Old", is_closed=False)
+
+        result = save_prefill(
+            {"name": "New", "is_closed": True}, instance=prefill
+        )
+
+        self.assertTrue(result.success)
+        prefill.refresh_from_db()
+        self.assertEqual(prefill.name, "New")
+        self.assertTrue(prefill.is_closed)
+
+
+class DeletePrefillTest(TestCase):
+    """Tests for delete_prefill() including the PROTECT block."""
+
+    def test_deletes_unreferenced_prefill(self):
+        prefill = PrefillFactory()
+
+        result = delete_prefill(prefill.id)
+
+        self.assertTrue(result.success)
+        self.assertEqual(Prefill.objects.count(), 0)
+
+    def test_not_found_returns_error(self):
+        result = delete_prefill(999)
+
+        self.assertFalse(result.success)
+        self.assertEqual(result.error, "Prefill not found.")
+
+    def test_blocks_delete_when_referenced_by_docsearch(self):
+        prefill = PrefillFactory(name="Con Ed")
+        DocSearch.objects.create(prefill=prefill, keyword="Amount Due")
+
+        result = delete_prefill(prefill.id)
+
+        self.assertFalse(result.success)
+        self.assertIn("Con Ed", result.error)
+        self.assertEqual(Prefill.objects.count(), 1)
+
+
+class DocSearchServiceTest(TestCase):
+    """Tests for the Doc Search CRUD scoped to a prefill."""
+
+    def setUp(self):
+        self.prefill = PrefillFactory()
+        self.account = AccountFactory(is_closed=False)
+
+    def test_get_docsearches_scoped_to_prefill(self):
+        DocSearch.objects.create(prefill=self.prefill, keyword="A")
+        other = PrefillFactory()
+        DocSearch.objects.create(prefill=other, keyword="B")
+
+        result = get_docsearches(self.prefill.id)
+
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result[0].keyword, "A")
+
+    def test_save_docsearch_sets_parent_prefill_on_create(self):
+        cleaned = {
+            "keyword": "Gross Pay",
+            "table_name": None,
+            "row": None,
+            "column": None,
+            "account": self.account,
+            "journal_entry_item_type": (
+                JournalEntryItem.JournalEntryType.DEBIT
+            ),
+            "selection": None,
+            "entity": None,
+        }
+
+        result = save_docsearch(self.prefill, cleaned)
+
+        self.assertIsInstance(result, DocSearchResult)
+        self.assertTrue(result.success)
+        self.assertEqual(result.doc_search.prefill_id, self.prefill.id)
+        self.assertEqual(result.doc_search.account_id, self.account.id)
+
+    def test_save_docsearch_updates_existing(self):
+        ds = DocSearch.objects.create(prefill=self.prefill, keyword="Old")
+        cleaned = {
+            "keyword": "New",
+            "table_name": None,
+            "row": None,
+            "column": None,
+            "account": self.account,
+            "journal_entry_item_type": (
+                JournalEntryItem.JournalEntryType.CREDIT
+            ),
+            "selection": None,
+            "entity": None,
+        }
+
+        result = save_docsearch(self.prefill, cleaned, instance=ds)
+
+        self.assertTrue(result.success)
+        ds.refresh_from_db()
+        self.assertEqual(ds.keyword, "New")
+        self.assertEqual(DocSearch.objects.count(), 1)
+
+    def test_delete_docsearch(self):
+        ds = DocSearch.objects.create(prefill=self.prefill, keyword="A")
+
+        result = delete_docsearch(ds.id)
+
+        self.assertTrue(result.success)
+        self.assertEqual(DocSearch.objects.count(), 0)
+
+    def test_get_docsearch_form_options_excludes_closed_accounts(self):
+        AccountFactory(is_closed=True)
+        accounts, entities = get_docsearch_form_options()
+
+        self.assertIn(self.account, accounts)
+        self.assertTrue(all(not a.is_closed for a in accounts))
+
+
+class DocSearchFormValidationTest(TestCase):
+    """The form reuses DocSearch.clean() for the either/or field rules."""
+
+    def setUp(self):
+        self.account = AccountFactory(is_closed=False)
+
+    def _data(self, **overrides):
+        data = {
+            "keyword": "",
+            "table_name": "",
+            "row": "",
+            "column": "",
+            "account": "",
+            "journal_entry_item_type": "",
+            "selection": "",
+            "entity": "",
+        }
+        data.update(overrides)
+        return data
+
+    def test_valid_keyword_search_with_account(self):
+        form = DocSearchForm(
+            self._data(
+                keyword="Gross Pay",
+                account=str(self.account.id),
+                journal_entry_item_type=(
+                    JournalEntryItem.JournalEntryType.DEBIT
+                ),
+            )
+        )
+        self.assertTrue(form.is_valid(), form.errors)
+
+    def test_valid_table_search_with_selection(self):
+        form = DocSearchForm(
+            self._data(
+                table_name="Summary", row="Total", column="Amount",
+                selection="Company",
+            )
+        )
+        self.assertTrue(form.is_valid(), form.errors)
+
+    def test_invalid_without_keyword_or_row_column(self):
+        form = DocSearchForm(
+            self._data(
+                account=str(self.account.id),
+                journal_entry_item_type=(
+                    JournalEntryItem.JournalEntryType.DEBIT
+                ),
+            )
+        )
+        self.assertFalse(form.is_valid())
+
+    def test_invalid_with_both_account_and_selection(self):
+        form = DocSearchForm(
+            self._data(
+                keyword="Gross Pay",
+                account=str(self.account.id),
+                journal_entry_item_type=(
+                    JournalEntryItem.JournalEntryType.DEBIT
+                ),
+                selection="Company",
+            )
+        )
+        self.assertFalse(form.is_valid())

--- a/api/tests/views/test_form_helpers.py
+++ b/api/tests/views/test_form_helpers.py
@@ -1,0 +1,117 @@
+"""Unit tests for resolve_form_values — the shared Settings-form value resolver."""
+
+import datetime
+from types import SimpleNamespace
+
+from django.test import SimpleTestCase
+
+from api.views.form_helpers import resolve_form_values
+
+
+class _BoundForm:
+    """Minimal stand-in for a bound Django form (only what the helper reads)."""
+
+    is_bound = True
+
+    def __init__(self, data):
+        self.data = data
+
+
+class ResolveFormValuesBoundTest(SimpleTestCase):
+    """Bound form present: echo submitted data (re-display an invalid POST)."""
+
+    def test_text_uses_submitted_value_then_default(self):
+        form = _BoundForm({"name": "typed"})
+        values = resolve_form_values(
+            None, form, text=("name", "type"), defaults={"type": "asset"}
+        )
+        self.assertEqual(values["name"], "typed")
+        # Missing key falls back to the provided default.
+        self.assertEqual(values["type"], "asset")
+
+    def test_fk_uses_submitted_value_and_ignores_defaults(self):
+        form = _BoundForm({"account": "5"})
+        values = resolve_form_values(
+            None, form, fks=("account", "entity"), defaults={"account": "9"}
+        )
+        self.assertEqual(values["account"], "5")
+        # An FK always defaults to "" regardless of `defaults`.
+        self.assertEqual(values["entity"], "")
+
+    def test_boolean_reflects_presence_in_post(self):
+        form = _BoundForm({"is_closed": "on"})
+        values = resolve_form_values(
+            None, form, booleans=("is_closed", "is_depreciation")
+        )
+        self.assertTrue(values["is_closed"])
+        self.assertFalse(values["is_depreciation"])
+
+    def test_date_uses_submitted_string(self):
+        form = _BoundForm({"start_date": "2026-01-02"})
+        values = resolve_form_values(None, form, dates=("start_date",))
+        self.assertEqual(values["start_date"], "2026-01-02")
+
+
+class ResolveFormValuesInstanceTest(SimpleTestCase):
+    """No bound form, instance present: show the stored values."""
+
+    def _instance(self, **kwargs):
+        return SimpleNamespace(**kwargs)
+
+    def test_text_none_renders_empty(self):
+        inst = self._instance(keyword=None, name="Gross")
+        values = resolve_form_values(inst, None, text=("keyword", "name"))
+        self.assertEqual(values["keyword"], "")
+        self.assertEqual(values["name"], "Gross")
+
+    def test_fk_renders_string_id_or_empty(self):
+        inst = self._instance(account_id=7, entity_id=None)
+        values = resolve_form_values(inst, None, fks=("account", "entity"))
+        self.assertEqual(values["account"], "7")
+        self.assertEqual(values["entity"], "")
+
+    def test_date_renders_isoformat_or_empty(self):
+        inst = self._instance(
+            start_date=datetime.date(2026, 7, 1), end_date=None
+        )
+        values = resolve_form_values(inst, None, dates=("start_date", "end_date"))
+        self.assertEqual(values["start_date"], "2026-07-01")
+        self.assertEqual(values["end_date"], "")
+
+    def test_boolean_reads_attribute(self):
+        inst = self._instance(is_closed=True)
+        values = resolve_form_values(inst, None, booleans=("is_closed",))
+        self.assertTrue(values["is_closed"])
+
+    def test_unbound_form_is_treated_as_absent(self):
+        # An unbound form (create page) should not shadow the instance branch.
+        class Unbound:
+            is_bound = False
+
+        inst = self._instance(name="Edited")
+        values = resolve_form_values(inst, Unbound(), text=("name",))
+        self.assertEqual(values["name"], "Edited")
+
+
+class ResolveFormValuesBlankTest(SimpleTestCase):
+    """Neither form nor instance: blank-create defaults."""
+
+    def test_defaults_and_empties(self):
+        values = resolve_form_values(
+            None,
+            None,
+            text=("name", "type", "date_window_days"),
+            fks=("entity",),
+            booleans=("is_closed", "wants_email"),
+            defaults={
+                "type": "asset",
+                "date_window_days": "7",
+                "wants_email": True,
+            },
+        )
+        self.assertEqual(values["name"], "")
+        self.assertEqual(values["type"], "asset")
+        self.assertEqual(values["date_window_days"], "7")
+        self.assertEqual(values["entity"], "")
+        self.assertFalse(values["is_closed"])
+        self.assertTrue(values["wants_email"])

--- a/api/tests/views/test_settings_views.py
+++ b/api/tests/views/test_settings_views.py
@@ -24,7 +24,7 @@ class SettingsViewTest(HTMXViewTestCase):
     def test_page_contains_flat_menu_sections(self):
         response = self.client.get(reverse("settings"))
         # The flat menu is client-rendered from this section list.
-        self.assertContains(response, "'Entities', 'Paystubs', 'Auto Tags', 'CSV Profiles'")
+        self.assertContains(response, "'Entities', 'Prefills', 'Paystubs', 'Auto Tags', 'CSV Profiles'")
 
     def test_new_account_form_view(self):
         response = self.client.get(reverse("settings-account-new-form"))

--- a/api/views/bill_settings_helpers.py
+++ b/api/views/bill_settings_helpers.py
@@ -6,13 +6,14 @@ These pure functions take data and return HTML strings via render_to_string.
 They contain no database writes and no business logic. Mirrors settings_helpers.
 """
 
-from typing import Any, Dict, List, Optional
+from typing import List, Optional
 
 from django.db.models import QuerySet
 from django.template.loader import render_to_string
 
 from api.forms import UtilityBillRuleForm
 from api.models import Transaction, UtilityBill, UtilityBillRule
+from api.views.form_helpers import resolve_form_values
 
 
 def render_bill_rules_content(
@@ -30,50 +31,6 @@ def render_bill_rules_content(
             "rule_form": rule_form_html,
         },
     )
-
-
-def _rule_form_values(
-    rule: Optional[UtilityBillRule], form: Optional[UtilityBillRuleForm]
-) -> Dict[str, Any]:
-    """Resolves the field values to display: submitted data on a bound (invalid)
-    form, else the rule being edited, else blank-create defaults."""
-    if form is not None and form.is_bound:
-        data = form.data
-        return {
-            "from_address": data.get("from_address", ""),
-            "subject": data.get("subject", ""),
-            "account_number": data.get("account_number", ""),
-            "address_hint": data.get("address_hint", ""),
-            "transaction_description_match": data.get(
-                "transaction_description_match", ""
-            ),
-            "account": data.get("account", ""),
-            "entity": data.get("entity", ""),
-            "transaction_type": data.get(
-                "transaction_type", Transaction.TransactionType.PURCHASE
-            ),
-        }
-    if rule is not None:
-        return {
-            "from_address": rule.from_address,
-            "subject": rule.subject,
-            "account_number": rule.account_number,
-            "address_hint": rule.address_hint,
-            "transaction_description_match": rule.transaction_description_match,
-            "account": str(rule.account_id or ""),
-            "entity": str(rule.entity_id or ""),
-            "transaction_type": rule.transaction_type,
-        }
-    return {
-        "from_address": "",
-        "subject": "",
-        "account_number": "",
-        "address_hint": "",
-        "transaction_description_match": "",
-        "account": "",
-        "entity": "",
-        "transaction_type": Transaction.TransactionType.PURCHASE,
-    }
 
 
 def render_bill_rule_form(
@@ -99,7 +56,22 @@ def render_bill_rule_form(
         "change": change,
         "error": error,
         "form": form,
-        "values": _rule_form_values(rule, form),
+        "values": resolve_form_values(
+            rule,
+            form,
+            text=(
+                "from_address",
+                "subject",
+                "account_number",
+                "address_hint",
+                "transaction_description_match",
+                "transaction_type",
+            ),
+            fks=("account", "entity"),
+            defaults={
+                "transaction_type": Transaction.TransactionType.PURCHASE
+            },
+        ),
         "accounts": accounts,
         "entities": entities,
         "type_choices": Transaction.TransactionType.choices,

--- a/api/views/entity_settings_helpers.py
+++ b/api/views/entity_settings_helpers.py
@@ -7,12 +7,13 @@ They contain no database writes and no business logic. Mirrors
 bill_settings_helpers.
 """
 
-from typing import Any, Dict, List, Optional
+from typing import List, Optional
 
 from django.template.loader import render_to_string
 
 from api.forms import EntityForm
 from api.models import Entity
+from api.views.form_helpers import resolve_form_values
 
 
 def render_entities_content(
@@ -30,28 +31,6 @@ def render_entities_content(
             "entity_form": entity_form_html,
         },
     )
-
-
-def _entity_form_values(
-    entity: Optional[Entity], form: Optional[EntityForm]
-) -> Dict[str, Any]:
-    """Resolves the field values to display: submitted data on a bound (invalid)
-    form, else the entity being edited, else blank-create defaults."""
-    if form is not None and form.is_bound:
-        data = form.data
-        return {
-            "name": data.get("name", ""),
-            "is_closed": "is_closed" in data,
-        }
-    if entity is not None:
-        return {
-            "name": entity.name,
-            "is_closed": entity.is_closed,
-        }
-    return {
-        "name": "",
-        "is_closed": False,
-    }
 
 
 def render_entity_form(
@@ -73,6 +52,8 @@ def render_entity_form(
         "change": change,
         "error": error,
         "form": form,
-        "values": _entity_form_values(entity, form),
+        "values": resolve_form_values(
+            entity, form, text=("name",), booleans=("is_closed",)
+        ),
     }
     return render_to_string("api/entry_forms/entity-form.html", context)

--- a/api/views/form_helpers.py
+++ b/api/views/form_helpers.py
@@ -1,0 +1,83 @@
+"""
+Shared value-resolution for hand-rendered Settings forms.
+
+The Settings sections (Accounts, Bill Rules, Loans, Entities, Prefills, Doc
+Searches) render their add/edit forms as raw ``<input>``/``<select>`` markup so
+they can carry the design-system CSS classes and Alpine bindings — rather than
+relying on Django's ``{{ form.field }}`` widget rendering. That means each
+template needs a plain ``values`` dict giving the string to display in every
+field.
+
+The value for a field comes from one of three sources, in priority order:
+
+1. a bound (re-submitted, usually invalid) ``form`` — echo what the user typed,
+   so a validation error doesn't wipe their input;
+2. an ``instance`` being edited — its stored values;
+3. neither — blank-create defaults.
+
+Each section used to hand-roll this three-branch resolution per field, listing
+every field name three times. :func:`resolve_form_values` does it once, driven
+by a per-kind field list, so the field names live in a single place.
+"""
+
+from typing import Any, Dict, Optional, Sequence
+
+
+def resolve_form_values(
+    instance: Optional[Any],
+    form: Optional[Any],
+    *,
+    text: Sequence[str] = (),
+    booleans: Sequence[str] = (),
+    fks: Sequence[str] = (),
+    dates: Sequence[str] = (),
+    defaults: Optional[Dict[str, Any]] = None,
+) -> Dict[str, Any]:
+    """Resolve the display value for each field of a hand-rendered form.
+
+    Field kinds differ in how each source is read:
+
+    - ``text``: plain scalar (CharField, choice, number). ``None`` renders "".
+    - ``booleans``: checkbox; presence of the name in POST means checked.
+    - ``fks``: foreign key, rendered as its string id for ``<select>`` compare.
+    - ``dates``: date, rendered ISO (``YYYY-MM-DD``) for ``<input type="date">``.
+
+    ``defaults`` supplies non-empty defaults for specific fields; they apply to
+    the blank-create branch and as the fallback for a missing key on the bound
+    branch (text/date/boolean only — an FK always defaults to "").
+    """
+    defaults = defaults or {}
+
+    if form is not None and form.is_bound:
+        data = form.data
+        values: Dict[str, Any] = {}
+        for name in (*text, *dates):
+            values[name] = data.get(name, defaults.get(name, ""))
+        for name in fks:
+            values[name] = data.get(name, "")
+        for name in booleans:
+            values[name] = name in data
+        return values
+
+    if instance is not None:
+        values = {}
+        for name in text:
+            value = getattr(instance, name)
+            values[name] = "" if value is None else value
+        for name in dates:
+            value = getattr(instance, name)
+            values[name] = value.isoformat() if value else ""
+        for name in fks:
+            values[name] = str(getattr(instance, f"{name}_id") or "")
+        for name in booleans:
+            values[name] = getattr(instance, name)
+        return values
+
+    values = {}
+    for name in (*text, *dates):
+        values[name] = defaults.get(name, "")
+    for name in fks:
+        values[name] = ""
+    for name in booleans:
+        values[name] = defaults.get(name, False)
+    return values

--- a/api/views/loan_helpers.py
+++ b/api/views/loan_helpers.py
@@ -7,13 +7,14 @@ They contain no database writes and no business logic. Mirrors
 bill_settings_helpers.
 """
 
-from typing import Any, Dict, List, Optional
+from typing import List, Optional
 
 from django.db.models import QuerySet
 from django.template.loader import render_to_string
 
 from api.forms import LoanForm
 from api.models import Loan, LoanPayment
+from api.views.form_helpers import resolve_form_values
 
 
 def render_loans_content(
@@ -31,58 +32,6 @@ def render_loans_content(
             "loan_form": loan_form_html,
         },
     )
-
-
-def _loan_form_values(
-    loan: Optional[Loan], form: Optional[LoanForm]
-) -> Dict[str, Any]:
-    """Resolves the field values to display: submitted data on a bound (invalid)
-    form, else the loan being edited, else blank-create defaults."""
-    if form is not None and form.is_bound:
-        data = form.data
-        return {
-            "name": data.get("name", ""),
-            "original_amount": data.get("original_amount", ""),
-            "annual_interest_rate": data.get("annual_interest_rate", ""),
-            "term_months": data.get("term_months", ""),
-            "start_date": data.get("start_date", ""),
-            "payment_amount": data.get("payment_amount", ""),
-            "principal_account": data.get("principal_account", ""),
-            "interest_account": data.get("interest_account", ""),
-            "payment_account": data.get("payment_account", ""),
-            "description_match": data.get("description_match", ""),
-            "date_window_days": data.get("date_window_days", "7"),
-            "entity": data.get("entity", ""),
-        }
-    if loan is not None:
-        return {
-            "name": loan.name,
-            "original_amount": loan.original_amount,
-            "annual_interest_rate": loan.annual_interest_rate,
-            "term_months": loan.term_months,
-            "start_date": loan.start_date.isoformat() if loan.start_date else "",
-            "payment_amount": loan.payment_amount if loan.payment_amount else "",
-            "principal_account": str(loan.principal_account_id or ""),
-            "interest_account": str(loan.interest_account_id or ""),
-            "payment_account": str(loan.payment_account_id or ""),
-            "description_match": loan.description_match,
-            "date_window_days": loan.date_window_days,
-            "entity": str(loan.entity_id or ""),
-        }
-    return {
-        "name": "",
-        "original_amount": "",
-        "annual_interest_rate": "",
-        "term_months": "",
-        "start_date": "",
-        "payment_amount": "",
-        "principal_account": "",
-        "interest_account": "",
-        "payment_account": "",
-        "description_match": "",
-        "date_window_days": "7",
-        "entity": "",
-    }
 
 
 def render_loan_form(
@@ -112,7 +61,27 @@ def render_loan_form(
         "change": change,
         "error": error,
         "form": form,
-        "values": _loan_form_values(loan, form),
+        "values": resolve_form_values(
+            loan,
+            form,
+            text=(
+                "name",
+                "original_amount",
+                "annual_interest_rate",
+                "term_months",
+                "payment_amount",
+                "description_match",
+                "date_window_days",
+            ),
+            dates=("start_date",),
+            fks=(
+                "principal_account",
+                "interest_account",
+                "payment_account",
+                "entity",
+            ),
+            defaults={"date_window_days": "7"},
+        ),
         "liability_accounts": liability_accounts,
         "expense_accounts": expense_accounts,
         "payment_accounts": payment_accounts,

--- a/api/views/prefill_settings_helpers.py
+++ b/api/views/prefill_settings_helpers.py
@@ -1,0 +1,115 @@
+"""
+Helper functions for rendering the Prefills Settings section.
+
+Pure functions that take data and return HTML strings via ``render_to_string``.
+No database writes and no business logic. Mirrors ``entity_settings_helpers``
+plus a nested Doc Search list/form scoped to a prefill.
+"""
+
+from typing import List, Optional
+
+from django.template.loader import render_to_string
+
+from api.forms import DocSearchForm, PrefillForm
+from api.models import Account, DocSearch, Entity, JournalEntryItem, Prefill
+from api.views.form_helpers import resolve_form_values
+
+
+# --- Prefills (top-level) -----------------------------------------------------
+
+
+def render_prefills_content(
+    prefills: List[Prefill],
+    prefill_form_html: str,
+    selected_id: Optional[int] = None,
+) -> str:
+    """Combines the header + table + form into the swappable Prefills fragment."""
+    return render_to_string(
+        "api/content/prefills-content.html",
+        {
+            "prefills": prefills,
+            "total": len(prefills),
+            "selected_id": selected_id,
+            "prefill_form": prefill_form_html,
+        },
+    )
+
+
+def render_prefill_form(
+    prefill: Optional[Prefill] = None,
+    change: Optional[str] = None,
+    error: Optional[str] = None,
+    form: Optional[PrefillForm] = None,
+) -> str:
+    """Renders the prefill add/edit form HTML. When editing an existing prefill,
+    the template lazy-loads that prefill's Doc Searches panel."""
+    context = {
+        "prefill": prefill,
+        "change": change,
+        "error": error,
+        "form": form,
+        "values": resolve_form_values(
+            prefill, form, text=("name",), booleans=("is_closed",)
+        ),
+    }
+    return render_to_string("api/entry_forms/prefill-form.html", context)
+
+
+# --- Doc Searches (nested under a prefill) ------------------------------------
+
+
+def render_docsearches_content(
+    prefill: Prefill,
+    docsearches: List[DocSearch],
+    docsearch_form_html: str,
+    selected_id: Optional[int] = None,
+) -> str:
+    """Combines the header + table + form into the swappable Doc Searches
+    fragment for a single prefill."""
+    return render_to_string(
+        "api/content/prefill-docsearches-content.html",
+        {
+            "prefill": prefill,
+            "docsearches": docsearches,
+            "total": len(docsearches),
+            "selected_id": selected_id,
+            "docsearch_form": docsearch_form_html,
+        },
+    )
+
+
+def render_docsearch_form(
+    prefill: Prefill,
+    accounts: List[Account],
+    entities: List[Entity],
+    doc_search: Optional[DocSearch] = None,
+    change: Optional[str] = None,
+    error: Optional[str] = None,
+    form: Optional[DocSearchForm] = None,
+) -> str:
+    """Renders the Doc Search add/edit form HTML for a prefill."""
+    context = {
+        "prefill": prefill,
+        "accounts": accounts,
+        "entities": entities,
+        "type_choices": JournalEntryItem.JournalEntryType.choices,
+        "selection_choices": DocSearch.STRING_CHOICES,
+        "doc_search": doc_search,
+        "change": change,
+        "error": error,
+        "form": form,
+        "values": resolve_form_values(
+            doc_search,
+            form,
+            text=(
+                "keyword",
+                "table_name",
+                "row",
+                "column",
+                "journal_entry_item_type",
+                "selection",
+            ),
+            fks=("account", "entity"),
+        ),
+    }
+    return render_to_string("api/entry_forms/docsearch-form.html", context)

--- a/api/views/prefill_settings_views.py
+++ b/api/views/prefill_settings_views.py
@@ -1,0 +1,257 @@
+"""
+Views for the Prefills Settings section.
+
+Loaded as HTML fragments into the Settings shell:
+- Prefills: config CRUD over Prefill (mirrors EntitySettingsView).
+- Doc Searches: config CRUD over a prefill's DocSearch rows (nested, scoped by
+  ``prefill_id`` — follows the LoanScheduleView nested precedent).
+
+Views parse requests, call services for business logic, and call helpers for
+rendering. No database writes and no HTML building here.
+"""
+
+from typing import Optional
+
+from django.contrib.auth.mixins import LoginRequiredMixin
+from django.http import HttpResponse
+from django.shortcuts import get_object_or_404
+from django.views import View
+
+from api.forms import DocSearchForm, PrefillForm
+from api.models import DocSearch, Prefill
+from api.services import prefill_services
+from api.views import prefill_settings_helpers
+
+
+class PrefillSettingsView(LoginRequiredMixin, View):
+    login_url = "/login/"
+    redirect_field_name = "next"
+
+    def _render_content(
+        self,
+        prefill: Optional[Prefill] = None,
+        change: Optional[str] = None,
+        error: Optional[str] = None,
+        form: Optional[PrefillForm] = None,
+        selected_id: Optional[int] = None,
+    ) -> str:
+        """Builds the swappable Prefills fragment (header + table + form)."""
+        prefill_form_html = prefill_settings_helpers.render_prefill_form(
+            prefill=prefill,
+            change=change,
+            error=error,
+            form=form,
+        )
+        prefills = prefill_services.get_prefills()
+        return prefill_settings_helpers.render_prefills_content(
+            prefills=prefills,
+            prefill_form_html=prefill_form_html,
+            selected_id=selected_id,
+        )
+
+    def get(self, request):
+        return HttpResponse(self._render_content())
+
+    def post(self, request, prefill_id=None):
+        action = request.POST.get("action")
+
+        if action == "clear":
+            return HttpResponse(self._render_content())
+
+        if action == "delete":
+            result = prefill_services.delete_prefill(prefill_id)
+            if result.success:
+                return HttpResponse(self._render_content(change="delete"))
+            return HttpResponse(
+                self._render_content(
+                    prefill=result.prefill,
+                    error=result.error,
+                    selected_id=result.prefill.id if result.prefill else None,
+                )
+            )
+
+        if prefill_id:
+            prefill = get_object_or_404(Prefill, pk=prefill_id)
+            form = PrefillForm(request.POST, instance=prefill)
+            change = "update"
+        else:
+            prefill = None
+            form = PrefillForm(request.POST)
+            change = "create"
+
+        if not form.is_valid():
+            return HttpResponse(
+                self._render_content(
+                    prefill=prefill,
+                    form=form,
+                    selected_id=prefill.id if prefill else None,
+                )
+            )
+
+        result = prefill_services.save_prefill(form.cleaned_data, instance=prefill)
+        if not result.success:
+            return HttpResponse(
+                self._render_content(
+                    prefill=prefill,
+                    form=form,
+                    error=result.error,
+                    selected_id=prefill.id if prefill else None,
+                )
+            )
+
+        return HttpResponse(
+            self._render_content(
+                prefill=result.prefill,
+                change=change,
+                selected_id=result.prefill.id,
+            )
+        )
+
+
+class PrefillFormView(LoginRequiredMixin, View):
+    """Loads a prefill (or a blank create form) into the edit form.
+
+    Used on table row clicks (existing prefill) and the New Prefill button (no
+    prefill_id -> blank form).
+    """
+
+    login_url = "/login/"
+    redirect_field_name = "next"
+
+    def get(self, request, prefill_id=None):
+        prefill = get_object_or_404(Prefill, pk=prefill_id) if prefill_id else None
+        form_html = prefill_settings_helpers.render_prefill_form(prefill=prefill)
+        return HttpResponse(form_html)
+
+
+class DocSearchView(LoginRequiredMixin, View):
+    """Renders a prefill's Doc Searches (GET) and applies create/edit/delete of
+    a single Doc Search (POST), scoped to the parent prefill."""
+
+    login_url = "/login/"
+    redirect_field_name = "next"
+
+    def _render_content(
+        self,
+        prefill: Prefill,
+        doc_search: Optional[DocSearch] = None,
+        change: Optional[str] = None,
+        error: Optional[str] = None,
+        form: Optional[DocSearchForm] = None,
+        selected_id: Optional[int] = None,
+    ) -> str:
+        """Builds the swappable Doc Searches fragment for a prefill."""
+        accounts, entities = prefill_services.get_docsearch_form_options()
+        docsearch_form_html = prefill_settings_helpers.render_docsearch_form(
+            prefill=prefill,
+            accounts=accounts,
+            entities=entities,
+            doc_search=doc_search,
+            change=change,
+            error=error,
+            form=form,
+        )
+        docsearches = prefill_services.get_docsearches(prefill.id)
+        return prefill_settings_helpers.render_docsearches_content(
+            prefill=prefill,
+            docsearches=docsearches,
+            docsearch_form_html=docsearch_form_html,
+            selected_id=selected_id,
+        )
+
+    def get(self, request, prefill_id):
+        prefill = get_object_or_404(Prefill, pk=prefill_id)
+        return HttpResponse(self._render_content(prefill))
+
+    def post(self, request, prefill_id, docsearch_id=None):
+        prefill = get_object_or_404(Prefill, pk=prefill_id)
+        action = request.POST.get("action")
+
+        if action == "clear":
+            return HttpResponse(self._render_content(prefill))
+
+        if action == "delete":
+            result = prefill_services.delete_docsearch(docsearch_id)
+            if result.success:
+                return HttpResponse(self._render_content(prefill, change="delete"))
+            return HttpResponse(
+                self._render_content(
+                    prefill,
+                    doc_search=result.doc_search,
+                    error=result.error,
+                    selected_id=(
+                        result.doc_search.id if result.doc_search else None
+                    ),
+                )
+            )
+
+        if docsearch_id:
+            doc_search = get_object_or_404(
+                DocSearch, pk=docsearch_id, prefill=prefill
+            )
+            form = DocSearchForm(request.POST, instance=doc_search)
+            change = "update"
+        else:
+            doc_search = None
+            form = DocSearchForm(request.POST)
+            change = "create"
+
+        if not form.is_valid():
+            return HttpResponse(
+                self._render_content(
+                    prefill,
+                    doc_search=doc_search,
+                    form=form,
+                    selected_id=doc_search.id if doc_search else None,
+                )
+            )
+
+        result = prefill_services.save_docsearch(
+            prefill, form.cleaned_data, instance=doc_search
+        )
+        if not result.success:
+            return HttpResponse(
+                self._render_content(
+                    prefill,
+                    doc_search=doc_search,
+                    form=form,
+                    error=result.error,
+                    selected_id=doc_search.id if doc_search else None,
+                )
+            )
+
+        return HttpResponse(
+            self._render_content(
+                prefill,
+                doc_search=result.doc_search,
+                change=change,
+                selected_id=result.doc_search.id,
+            )
+        )
+
+
+class DocSearchFormView(LoginRequiredMixin, View):
+    """Loads a Doc Search (or a blank create form) into the edit form.
+
+    Used on row clicks (existing Doc Search) and the New Doc Search button (no
+    docsearch_id -> blank form).
+    """
+
+    login_url = "/login/"
+    redirect_field_name = "next"
+
+    def get(self, request, prefill_id, docsearch_id=None):
+        prefill = get_object_or_404(Prefill, pk=prefill_id)
+        doc_search = (
+            get_object_or_404(DocSearch, pk=docsearch_id, prefill=prefill)
+            if docsearch_id
+            else None
+        )
+        accounts, entities = prefill_services.get_docsearch_form_options()
+        form_html = prefill_settings_helpers.render_docsearch_form(
+            prefill=prefill,
+            accounts=accounts,
+            entities=entities,
+            doc_search=doc_search,
+        )
+        return HttpResponse(form_html)

--- a/api/views/settings_helpers.py
+++ b/api/views/settings_helpers.py
@@ -5,13 +5,14 @@ These pure functions take data and return HTML strings via render_to_string.
 They contain no database writes and no business logic.
 """
 
-from typing import Any, Dict, List, Optional
+from typing import Dict, List, Optional
 
 from django.db.models import QuerySet
 from django.template.loader import render_to_string
 
 from api.forms import AccountForm
 from api.models import Account
+from api.views.form_helpers import resolve_form_values
 
 
 def build_subtype_map() -> Dict[str, List[Dict[str, str]]]:
@@ -46,43 +47,6 @@ def render_settings_content(
     )
 
 
-def _form_values(
-    account: Optional[Account], form: Optional[AccountForm]
-) -> Dict[str, Any]:
-    """Resolves the current field values to display: submitted data on a bound
-    (invalid) form, else the account being edited, else blank-create defaults."""
-    if form is not None and form.is_bound:
-        data = form.data
-        return {
-            "name": data.get("name", ""),
-            "type": data.get("type", "asset"),
-            "sub_type": data.get("sub_type", ""),
-            "entity": data.get("entity", ""),
-            "csv_profile": data.get("csv_profile", ""),
-            "is_closed": "is_closed" in data,
-            "is_depreciation": "is_depreciation" in data,
-        }
-    if account is not None:
-        return {
-            "name": account.name,
-            "type": account.type,
-            "sub_type": account.sub_type,
-            "entity": str(account.entity_id or ""),
-            "csv_profile": str(account.csv_profile_id or ""),
-            "is_closed": account.is_closed,
-            "is_depreciation": account.is_depreciation,
-        }
-    return {
-        "name": "",
-        "type": Account.Type.ASSET,
-        "sub_type": "",
-        "entity": "",
-        "csv_profile": "",
-        "is_closed": False,
-        "is_depreciation": False,
-    }
-
-
 def render_account_form(
     entities: QuerySet,
     csv_profiles: QuerySet,
@@ -106,7 +70,14 @@ def render_account_form(
         "change": change,
         "error": error,
         "form": form,
-        "values": _form_values(account, form),
+        "values": resolve_form_values(
+            account,
+            form,
+            text=("name", "type", "sub_type"),
+            fks=("entity", "csv_profile"),
+            booleans=("is_closed", "is_depreciation"),
+            defaults={"type": Account.Type.ASSET},
+        ),
         "type_choices": Account.Type.choices,
         "subtype_map": build_subtype_map(),
         "entities": entities,

--- a/ledger/templates/api/content/prefill-docsearches-content.html
+++ b/ledger/templates/api/content/prefill-docsearches-content.html
@@ -1,0 +1,73 @@
+<div x-data="searchList({{ total }}, 'doc searches', {{ selected_id|default:'null' }})">
+
+  <div class="card-head">
+    <div class="card-head-left">
+      <h2 class="card-title">Doc Searches</h2>
+      <span class="card-count" x-text="countLabel()"></span>
+    </div>
+    <div class="card-head-right">
+      {% include "api/components/search-box.html" with placeholder="Search doc searches" %}
+      <button class="btn btn-primary"
+              @click="selectedId = null"
+              hx-get="{% url 'settings-docsearch-new-form' prefill.id %}"
+              hx-target="#docsearch-form-div">New Doc Search</button>
+    </div>
+  </div>
+
+  <div class="table-scroll has-list">
+  <table class="table">
+    <thead>
+      <tr>
+        <th>Lookup</th>
+        <th>Maps to</th>
+        <th>Type</th>
+        <th>Entity</th>
+      </tr>
+    </thead>
+    <tbody>
+      {% for ds in docsearches %}
+      <tr class="row"
+          data-search="{{ ds.keyword|lower }} {{ ds.table_name|lower }} {% if ds.account %}{{ ds.account.name|lower }}{% endif %} {{ ds.selection|lower }}"
+          :class="{ selected: selectedId === {{ ds.id }} }"
+          x-show="matches($el)"
+          @click="selectedId = {{ ds.id }}"
+          hx-get="{% url 'settings-docsearch-form' prefill.id ds.id %}"
+          hx-target="#docsearch-form-div">
+        <td class="td-name">
+          {% if ds.keyword %}{{ ds.keyword }}{% else %}<span class="td-muted">Table</span> {{ ds.table_name|default:"—" }} · {{ ds.row|default:"—" }}/{{ ds.column|default:"—" }}{% endif %}
+        </td>
+        <td class="td-2">{% if ds.account %}{{ ds.account.name }}{% elif ds.selection %}{{ ds.selection }}{% else %}<span class="td-faint">—</span>{% endif %}</td>
+        <td class="td-muted">{{ ds.get_journal_entry_item_type_display|default:"—" }}</td>
+        <td class="td-muted">{% if ds.entity %}{{ ds.entity.name }}{% else %}<span class="td-faint">—</span>{% endif %}</td>
+      </tr>
+      {% endfor %}
+    </tbody>
+  </table>
+  </div>
+
+  <div class="list">
+    {% for ds in docsearches %}
+    <div class="lrow"
+         data-search="{{ ds.keyword|lower }} {{ ds.table_name|lower }} {% if ds.account %}{{ ds.account.name|lower }}{% endif %} {{ ds.selection|lower }}"
+         :class="{ selected: selectedId === {{ ds.id }} }"
+         x-show="matches($el)"
+         @click="selectedId = {{ ds.id }}"
+         hx-get="{% url 'settings-docsearch-form' prefill.id ds.id %}"
+         hx-target="#docsearch-form-div">
+      <div class="lrow-top">
+        <span class="lname">{% if ds.keyword %}{{ ds.keyword }}{% else %}Table · {{ ds.row|default:"—" }}/{{ ds.column|default:"—" }}{% endif %}</span>
+        <span class="lmeta-right">{% if ds.account %}{{ ds.account.name }}{% elif ds.selection %}{{ ds.selection }}{% else %}—{% endif %}</span>
+      </div>
+      <div class="lmeta">{{ ds.get_journal_entry_item_type_display|default:"—" }}{% if ds.entity %} · {{ ds.entity.name }}{% endif %}</div>
+    </div>
+    {% endfor %}
+  </div>
+
+  <div class="table-empty" x-show="visible() === 0" x-cloak>
+    No doc searches match "<span x-text="q"></span>".
+  </div>
+
+  <div id="docsearch-form-div">
+    {{ docsearch_form }}
+  </div>
+</div>

--- a/ledger/templates/api/content/prefills-content.html
+++ b/ledger/templates/api/content/prefills-content.html
@@ -1,0 +1,69 @@
+<div x-data="searchList({{ total }}, 'prefills', {{ selected_id|default:'null' }})">
+
+  <div class="card-head">
+    <div class="card-head-left">
+      <h2 class="card-title">Prefills</h2>
+      <span class="card-count" x-text="countLabel()"></span>
+    </div>
+    <div class="card-head-right">
+      {% include "api/components/search-box.html" with placeholder="Search prefills" %}
+      <button class="btn btn-primary"
+              @click="selectedId = null"
+              hx-get="{% url 'settings-prefill-new-form' %}"
+              hx-target="#prefill-form-div">New Prefill</button>
+    </div>
+  </div>
+
+  <div class="table-scroll has-list">
+  <table class="table">
+    <thead>
+      <tr>
+        <th>Name</th>
+        <th class="center">Doc Searches</th>
+        <th class="center">Closed</th>
+      </tr>
+    </thead>
+    <tbody>
+      {% for prefill in prefills %}
+      <tr class="row"
+          data-search="{{ prefill.name|lower }}"
+          :class="{ selected: selectedId === {{ prefill.id }} }"
+          x-show="matches($el)"
+          @click="selectedId = {{ prefill.id }}"
+          hx-get="{% url 'settings-prefill-form' prefill.id %}"
+          hx-target="#prefill-form-div">
+        <td class="td-name">{{ prefill.name }}</td>
+        <td class="td-muted center">{{ prefill.docsearch_count }}</td>
+        <td class="td-muted center">{% if prefill.is_closed %}Yes{% else %}No{% endif %}</td>
+      </tr>
+      {% endfor %}
+    </tbody>
+  </table>
+  </div>
+
+  <div class="list">
+    {% for prefill in prefills %}
+    <div class="lrow"
+         data-search="{{ prefill.name|lower }}"
+         :class="{ selected: selectedId === {{ prefill.id }} }"
+         x-show="matches($el)"
+         @click="selectedId = {{ prefill.id }}"
+         hx-get="{% url 'settings-prefill-form' prefill.id %}"
+         hx-target="#prefill-form-div">
+      <div class="lrow-top">
+        <span class="lname">{{ prefill.name }}</span>
+        <span class="lmeta-right">{{ prefill.docsearch_count }} doc search{{ prefill.docsearch_count|pluralize:"es" }}</span>
+      </div>
+      <div class="lmeta">{% if prefill.is_closed %}Closed{% else %}Open{% endif %}</div>
+    </div>
+    {% endfor %}
+  </div>
+
+  <div class="table-empty" x-show="visible() === 0" x-cloak>
+    No prefills match "<span x-text="q"></span>".
+  </div>
+
+  <div id="prefill-form-div">
+    {{ prefill_form }}
+  </div>
+</div>

--- a/ledger/templates/api/entry_forms/docsearch-form.html
+++ b/ledger/templates/api/entry_forms/docsearch-form.html
@@ -1,0 +1,106 @@
+<div class="form">
+
+  <div class="form-header">
+    {% if doc_search %}Edit doc search{% else %}New doc search{% endif %}
+  </div>
+
+  {% if change == "create" %}
+    <div class="alert alert-success">Doc search created.</div>
+  {% elif change == "update" %}
+    <div class="alert alert-success">Doc search updated.</div>
+  {% elif change == "delete" %}
+    <div class="alert alert-success">Doc search deleted.</div>
+  {% endif %}
+  {% if error %}
+    <div class="alert alert-danger">{{ error }}</div>
+  {% endif %}
+  {% if form.non_field_errors %}
+    <div class="alert alert-danger">{{ form.non_field_errors }}</div>
+  {% endif %}
+
+  <form method="post"
+        {% if doc_search %}hx-post="{% url 'settings-docsearch' prefill.id doc_search.id %}"{% else %}hx-post="{% url 'settings-prefill-docsearches' prefill.id %}"{% endif %}
+        hx-target="#prefill-docsearches"
+        hx-swap="innerHTML">
+    {% csrf_token %}
+
+    <p class="muted fs-body">Locate a value by <strong>keyword</strong>, or by <strong>table</strong> row/column. Then map it to an account + type, or to a metadata selection.</p>
+
+    <div class="grid grid-4">
+      <div>
+        <label class="label">Keyword</label>
+        <input class="input" name="keyword" value="{{ values.keyword }}" placeholder="e.g. Gross Pay" />
+        {% for e in form.keyword.errors %}<div class="field-error">{{ e }}</div>{% endfor %}
+      </div>
+      <div>
+        <label class="label">Table name</label>
+        <input class="input" name="table_name" value="{{ values.table_name }}" placeholder="Table title" />
+        {% for e in form.table_name.errors %}<div class="field-error">{{ e }}</div>{% endfor %}
+      </div>
+      <div>
+        <label class="label">Row</label>
+        <input class="input" name="row" value="{{ values.row }}" placeholder="Row label" />
+        {% for e in form.row.errors %}<div class="field-error">{{ e }}</div>{% endfor %}
+      </div>
+      <div>
+        <label class="label">Column</label>
+        <input class="input" name="column" value="{{ values.column }}" placeholder="Column label" />
+        {% for e in form.column.errors %}<div class="field-error">{{ e }}</div>{% endfor %}
+      </div>
+    </div>
+
+    <div class="grid grid-4 grid-end">
+      <div>
+        <label class="label">Account</label>
+        <select class="select" name="account">
+          <option value="" {% if not values.account %}selected{% endif %}>Select…</option>
+          {% for account in accounts %}
+          <option value="{{ account.id }}" {% if values.account == account.id|stringformat:'s' %}selected{% endif %}>{{ account.name }}</option>
+          {% endfor %}
+        </select>
+        {% for e in form.account.errors %}<div class="field-error">{{ e }}</div>{% endfor %}
+      </div>
+      <div>
+        <label class="label">Type</label>
+        <select class="select" name="journal_entry_item_type">
+          <option value="" {% if not values.journal_entry_item_type %}selected{% endif %}>Select…</option>
+          {% for value, label in type_choices %}
+          <option value="{{ value }}" {% if values.journal_entry_item_type == value %}selected{% endif %}>{{ label }}</option>
+          {% endfor %}
+        </select>
+        {% for e in form.journal_entry_item_type.errors %}<div class="field-error">{{ e }}</div>{% endfor %}
+      </div>
+      <div>
+        <label class="label">Selection</label>
+        <select class="select" name="selection">
+          <option value="" {% if not values.selection %}selected{% endif %}>Select…</option>
+          {% for value, label in selection_choices %}
+          <option value="{{ value }}" {% if values.selection == value %}selected{% endif %}>{{ label }}</option>
+          {% endfor %}
+        </select>
+        {% for e in form.selection.errors %}<div class="field-error">{{ e }}</div>{% endfor %}
+      </div>
+      <div>
+        <label class="label">Entity</label>
+        <select class="select" name="entity">
+          <option value="" {% if not values.entity %}selected{% endif %}>Select…</option>
+          {% for entity in entities %}
+          <option value="{{ entity.id }}" {% if values.entity == entity.id|stringformat:'s' %}selected{% endif %}>{{ entity.name }}</option>
+          {% endfor %}
+        </select>
+        {% for e in form.entity.errors %}<div class="field-error">{{ e }}</div>{% endfor %}
+      </div>
+    </div>
+
+    <div class="actions">
+      <button type="submit" name="action" value="save" class="btn btn-primary">{% if doc_search %}Save{% else %}Create{% endif %}</button>
+      {% if doc_search %}
+      <button type="submit" name="action" value="delete" class="btn btn-danger">Delete</button>
+      {% endif %}
+      <button type="button" class="btn btn-ghost"
+              @click="selectedId = null"
+              hx-get="{% url 'settings-docsearch-new-form' prefill.id %}"
+              hx-target="#docsearch-form-div">Clear</button>
+    </div>
+  </form>
+</div>

--- a/ledger/templates/api/entry_forms/prefill-form.html
+++ b/ledger/templates/api/entry_forms/prefill-form.html
@@ -1,0 +1,59 @@
+<div class="form">
+
+  <div class="form-header">
+    {% if prefill %}Edit · {{ prefill.name }}{% else %}New prefill{% endif %}
+  </div>
+
+  {% if change == "create" %}
+    <div class="alert alert-success">Prefill created.</div>
+  {% elif change == "update" %}
+    <div class="alert alert-success">Prefill updated.</div>
+  {% elif change == "delete" %}
+    <div class="alert alert-success">Prefill deleted.</div>
+  {% endif %}
+  {% if error %}
+    <div class="alert alert-danger">{{ error }}</div>
+  {% endif %}
+  {% if form.non_field_errors %}
+    <div class="alert alert-danger">{{ form.non_field_errors }}</div>
+  {% endif %}
+
+  <form method="post"
+        {% if prefill %}hx-post="{% url 'settings-prefill' prefill.id %}"{% else %}hx-post="{% url 'settings-prefills' %}"{% endif %}
+        hx-target="#prefills-content"
+        hx-swap="innerHTML">
+    {% csrf_token %}
+
+    <div class="grid grid-wide-first grid-end">
+      <div>
+        <label class="label">Name</label>
+        <input class="input" name="name" value="{{ values.name }}" placeholder="Prefill name" />
+        {% for e in form.name.errors %}<div class="field-error">{{ e }}</div>{% endfor %}
+      </div>
+      <div class="checks">
+        <label class="check">
+          <input type="checkbox" name="is_closed" {% if values.is_closed %}checked{% endif %} />Closed
+        </label>
+      </div>
+    </div>
+
+    <div class="actions">
+      <button type="submit" name="action" value="save" class="btn btn-primary">{% if prefill %}Save{% else %}Create{% endif %}</button>
+      {% if prefill %}
+      <button type="submit" name="action" value="delete" class="btn btn-danger">Delete</button>
+      {% endif %}
+      <button type="button" class="btn btn-ghost"
+              @click="selectedId = null"
+              hx-get="{% url 'settings-prefill-new-form' %}"
+              hx-target="#prefill-form-div">Clear</button>
+    </div>
+  </form>
+
+  {% if prefill %}
+  <div id="prefill-docsearches"
+       hx-get="{% url 'settings-prefill-docsearches' prefill.id %}"
+       hx-trigger="load">
+    <div class="table-empty">Loading doc searches…</div>
+  </div>
+  {% endif %}
+</div>

--- a/ledger/templates/api/views/settings.html
+++ b/ledger/templates/api/views/settings.html
@@ -1,6 +1,6 @@
 <div x-data="{
         section: 'Accounts',
-        sections: ['Accounts', 'Bill Rules', 'Utility Bills', 'Loans', 'Entities', 'Paystubs', 'Auto Tags', 'CSV Profiles'],
+        sections: ['Accounts', 'Bill Rules', 'Utility Bills', 'Loans', 'Entities', 'Prefills', 'Paystubs', 'Auto Tags', 'CSV Profiles'],
         stubs: {
           'Paystubs': 'Saved paystub templates parsed via AWS Textract.',
           'Auto Tags': 'Rules that auto-categorize incoming transactions.',
@@ -55,6 +55,14 @@
       <div x-show="section === 'Loans'">
         <div id="loans-content"
              hx-get="{% url 'settings-loans' %}" hx-trigger="load">
+          <div class="table-empty">Loading…</div>
+        </div>
+      </div>
+
+      <!-- Prefills (functional, lazy-loaded) -->
+      <div x-show="section === 'Prefills'">
+        <div id="prefills-content"
+             hx-get="{% url 'settings-prefills' %}" hx-trigger="load">
           <div class="table-empty">Loading…</div>
         </div>
       </div>

--- a/ledger/urls.py
+++ b/ledger/urls.py
@@ -50,6 +50,12 @@ from api.views.loan_views import (
     LoanScheduleView,
     LoanSettingsView,
 )
+from api.views.prefill_settings_views import (
+    DocSearchFormView,
+    DocSearchView,
+    PrefillFormView,
+    PrefillSettingsView,
+)
 from api.views.settings_views import AccountFormView, SettingsView
 from api.views.statement_views import (
     StatementDetailView,
@@ -328,6 +334,47 @@ urlpatterns = [
         "settings/loans/schedule-row/<int:row_id>/",
         LoanScheduleView.as_view(),
         name="settings-loan-schedule-row",
+    ),
+    # Settings — prefills (config CRUD) and their doc searches
+    path(
+        "settings/prefills/",
+        PrefillSettingsView.as_view(),
+        name="settings-prefills",
+    ),
+    path(
+        "settings/prefills/new/form/",
+        PrefillFormView.as_view(),
+        name="settings-prefill-new-form",
+    ),
+    path(
+        "settings/prefills/<int:prefill_id>/",
+        PrefillSettingsView.as_view(),
+        name="settings-prefill",
+    ),
+    path(
+        "settings/prefills/<int:prefill_id>/form/",
+        PrefillFormView.as_view(),
+        name="settings-prefill-form",
+    ),
+    path(
+        "settings/prefills/<int:prefill_id>/docsearches/",
+        DocSearchView.as_view(),
+        name="settings-prefill-docsearches",
+    ),
+    path(
+        "settings/prefills/<int:prefill_id>/docsearches/new/form/",
+        DocSearchFormView.as_view(),
+        name="settings-docsearch-new-form",
+    ),
+    path(
+        "settings/prefills/<int:prefill_id>/docsearches/<int:docsearch_id>/",
+        DocSearchView.as_view(),
+        name="settings-docsearch",
+    ),
+    path(
+        "settings/prefills/<int:prefill_id>/docsearches/<int:docsearch_id>/form/",
+        DocSearchFormView.as_view(),
+        name="settings-docsearch-form",
     ),
     path("tag/", TagEntitiesView.as_view(), name="tag-entities"),
     path("tag/balances/", EntityGroupedBalancesView.as_view(), name="entity-balances"),


### PR DESCRIPTION
## Summary

Adds a user-facing **Prefills** section to the Settings page for configuring Prefill objects and their **Doc Searches** — previously only editable via the Django admin. Doc Searches drive paystub/document extraction: each one tells the parser where to find a value on a document (by keyword, or table row/column) and which account/metadata field it maps to.

- **Prefills** — full CRUD: create, rename, close/reopen (`is_closed`), and delete, with a friendly inline message when a delete is blocked by a `PROTECT` reference (suggests closing instead). Closed prefills drop out of the upload picker.
- **Doc Searches** — master-detail CRUD scoped to a selected prefill, lazy-loaded into the prefill edit form. The either/or field rules (keyword vs table row/column; account+type vs selection) reuse `DocSearch.clean()` rather than re-implementing validation.

Follows the established **Views → Helpers → Forms → Services → Models** layering, mirroring the Entities/Bill-Rule/Loan settings sections and reusing the shared `crud.py` engine. `PrefillItem` editing is intentionally out of scope for now.

## Refactor: shared `resolve_form_values` helper

Extracts `api/views/form_helpers.py::resolve_form_values()` and migrates **all** settings sections (accounts, entities, bill rules, loans, prefills, doc searches) to it. This replaces ~200 lines of triplicated per-field "bound → instance → blank" value dicts with declarative field-list calls (`text` / `booleans` / `fks` / `dates` / `defaults`), so each form's field names live in a single place — removing the silent-drift risk when a field is renamed or added.

## Testing

- `test_prefill_services.py` — service CRUD, PROTECT-block, and `DocSearchForm` validation.
- `test_form_helpers.py` — 10 unit tests covering all three branches × four field kinds.
- Full suite: **600 passing**. `manage.py check` and `pyflakes` clean.
- Smoke-tested rendered pre-fill for tricky cases (loan `start_date`→ISO, blank `date_window_days="7"`, account `type=asset`, bill `transaction_type=PURCHASE`, FK `selected` options).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0174xTpCw8XLgrR8LYpUS3ip