### PR TITLE
Add read-only reporting API + MCP server for agent access

### DIFF
--- a/api/rest_api/report_serializers.py
+++ b/api/rest_api/report_serializers.py
@@ -1,0 +1,131 @@
+"""
+Serialization helpers for the read-only reporting endpoints.
+
+The statement engine (``api/statement.py``) and ``statement_services`` return
+plain Python objects (``Balance``, ``EntityBalance``) and dataclasses
+(``StatementSummary``, ``EntityIncomeSummary``, ``CashFlowMetrics``,
+``StatementDetailData``), not Django models. These functions flatten those
+objects into JSON-able dicts for ``rest_framework.response.Response`` (its
+JSON encoder renders ``Decimal``/``date`` natively).
+
+Pure functions: object → dict. No database access, no business logic. The
+shapes mirror the hierarchy that ``api/views/statement_helpers`` renders to
+HTML, so the JSON reconciles with the on-screen statements.
+"""
+
+from typing import Any, Dict, List
+
+from api.services.statement_services import (
+    CashFlowMetrics,
+    EntityIncomeSummary,
+    StatementDetailData,
+    StatementSummary,
+)
+from api.statement import Balance, EntityBalance
+
+
+def serialize_balance(balance: Balance) -> Dict[str, Any]:
+    """One account's balance line (works for real or synthetic accounts)."""
+    account = balance.account
+    return {
+        "account": account.name,
+        "account_type": account.type,
+        "sub_type": account.sub_type,
+        "amount": balance.amount,
+        "flow_type": balance.type,
+    }
+
+
+def serialize_entity_balance(entity_balance: EntityBalance) -> Dict[str, Any]:
+    """One entity's balance within a statement section."""
+    return {
+        "entity_id": entity_balance.entity_id,
+        "entity": entity_balance.name,
+        "amount": entity_balance.amount,
+        "sub_type": entity_balance.sub_type,
+    }
+
+
+def serialize_statement_summary(summary: StatementSummary) -> Dict[str, Any]:
+    """The by-account type → sub_type → balances hierarchy as nested dicts."""
+    return {
+        account_type: {
+            "name": type_summary.name,
+            "total": type_summary.total,
+            "sub_types": [
+                {
+                    "name": sub.name,
+                    "total": sub.total,
+                    "balances": [serialize_balance(b) for b in sub.balances],
+                }
+                for sub in type_summary.sub_types
+            ],
+        }
+        for account_type, type_summary in summary.account_types.items()
+    }
+
+
+def _serialize_entity_section(section) -> Dict[str, Any]:
+    return {
+        "name": section.name,
+        "total": section.total,
+        "balances": [serialize_entity_balance(b) for b in section.balances],
+    }
+
+
+def serialize_entity_income_summary(summary: EntityIncomeSummary) -> Dict[str, Any]:
+    """Income/expense broken out by entity, largest sources/uses first."""
+    return {
+        "income_total": summary.income_total,
+        "expense_total": summary.expense_total,
+        "net_income": summary.net_income,
+        "income_sub_types": [
+            _serialize_entity_section(s) for s in summary.income_sub_types
+        ],
+        "expense_sub_types": [
+            _serialize_entity_section(s) for s in summary.expense_sub_types
+        ],
+    }
+
+
+def serialize_cash_flow_metrics(metrics: CashFlowMetrics) -> Dict[str, Any]:
+    """Flat cash-flow totals plus the per-account flows in each section."""
+    return {
+        "cash_from_operations": metrics.cash_from_operations,
+        "cash_from_financing": metrics.cash_from_financing,
+        "cash_from_investing": metrics.cash_from_investing,
+        "net_cash_flow": metrics.net_cash_flow,
+        "levered_cash_flow": metrics.levered_cash_flow,
+        "levered_cash_flow_post_retirement": (
+            metrics.levered_cash_flow_post_retirement
+        ),
+        "cash_flow_discrepancy": metrics.cash_flow_discrepancy,
+        "operations_flows": [serialize_balance(b) for b in metrics.operations_flows],
+        "financing_flows": [serialize_balance(b) for b in metrics.financing_flows],
+        "investing_flows": [serialize_balance(b) for b in metrics.investing_flows],
+    }
+
+
+def serialize_trend_balances(balances: List[Balance]) -> List[Dict[str, Any]]:
+    """Monthly time-series rows; each balance carries its month-end date."""
+    return [
+        {**serialize_balance(balance), "date": balance.date} for balance in balances
+    ]
+
+
+def serialize_detail(detail: StatementDetailData) -> Dict[str, Any]:
+    """Signed line-item drill-down for an account or entity section."""
+    return {
+        "account": detail.account.name if detail.account else None,
+        "items": [
+            {
+                "date": item.journal_entry.date,
+                "label": item.display_label,
+                "account": item.account.name,
+                "entity": item.entity.name if item.entity else None,
+                "amount": item.amount_signed,
+                "type": item.type,
+            }
+            for item in detail.journal_entry_items
+        ],
+    }

--- a/api/rest_api/report_views.py
+++ b/api/rest_api/report_views.py
@@ -1,0 +1,200 @@
+"""
+Read-only reporting endpoints for the /api/v1/ REST API.
+
+These GET endpoints expose the statement engine (``api/statement.py`` +
+``api/services/statement_services.py``) as JSON so an agent can answer
+questions about spending, build dashboards, and write summaries. They wrap the
+same services the login-gated HTML statement views use (``StatementView``), add
+no business logic, and never write. They ride the global DRF API-key auth
+(``APIKeyAuthentication`` + ``IsAuthenticated``), so callers need ``LEDGER_API_KEY``.
+"""
+
+from datetime import date, datetime
+from typing import Optional, Tuple
+
+from rest_framework.exceptions import ValidationError
+from rest_framework.response import Response
+from rest_framework.views import APIView
+
+from api import utils
+from api.rest_api import report_serializers
+from api.services import statement_services
+from api.statement import BalanceSheet, IncomeStatement, Trend
+
+DATE_FORMAT = "%Y-%m-%d"
+
+
+def _parse_date(value: Optional[str], field: str) -> Optional[date]:
+    """Parse a YYYY-MM-DD query param.
+
+    Returns None when the param is absent (so the caller can default it), but
+    raises a 400 when it's present-but-unparseable — better for an agent client
+    than silently returning data for a different (defaulted) period.
+    """
+    if not value:
+        return None
+    try:
+        return datetime.strptime(value, DATE_FORMAT).date()
+    except ValueError:
+        raise ValidationError(
+            {field: f"Invalid date '{value}'; expected YYYY-MM-DD."}
+        )
+
+
+def _date_range(request) -> Tuple[date, date]:
+    """Resolve ``from_date``/``to_date`` params, defaulting to last month."""
+    default_from, default_to = utils.get_default_statement_date_range()
+    from_param = request.query_params.get("from_date")
+    to_param = request.query_params.get("to_date")
+    from_date = _parse_date(from_param, "from_date") or default_from
+    to_date = _parse_date(to_param, "to_date") or default_to
+    return from_date, to_date
+
+
+class IncomeReportView(APIView):
+    """GET /api/v1/reports/income/ — income statement for a date range.
+
+    ``?group_by=entity`` returns the by-entity breakdown instead of by-account.
+    """
+
+    def get(self, request):
+        from_date, to_date = _date_range(request)
+        income_statement = IncomeStatement(end_date=to_date, start_date=from_date)
+
+        payload = {
+            "from_date": from_date,
+            "to_date": to_date,
+            "net_income": income_statement.net_income,
+            "tax_rate": income_statement.get_tax_rate(),
+            "savings_rate": income_statement.get_savings_rate(),
+        }
+
+        if request.query_params.get("group_by") == "entity":
+            summary = statement_services.build_entity_income_summary(income_statement)
+            payload["group_by"] = "entity"
+            payload["summary"] = report_serializers.serialize_entity_income_summary(
+                summary
+            )
+        else:
+            summary = statement_services.build_statement_summary(income_statement)
+            payload["group_by"] = "account"
+            payload["summary"] = report_serializers.serialize_statement_summary(
+                summary
+            )
+
+        return Response(payload)
+
+
+class BalanceSheetReportView(APIView):
+    """GET /api/v1/reports/balance-sheet/ — point-in-time position at to_date."""
+
+    def get(self, request):
+        _, to_date = _date_range(request)
+        balance_sheet = BalanceSheet(end_date=to_date)
+        summary = statement_services.build_statement_summary(balance_sheet)
+
+        return Response(
+            {
+                "as_of": to_date,
+                "summary": report_serializers.serialize_statement_summary(summary),
+                "metrics": {
+                    metric.name: metric.value for metric in balance_sheet.metrics
+                },
+            }
+        )
+
+
+class CashFlowReportView(APIView):
+    """GET /api/v1/reports/cash-flow/ — cash flow metrics for a date range."""
+
+    def get(self, request):
+        from_date, to_date = _date_range(request)
+        metrics = statement_services.calculate_cash_flow_metrics(from_date, to_date)
+
+        return Response(
+            {
+                "from_date": from_date,
+                "to_date": to_date,
+                **report_serializers.serialize_cash_flow_metrics(metrics),
+            }
+        )
+
+
+class SpendingByEntityReportView(APIView):
+    """GET /api/v1/reports/spending-by-entity/ — income/expense by entity."""
+
+    def get(self, request):
+        from_date, to_date = _date_range(request)
+        income_statement = IncomeStatement(end_date=to_date, start_date=from_date)
+        summary = statement_services.build_entity_income_summary(income_statement)
+
+        return Response(
+            {
+                "from_date": from_date,
+                "to_date": to_date,
+                **report_serializers.serialize_entity_income_summary(summary),
+            }
+        )
+
+
+class TrendReportView(APIView):
+    """GET /api/v1/reports/trend/ — month-by-month balances for a date range."""
+
+    def get(self, request):
+        from_date, to_date = _date_range(request)
+        # Trend takes start_date as a string and end_date as a date object.
+        trend = Trend(
+            start_date=utils.format_datetime_to_string(from_date), end_date=to_date
+        )
+        return Response(
+            {
+                "from_date": from_date,
+                "to_date": to_date,
+                "balances": report_serializers.serialize_trend_balances(
+                    trend.get_balances()
+                ),
+            }
+        )
+
+
+class AccountDetailReportView(APIView):
+    """GET /api/v1/reports/account-detail/ — signed line items for one account.
+
+    Requires ``account_id``, ``from_date``, ``to_date``.
+    """
+
+    def get(self, request):
+        account_id = request.query_params.get("account_id")
+        if not account_id:
+            return Response({"error": "account_id is required."}, status=400)
+
+        from_date, to_date = _date_range(request)
+        detail = statement_services.get_statement_detail_items(
+            account_id=account_id,
+            from_date=utils.format_datetime_to_string(from_date),
+            to_date=utils.format_datetime_to_string(to_date),
+        )
+        return Response(report_serializers.serialize_detail(detail))
+
+
+class EntityDetailReportView(APIView):
+    """GET /api/v1/reports/entity-detail/ — signed line items for an entity section.
+
+    Requires ``sub_type``, ``from_date``, ``to_date``. ``entity_id`` is optional;
+    omit it (or pass empty) to get the Unassigned bucket.
+    """
+
+    def get(self, request):
+        sub_type = request.query_params.get("sub_type")
+        if not sub_type:
+            return Response({"error": "sub_type is required."}, status=400)
+
+        entity_id = request.query_params.get("entity_id") or None
+        from_date, to_date = _date_range(request)
+        detail = statement_services.get_statement_detail_items_by_entity(
+            entity_id=entity_id,
+            sub_type=sub_type,
+            from_date=utils.format_datetime_to_string(from_date),
+            to_date=utils.format_datetime_to_string(to_date),
+        )
+        return Response(report_serializers.serialize_detail(detail))

--- a/api/rest_api/urls.py
+++ b/api/rest_api/urls.py
@@ -1,5 +1,14 @@
 from django.urls import path
 
+from api.rest_api.report_views import (
+    AccountDetailReportView,
+    BalanceSheetReportView,
+    CashFlowReportView,
+    EntityDetailReportView,
+    IncomeReportView,
+    SpendingByEntityReportView,
+    TrendReportView,
+)
 from api.rest_api.views import (
     AccountListView,
     EntityListView,
@@ -14,4 +23,28 @@ urlpatterns = [
     path("accounts/", AccountListView.as_view(), name="accounts"),
     path("entities/", EntityListView.as_view(), name="entities"),
     path("journal-entries/", JournalEntryCreateView.as_view(), name="journal-entries"),
+    # Read-only reporting endpoints (wrap the statement engine).
+    path("reports/income/", IncomeReportView.as_view(), name="reports-income"),
+    path(
+        "reports/balance-sheet/",
+        BalanceSheetReportView.as_view(),
+        name="reports-balance-sheet",
+    ),
+    path("reports/cash-flow/", CashFlowReportView.as_view(), name="reports-cash-flow"),
+    path(
+        "reports/spending-by-entity/",
+        SpendingByEntityReportView.as_view(),
+        name="reports-spending-by-entity",
+    ),
+    path("reports/trend/", TrendReportView.as_view(), name="reports-trend"),
+    path(
+        "reports/account-detail/",
+        AccountDetailReportView.as_view(),
+        name="reports-account-detail",
+    ),
+    path(
+        "reports/entity-detail/",
+        EntityDetailReportView.as_view(),
+        name="reports-entity-detail",
+    ),
 ]

--- a/api/tests/rest_api/test_report_views.py
+++ b/api/tests/rest_api/test_report_views.py
@@ -1,0 +1,198 @@
+"""
+Tests for the read-only reporting endpoints (/api/v1/reports/*).
+
+Builds a small real ledger (income + expense within one month) and asserts the
+endpoints return the statement engine's numbers as JSON, enforce API-key auth,
+and validate required params.
+"""
+
+from decimal import Decimal
+
+from django.test import TestCase, override_settings
+from rest_framework.test import APIClient
+
+from api.models import Account, JournalEntry, JournalEntryItem, Transaction
+from api.tests.testing_factories import (
+    AccountFactory,
+    EntityFactory,
+    TransactionFactory,
+)
+
+API_KEY = "test-api-key-12345"
+FROM_DATE = "2024-03-01"
+TO_DATE = "2024-03-31"
+IN_RANGE = "2024-03-15"
+
+
+def _booked_entry(*, account, amount, debit_account, credit_account, entity=None):
+    """Create a transaction + balanced two-item journal entry on IN_RANGE."""
+    transaction = TransactionFactory(
+        account=account,
+        amount=amount,
+        date=IN_RANGE,
+        is_closed=True,
+        type=Transaction.TransactionType.PURCHASE,
+    )
+    journal_entry = JournalEntry.objects.create(
+        date=IN_RANGE, description="test entry", transaction=transaction
+    )
+    JournalEntryItem.objects.create(
+        journal_entry=journal_entry,
+        type=JournalEntryItem.JournalEntryType.DEBIT,
+        amount=amount,
+        account=debit_account,
+        entity=entity,
+    )
+    JournalEntryItem.objects.create(
+        journal_entry=journal_entry,
+        type=JournalEntryItem.JournalEntryType.CREDIT,
+        amount=amount,
+        account=credit_account,
+        entity=entity,
+    )
+    return journal_entry
+
+
+@override_settings(LEDGER_API_KEY=API_KEY)
+class ReportEndpointsTest(TestCase):
+    def setUp(self):
+        self.client = APIClient()
+        self.client.credentials(HTTP_AUTHORIZATION=f"Api-Key {API_KEY}")
+
+        self.cash = AccountFactory(
+            name="Checking", type=Account.Type.ASSET, sub_type=Account.SubType.CASH,
+            is_closed=False,
+        )
+        self.salary = AccountFactory(
+            name="Salary", type=Account.Type.INCOME, sub_type=Account.SubType.SALARY,
+            is_closed=False,
+        )
+        self.groceries = AccountFactory(
+            name="Groceries", type=Account.Type.EXPENSE,
+            sub_type=Account.SubType.OPERATING, is_closed=False,
+        )
+        self.whole_foods = EntityFactory(name="Whole Foods")
+
+        # $5,000 salary income and $100 groceries expense, both in-range.
+        _booked_entry(
+            account=self.cash, amount=Decimal("5000.00"),
+            debit_account=self.cash, credit_account=self.salary,
+        )
+        _booked_entry(
+            account=self.cash, amount=Decimal("100.00"),
+            debit_account=self.groceries, credit_account=self.cash,
+            entity=self.whole_foods,
+        )
+
+    def _get(self, path, **params):
+        query = {"from_date": FROM_DATE, "to_date": TO_DATE, **params}
+        return self.client.get(path, data=query)
+
+    def test_income_by_account(self):
+        response = self._get("/api/v1/reports/income/")
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.data["group_by"], "account")
+        self.assertEqual(Decimal(str(response.data["net_income"])), Decimal("4900.00"))
+        self.assertIn("income", response.data["summary"])
+        self.assertIn("expense", response.data["summary"])
+
+    def test_income_by_entity(self):
+        response = self._get("/api/v1/reports/income/", group_by="entity")
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.data["group_by"], "entity")
+        self.assertEqual(
+            Decimal(str(response.data["summary"]["income_total"])),
+            Decimal("5000.00"),
+        )
+        self.assertEqual(
+            Decimal(str(response.data["summary"]["expense_total"])),
+            Decimal("100.00"),
+        )
+        # Whole Foods should appear as an expense entity.
+        expense_entities = [
+            b["entity"]
+            for section in response.data["summary"]["expense_sub_types"]
+            for b in section["balances"]
+        ]
+        self.assertIn("Whole Foods", expense_entities)
+
+    def test_balance_sheet(self):
+        response = self._get("/api/v1/reports/balance-sheet/")
+        self.assertEqual(response.status_code, 200)
+        self.assertIn("summary", response.data)
+        self.assertIn("asset", response.data["summary"])
+        self.assertIn("metrics", response.data)
+
+    def test_cash_flow(self):
+        response = self._get("/api/v1/reports/cash-flow/")
+        self.assertEqual(response.status_code, 200)
+        for key in (
+            "cash_from_operations",
+            "cash_from_financing",
+            "cash_from_investing",
+            "net_cash_flow",
+            "operations_flows",
+        ):
+            self.assertIn(key, response.data)
+
+    def test_spending_by_entity(self):
+        response = self._get("/api/v1/reports/spending-by-entity/")
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(
+            Decimal(str(response.data["expense_total"])), Decimal("100.00")
+        )
+
+    def test_trend(self):
+        response = self._get("/api/v1/reports/trend/")
+        self.assertEqual(response.status_code, 200)
+        self.assertIsInstance(response.data["balances"], list)
+        self.assertTrue(response.data["balances"])
+        self.assertIn("date", response.data["balances"][0])
+
+    def test_account_detail(self):
+        response = self._get(
+            "/api/v1/reports/account-detail/", account_id=self.groceries.id
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.data["account"], "Groceries")
+        self.assertEqual(len(response.data["items"]), 1)
+        self.assertEqual(
+            Decimal(str(response.data["items"][0]["amount"])), Decimal("100.00")
+        )
+
+    def test_account_detail_requires_account_id(self):
+        response = self._get("/api/v1/reports/account-detail/")
+        self.assertEqual(response.status_code, 400)
+
+    def test_entity_detail(self):
+        response = self._get(
+            "/api/v1/reports/entity-detail/",
+            sub_type=Account.SubType.OPERATING,
+            entity_id=self.whole_foods.id,
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(len(response.data["items"]), 1)
+
+    def test_entity_detail_requires_sub_type(self):
+        response = self._get("/api/v1/reports/entity-detail/")
+        self.assertEqual(response.status_code, 400)
+
+    def test_defaults_to_last_month_without_dates(self):
+        response = self.client.get("/api/v1/reports/income/")
+        self.assertEqual(response.status_code, 200)
+        self.assertIn("from_date", response.data)
+        self.assertIn("to_date", response.data)
+
+    def test_invalid_date_returns_400(self):
+        # A malformed date must error, not silently fall back to the default
+        # period and return data for a range the caller did not ask for.
+        response = self.client.get(
+            "/api/v1/reports/income/", data={"from_date": "garbage"}
+        )
+        self.assertEqual(response.status_code, 400)
+        self.assertIn("from_date", response.data)
+
+    def test_unauthenticated_returns_403(self):
+        client = APIClient()
+        response = client.get("/api/v1/reports/income/")
+        self.assertEqual(response.status_code, 403)

--- a/api/utils.py
+++ b/api/utils.py
@@ -48,6 +48,17 @@ def get_last_days_of_month_tuples():
     return final_days_of_month
 
 
+def get_default_statement_date_range():
+    """First and last day of the last full calendar month.
+
+    The default reporting period shared by the HTML statement views and the
+    read-only reporting API.
+    """
+    last_day = get_last_days_of_month_tuples()[0][0]
+    first_day = get_first_day_of_month_from_date(last_day)
+    return first_day, last_day
+
+
 def get_last_day_of_last_month():
     current_date = datetime.now()
 

--- a/api/views/statement_views.py
+++ b/api/views/statement_views.py
@@ -116,10 +116,7 @@ class StatementView(LoginRequiredMixin, View):
 
     def _get_default_dates(self):
         """Get last month date range."""
-        last_month_tuple = utils.get_last_days_of_month_tuples()[0]
-        last_day = last_month_tuple[0]
-        first_day = utils.get_first_day_of_month_from_date(last_day)
-        return first_day, last_day
+        return utils.get_default_statement_date_range()
 
     def _render_income_statement(self, from_date, to_date):
         """Render income statement using services and helpers."""

--- a/mcp_server/README.md
+++ b/mcp_server/README.md
@@ -1,0 +1,82 @@
+# Ledger MCP Server
+
+A read-only [MCP](https://modelcontextprotocol.io) server that gives an agent
+(Claude Cowork / Claude Code) native tools for querying your Ledger accounting
+data — answering spending questions, building dashboards, and writing summaries.
+
+It's a thin HTTP client over the Ledger reporting API (`/api/v1/reports/*`). It
+**never touches the database** and only calls GET/reporting endpoints, so it is
+read-only by construction and needs no database credentials — just the API base
+URL and the shared API key.
+
+## Tools
+
+| Tool | What it returns |
+| --- | --- |
+| `get_income_statement(from_date, to_date, group_by)` | Revenue/expense/net income for a range; `group_by="entity"` for a payee breakdown |
+| `get_balance_sheet(to_date)` | Assets/liabilities/equity + ratios at a point in time |
+| `get_cash_flow(from_date, to_date)` | Operations / financing / investing cash flows |
+| `spending_by_entity(from_date, to_date)` | Income & expense by entity, largest first |
+| `get_trend(from_date, to_date)` | Month-by-month balances (time series for charts) |
+| `account_detail(account_id, from_date, to_date)` | Signed line items for one account |
+| `entity_detail(sub_type, entity_id, from_date, to_date)` | Signed line items for one entity section |
+| `list_transactions(account, type, is_closed)` | Raw transactions |
+| `list_accounts(type, is_closed)` | Chart of accounts (with ids) |
+| `list_entities(is_closed)` | Entities/payees (with ids) |
+
+Dates are `YYYY-MM-DD`. Omit them to default to the last full calendar month.
+
+## Configuration
+
+Two environment variables:
+
+- `LEDGER_API_BASE_URL` — e.g. `https://fast-cliffs-86166.herokuapp.com/api/v1`
+  (use `http://127.0.0.1:8000/api/v1` to point at a local dev server)
+- `LEDGER_API_KEY` — the same value set as `LEDGER_API_KEY` on the server
+
+### Register with Claude Code / Cowork
+
+Add to your MCP config (e.g. `.mcp.json` or the Claude Code MCP settings):
+
+```json
+{
+  "mcpServers": {
+    "ledger": {
+      "command": "uv",
+      "args": [
+        "run", "--with", "mcp[cli]", "--with", "httpx",
+        "python", "mcp_server/server.py"
+      ],
+      "env": {
+        "LEDGER_API_BASE_URL": "https://fast-cliffs-86166.herokuapp.com/api/v1",
+        "LEDGER_API_KEY": "your-api-key-here"
+      }
+    }
+  }
+}
+```
+
+## Example prompts
+
+Once connected, ask Cowork things like:
+
+- "What did I spend the most on last quarter? Build a dashboard."
+- "Summarize last quarter's cash flow and flag anything unusual."
+- "Chart my monthly expenses for 2025 and write a one-paragraph summary."
+- "How did my net income trend month over month this year?"
+
+Cowork calls these tools, then writes standalone artifacts (e.g.
+`dashboard.html`, `summary.md`) from the returned JSON — no changes to the
+Ledger app are needed.
+
+## Local smoke test
+
+```bash
+# Point at a locally running dev server (uv run python manage.py runserver),
+# with LEDGER_API_KEY set the same in both places.
+LEDGER_API_BASE_URL=http://127.0.0.1:8000/api/v1 \
+LEDGER_API_KEY=dev-key \
+uv run --with 'mcp[cli]' --with httpx mcp dev mcp_server/server.py
+```
+
+`mcp dev` opens the MCP Inspector so you can invoke each tool by hand.

--- a/mcp_server/pyproject.toml
+++ b/mcp_server/pyproject.toml
@@ -1,0 +1,12 @@
+[project]
+name = "ledger-mcp-server"
+version = "0.1.0"
+description = "Read-only MCP server exposing the Ledger reporting API to an agent."
+requires-python = ">=3.10"
+dependencies = [
+    "mcp[cli]>=1.2.0",
+    "httpx>=0.27.0",
+]
+
+[project.scripts]
+ledger-mcp = "server:mcp.run"

--- a/mcp_server/server.py
+++ b/mcp_server/server.py
@@ -1,0 +1,188 @@
+"""
+Ledger MCP server — read-only agent access to production accounting data.
+
+Exposes the Ledger reporting API (`/api/v1/reports/*` plus the raw list
+endpoints) as typed MCP tools so Claude Cowork can answer spending questions,
+build dashboards, and write summaries. It is a thin HTTP client over the
+deployed Django API: it never touches the database directly, so it inherits the
+API's read-only guarantee and needs no database credentials — only the base URL
+and the shared API key.
+
+Config (env vars):
+  LEDGER_API_BASE_URL  e.g. https://fast-cliffs-86166.herokuapp.com/api/v1
+  LEDGER_API_KEY       the same key the server checks (Authorization: Api-Key ...)
+
+Run:  uv run --with 'mcp[cli]' --with httpx python mcp_server/server.py
+"""
+
+import os
+from typing import Any, Optional
+
+import httpx
+from mcp.server.fastmcp import FastMCP
+
+BASE_URL = os.environ.get("LEDGER_API_BASE_URL", "").rstrip("/")
+API_KEY = os.environ.get("LEDGER_API_KEY", "")
+
+mcp = FastMCP("ledger")
+
+# One pooled client, reused across every tool call so an agent's many sequential
+# requests share keep-alive connections instead of re-doing the TLS handshake.
+_client = httpx.Client(
+    headers={"Authorization": f"Api-Key {API_KEY}"}, timeout=30.0
+)
+
+
+def _get(path: str, params: Optional[dict] = None) -> Any:
+    """GET a reporting endpoint and return parsed JSON (or an error dict)."""
+    if not BASE_URL:
+        return {"error": "LEDGER_API_BASE_URL is not set."}
+    if not API_KEY:
+        return {"error": "LEDGER_API_KEY is not set."}
+
+    # Drop unset optional filters so the API applies its own defaults.
+    clean = {k: v for k, v in (params or {}).items() if v is not None}
+    try:
+        response = _client.get(f"{BASE_URL}/{path.lstrip('/')}", params=clean)
+    except httpx.HTTPError as exc:
+        return {"error": f"Request failed: {exc}"}
+
+    if response.status_code != 200:
+        return {"error": f"HTTP {response.status_code}", "body": response.text[:500]}
+    return response.json()
+
+
+# --- Reporting tools (aggregations wrapping the statement engine) -----------
+
+
+@mcp.tool()
+def get_income_statement(
+    from_date: Optional[str] = None,
+    to_date: Optional[str] = None,
+    group_by: str = "account",
+) -> Any:
+    """Income statement (revenue, expenses, net income) for a date range.
+
+    Dates are YYYY-MM-DD; omit them to default to the last full month.
+    group_by="entity" breaks income/expense out by payee/counterparty instead
+    of by account.
+    """
+    return _get(
+        "reports/income/",
+        {"from_date": from_date, "to_date": to_date, "group_by": group_by},
+    )
+
+
+@mcp.tool()
+def get_balance_sheet(to_date: Optional[str] = None) -> Any:
+    """Point-in-time balance sheet (assets, liabilities, equity) plus ratios.
+
+    to_date is YYYY-MM-DD; omit to default to the end of last month.
+    """
+    return _get("reports/balance-sheet/", {"to_date": to_date})
+
+
+@mcp.tool()
+def get_cash_flow(
+    from_date: Optional[str] = None, to_date: Optional[str] = None
+) -> Any:
+    """Cash flow statement (operations / financing / investing) for a range."""
+    return _get("reports/cash-flow/", {"from_date": from_date, "to_date": to_date})
+
+
+@mcp.tool()
+def spending_by_entity(
+    from_date: Optional[str] = None, to_date: Optional[str] = None
+) -> Any:
+    """Income and expense broken out by entity (who you paid / got paid by),
+    largest first — the 'what did I spend the most on' view."""
+    return _get(
+        "reports/spending-by-entity/",
+        {"from_date": from_date, "to_date": to_date},
+    )
+
+
+@mcp.tool()
+def get_trend(
+    from_date: Optional[str] = None, to_date: Optional[str] = None
+) -> Any:
+    """Month-by-month balances across a range — the time series for dashboards.
+
+    Returns one row per account per month, each tagged with its month-end date.
+    """
+    return _get("reports/trend/", {"from_date": from_date, "to_date": to_date})
+
+
+@mcp.tool()
+def account_detail(
+    account_id: int,
+    from_date: Optional[str] = None,
+    to_date: Optional[str] = None,
+) -> Any:
+    """Signed journal-entry line items for one account over a range (drill-down).
+
+    Get account_id from list_accounts.
+    """
+    return _get(
+        "reports/account-detail/",
+        {"account_id": account_id, "from_date": from_date, "to_date": to_date},
+    )
+
+
+@mcp.tool()
+def entity_detail(
+    sub_type: str,
+    entity_id: Optional[int] = None,
+    from_date: Optional[str] = None,
+    to_date: Optional[str] = None,
+) -> Any:
+    """Signed line items for one entity within a statement section (sub_type).
+
+    Pass entity_id=None for the Unassigned bucket. sub_type is an account
+    sub_type such as "operating", "salary", or "tax".
+    """
+    return _get(
+        "reports/entity-detail/",
+        {
+            "sub_type": sub_type,
+            "entity_id": entity_id,
+            "from_date": from_date,
+            "to_date": to_date,
+        },
+    )
+
+
+# --- Raw listings (for lookups / joins) -------------------------------------
+
+
+@mcp.tool()
+def list_transactions(
+    account: Optional[str] = None,
+    type: Optional[str] = None,
+    is_closed: Optional[bool] = None,
+) -> Any:
+    """List raw transactions. Optional filters: account name, type
+    (income/purchase/payment/transfer), is_closed."""
+    return _get(
+        "transactions/",
+        {"account": account, "type": type, "is_closed": is_closed},
+    )
+
+
+@mcp.tool()
+def list_accounts(
+    type: Optional[str] = None, is_closed: Optional[bool] = None
+) -> Any:
+    """List the chart of accounts (id, name, type, sub_type). Filter by type
+    (asset/liability/income/expense/equity) or is_closed."""
+    return _get("accounts/", {"type": type, "is_closed": is_closed})
+
+
+@mcp.tool()
+def list_entities(is_closed: Optional[bool] = None) -> Any:
+    """List entities (payees/counterparties): id, name, is_closed."""
+    return _get("entities/", {"is_closed": is_closed})
+
+
+if __name__ == "__main__":
+    mcp.run()


### PR DESCRIPTION
## Context

Enables an agent (Claude Cowork) to work with production accounting data — answering spending questions, building dashboards, and writing summaries — **read-only**, with no direct database credentials.

Production data lives in Heroku Postgres. The app already had a rich statement engine (`IncomeStatement`, `BalanceSheet`, `CashFlowStatement`, `Trend`) that was never exposed as JSON, plus an API-key-secured `/api/v1/` REST surface. This PR bridges that gap.

## What's in it

**Part A — Read-only reporting endpoints** (`api/rest_api/report_views.py`, `report_serializers.py`)
GET-only routes under `/api/v1/reports/`:
- `income/` (`?group_by=entity` for a payee breakdown)
- `balance-sheet/`, `cash-flow/`, `spending-by-entity/`, `trend/`
- `account-detail/`, `entity-detail/` (line-item drill-downs)

They wrap the existing statement engine (no new business logic), ride the existing `LEDGER_API_KEY` auth, and default to the last full month when dates are omitted. Malformed date params return a structured 400 rather than silently defaulting to a different period.

**Part B — MCP server** (`mcp_server/`)
A thin `FastMCP` server exposing those endpoints as 10 typed agent tools (`get_income_statement`, `spending_by_entity`, …). It's an HTTP client over Part A — no DB access, read-only by construction — with a pooled `httpx.Client` reused across calls. Includes a README with the `.mcp.json` config and example prompts.

**Part C — Dashboards/summaries**
No app code — the agent generates standalone `dashboard.html` / `summary.md` artifacts from the tool output.

**Refactor:** extracts the triplicated "last full month" default into `utils.get_default_statement_date_range()`, now shared by the reporting API and the existing `StatementView`.

## Testing

- New `api/tests/rest_api/test_report_views.py` (13 tests): builds a real ledger and asserts endpoint shapes/values, API-key auth (403), required-param validation, and invalid-date 400s.
- Full suite green (612 tests); reporting + views + utils subsets verified.
- Smoke-tested live against a dev server with real data and confirmed the MCP server loads all 10 tools and calls the API successfully.

## Note

The reporting endpoints reuse the single shared `LEDGER_API_KEY`. If you'd like the agent to have a separate, independently-rotatable key, that's a small follow-up to `APIKeyAuthentication` (accept a set of keys) — left out as it wasn't in scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)