### PR TITLE
Show clear success/error messages on CSV & paystub uploads

### DIFF
--- a/api/models.py
+++ b/api/models.py
@@ -1,5 +1,6 @@
 import calendar
 import datetime
+import logging
 import math
 import re
 from decimal import ROUND_HALF_UP, Decimal
@@ -17,6 +18,8 @@ from api.aws_services import (
 )
 from api.utils import short_error_label
 from api.validators import non_zero
+
+logger = logging.getLogger(__name__)
 
 
 class Entity(models.Model):
@@ -1075,11 +1078,22 @@ class CSVProfile(models.Model):
 
         # Tag any transactions that match a parsed utility bill or a loan
         # schedule. Imported locally to avoid a models <-> services import cycle.
+        # This is a best-effort convenience tag, not part of the core import, so a
+        # failure here must never break the import or its returned count (which the
+        # upload view relies on to show a success message).
         from api.services.bill_services import match_transactions_to_bills
         from api.services.loan_services import match_transactions_to_loans
 
-        match_transactions_to_bills(created)
-        match_transactions_to_loans(created)
+        try:
+            match_transactions_to_bills(created)
+            match_transactions_to_loans(created)
+        except Exception:
+            logger.exception(
+                "Bill/loan matching failed after importing %d transactions for "
+                "account %s; import succeeded, tagging skipped.",
+                len(transactions_list),
+                account,
+            )
 
         return len(transactions_list)
 

--- a/api/services/transaction_upload_services.py
+++ b/api/services/transaction_upload_services.py
@@ -1,0 +1,54 @@
+"""
+Service functions for transaction CSV upload orchestration.
+
+Wraps the CSV import so parsing/import failures become clear, user-facing errors
+instead of an unhandled 500. Mirrors the result-dataclass pattern used by
+``api/services/paystub_upload_services.py``.
+"""
+import logging
+from dataclasses import dataclass
+from typing import Optional
+
+from api.forms import UploadTransactionsForm
+from api.models import Account
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class TransactionsUploadResult:
+    success: bool
+    count: int = 0
+    account: Optional[Account] = None
+    error: Optional[str] = None
+
+
+def import_transactions_from_csv(
+    form: UploadTransactionsForm,
+) -> TransactionsUploadResult:
+    """
+    Runs a validated ``UploadTransactionsForm``'s import inside error handling.
+
+    The form must already be validated by the caller. Any exception raised while
+    parsing/importing the CSV (e.g. unexpected columns or unparseable dates) is
+    logged and returned as a user-facing error, so the upload view can always
+    render a clear success or error message instead of returning a 500.
+
+    Returns:
+        TransactionsUploadResult with the imported ``count`` and ``account`` on
+        success, or ``success=False`` and an ``error`` message on failure.
+    """
+    account = form.cleaned_data["account"]
+    try:
+        count = form.save()
+    except Exception:
+        logger.exception("Failed to import transactions from CSV for account %s", account)
+        return TransactionsUploadResult(
+            success=False,
+            error=(
+                "We couldn't read that file. Check that it's the CSV exported for "
+                "this account and try again."
+            ),
+        )
+
+    return TransactionsUploadResult(success=True, count=count, account=account)

--- a/api/tests/models/test_csvprofile.py
+++ b/api/tests/models/test_csvprofile.py
@@ -1,3 +1,5 @@
+from unittest.mock import patch
+
 from django.test import TestCase
 from api.models import CSVColumnValuePair, Transaction, AutoTag
 from api.tests.testing_factories import CSVProfileFactory, AccountFactory, PrefillFactory
@@ -160,6 +162,23 @@ class CSVProfileModelTest(TestCase):
         self.assertEqual(transaction.type, Transaction.TransactionType.PURCHASE)
         transaction = Transaction.objects.get(description='Dividends')
         self.assertEqual(transaction.type, Transaction.TransactionType.INCOME)
+
+    def test_import_succeeds_when_bill_matching_raises(self):
+        # Bill/loan matching is best-effort tagging that runs after the import.
+        # If it raises, the import (and its returned count) must not break — the
+        # upload view relies on that count to show a success message.
+        copied_list = list(csv_data)
+        copied_list.append({})
+        account = AccountFactory()
+
+        with patch(
+            'api.services.bill_services.match_transactions_to_bills',
+            side_effect=Exception('boom'),
+        ):
+            count = self.csv_profile.create_transactions_from_csv(copied_list, account)
+
+        self.assertEqual(count, 3)
+        self.assertEqual(Transaction.objects.filter(account=account).count(), 3)
 
 
     # search_string = models.CharField(max_length=20)

--- a/api/tests/services/test_transaction_upload_services.py
+++ b/api/tests/services/test_transaction_upload_services.py
@@ -1,0 +1,52 @@
+from unittest.mock import patch
+
+from django.core.files.uploadedfile import SimpleUploadedFile
+from django.test import TestCase
+
+from api.forms import UploadTransactionsForm
+from api.services.transaction_upload_services import import_transactions_from_csv
+from api.tests.testing_factories import AccountFactory
+
+
+class ImportTransactionsFromCsvTest(TestCase):
+    def setUp(self):
+        # AccountFactory attaches a csv_profile, so the account passes the form's
+        # queryset filter (Account.objects.filter(csv_profile__isnull=False)).
+        self.account = AccountFactory()
+
+    def _valid_form(self):
+        upload = SimpleUploadedFile(
+            "transactions.csv", b"date,amount\n", content_type="text/csv"
+        )
+        form = UploadTransactionsForm(
+            {"account": self.account.pk}, {"transaction_csv": upload}
+        )
+        self.assertTrue(form.is_valid(), form.errors)
+        return form
+
+    def test_successful_import_returns_count_and_account(self):
+        form = self._valid_form()
+        with patch.object(form, "save", return_value=5):
+            result = import_transactions_from_csv(form)
+
+        self.assertTrue(result.success)
+        self.assertEqual(result.count, 5)
+        self.assertEqual(result.account, self.account)
+        self.assertIsNone(result.error)
+
+    def test_zero_rows_is_still_success(self):
+        form = self._valid_form()
+        with patch.object(form, "save", return_value=0):
+            result = import_transactions_from_csv(form)
+
+        self.assertTrue(result.success)
+        self.assertEqual(result.count, 0)
+        self.assertEqual(result.account, self.account)
+
+    def test_exception_during_import_returns_error(self):
+        form = self._valid_form()
+        with patch.object(form, "save", side_effect=Exception("bad columns")):
+            result = import_transactions_from_csv(form)
+
+        self.assertFalse(result.success)
+        self.assertIsNotNone(result.error)

--- a/api/tests/test_frontend_views.py
+++ b/api/tests/test_frontend_views.py
@@ -103,15 +103,19 @@ class UploadTransactionsViewTest(TestCase):
         response = self.client.get(reverse('upload-transactions'))
         self.assertEqual(response.status_code, 200)
 
-    def test_post_with_invalid_paystub_form_returns_200(self):
-        """POST with 'paystubs' key but missing required fields should re-render the form."""
+    def test_post_with_invalid_paystub_form_shows_error(self):
+        """POST with 'paystubs' key but missing required fields re-renders the form
+        with a visible error alert instead of silently."""
         response = self.client.post(reverse('upload-transactions'), {"paystubs": ""})
         self.assertEqual(response.status_code, 200)
+        self.assertContains(response, "alert-danger")
 
-    def test_post_with_invalid_transactions_form_returns_200(self):
-        """POST with 'transactions' key but missing required fields should re-render the form."""
+    def test_post_with_invalid_transactions_form_shows_error(self):
+        """POST with 'transactions' key but missing required fields re-renders the
+        form with a visible error alert instead of silently."""
         response = self.client.post(reverse('upload-transactions'), {"transactions": ""})
         self.assertEqual(response.status_code, 200)
+        self.assertContains(response, "alert-danger")
 
     def test_post_with_no_form_type_returns_400(self):
         """POST with neither 'transactions' nor 'paystubs' should return 400."""

--- a/api/views/frontend_views.py
+++ b/api/views/frontend_views.py
@@ -10,12 +10,22 @@ from api import utils
 from api.forms import DocumentForm, UploadTransactionsForm, WalletForm
 from api.services.paystub_services import get_paystubs_table_data
 from api.services.paystub_upload_services import process_paystub_upload
+from api.services.transaction_upload_services import import_transactions_from_csv
 from api.statement import Trend
 from api.views.journal_entry_helpers import (
     render_paystubs_table,
     render_paystubs_table_oob_swap,
 )
 from api.views.page_utils import render_full_page
+
+
+def _flatten_form_errors(form) -> str:
+    """Join a form's validation errors into a single user-facing sentence."""
+    messages = []
+    for field, errors in form.errors.items():
+        label = "" if field == "__all__" else f"{field.replace('_', ' ')}: "
+        messages.extend(f"{label}{error}" for error in errors)
+    return " ".join(messages) or "Please correct the highlighted fields."
 
 
 class UploadTransactionsView(View):
@@ -25,11 +35,17 @@ class UploadTransactionsView(View):
         template = "api/entry_forms/textract-form.html"
         return render_to_string(template, {"form": form, "filename": filename, "error": error})
 
-    def get_csv_form_html(self, transactions_count=None, account=None):
+    def get_csv_form_html(self, transactions_count=None, account=None, error=None):
         form = UploadTransactionsForm()
         template = "api/entry_forms/upload-form.html"
         return render_to_string(
-            template, {"form": form, "count": transactions_count, "account": account}
+            template,
+            {
+                "form": form,
+                "count": transactions_count,
+                "account": account,
+                "error": error,
+            },
         )
 
     def get(self, request):
@@ -51,25 +67,29 @@ class UploadTransactionsView(View):
 
     def handle_transactions_form(self, request):
         form = UploadTransactionsForm(request.POST, request.FILES)
-        if form.is_valid():
-            transactions_count = form.save()
-            return self.get_csv_form_html(
-                transactions_count=transactions_count, account=form.cleaned_data["account"]
-            )
-        return self.get_csv_form_html()
+        if not form.is_valid():
+            return self.get_csv_form_html(error=_flatten_form_errors(form))
+
+        result = import_transactions_from_csv(form)
+        if not result.success:
+            return self.get_csv_form_html(error=result.error)
+        return self.get_csv_form_html(
+            transactions_count=result.count, account=result.account
+        )
 
     def handle_paystubs_form(self, request):
         form = DocumentForm(request.POST, request.FILES)
-        if form.is_valid():
-            result = process_paystub_upload(
-                file=form.cleaned_data["document"],
-                prefill=form.cleaned_data["prefill"],
-            )
-            if not result.success:
-                return self.get_textract_form_html(error=result.error)
-            filename = result.s3file.user_filename if result.s3file else None
-            return self.get_textract_form_html(filename=filename)
-        return self.get_textract_form_html()
+        if not form.is_valid():
+            return self.get_textract_form_html(error=_flatten_form_errors(form))
+
+        result = process_paystub_upload(
+            file=form.cleaned_data["document"],
+            prefill=form.cleaned_data["prefill"],
+        )
+        if not result.success:
+            return self.get_textract_form_html(error=result.error)
+        filename = result.s3file.user_filename if result.s3file else None
+        return self.get_textract_form_html(filename=filename)
 
     def post(self, request):
 

--- a/ledger/templates/api/entry_forms/upload-form.html
+++ b/ledger/templates/api/entry_forms/upload-form.html
@@ -23,8 +23,14 @@
     <button type="submit" name="transactions" class="btn btn-primary">Submit</button>
 </form>
 
-{% if count %}
+{% if error %}
+<div class="alert alert-danger mt-3" role="alert">{{ error }}</div>
+{% elif count %}
 <div class="alert alert-success mt-3" role="alert">
     Uploaded {{ count }} transactions to {{ account.name }}
+</div>
+{% elif count == 0 %}
+<div class="alert alert-info mt-3" role="alert">
+    No transactions were found in that file.
 </div>
 {% endif %}


### PR DESCRIPTION
## Problem

Uploading a CSV on the Upload Files page produced **no feedback at all — not even on a successful upload**. The transactions were created, but `CSVProfile.create_transactions_from_csv` runs best-effort bill/loan matching *after* `bulk_create` and *before* returning its count. If that matching raised, the request returned a **500**, and htmx silently discards non-200 responses — so nothing swapped into `#csv-upload` and the user saw nothing. Failure modes (invalid form, zero rows) were silent too, and the paystub form had the same silent invalid-form gap.

## Changes

- **Harden the import** (`api/models.py`): isolate the `match_transactions_to_bills`/`match_transactions_to_loans` calls in a `try/except` so a completed import always returns its count and never 500s on best-effort tagging.
- **New thin service** (`api/services/transaction_upload_services.py`): `import_transactions_from_csv(form)` returns a `TransactionsUploadResult` (success/count/account/error), mirroring `process_paystub_upload`/`UploadResult`, turning parse failures into user-facing errors.
- **Always return a 200 with feedback** (`api/views/frontend_views.py`): invalid forms render an error alert via a new `_flatten_form_errors` helper instead of re-rendering silently; the CSV handler routes through the service.
- **CSV template** (`upload-form.html`): success alert, an `alert-info` "No transactions were found in that file." for empty files, and an `alert-danger` for errors.
- **Paystub handler**: closes the same silent invalid-form gap (success copy unchanged — async parse status still shows in the poller table).

## Tests

- New `test_transaction_upload_services.py` — success / zero-row / exception paths.
- Regression test in `test_csvprofile.py` — a failing bill match no longer breaks the import's returned count.
- Strengthened the two frontend view tests to assert the error alerts actually render.

All non-e2e tests pass. (The one failing test, `test_settings_playwright`, is an unrelated `@tag("e2e")` browser smoke test for the Settings page.)

## Verification

`uv run python manage.py runserver` → Upload Files:
- Valid CSV for a matching account → green "Uploaded N transactions to <account>" (this is the reported bug — the message now appears).
- CSV that doesn't match the account's profile → blue "No transactions were found in that file." (no 500).
- Malformed file / no file → red error alert.
- Paystub with no file → red error alert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)