### PR TITLE
Extract advisory bill/loan tagging into a shared service

### DIFF
--- a/api/models.py
+++ b/api/models.py
@@ -1,6 +1,5 @@
 import calendar
 import datetime
-import logging
 import math
 import re
 from decimal import ROUND_HALF_UP, Decimal
@@ -18,8 +17,6 @@ from api.aws_services import (
 )
 from api.utils import short_error_label
 from api.validators import non_zero
-
-logger = logging.getLogger(__name__)
 
 
 class Entity(models.Model):
@@ -1076,26 +1073,11 @@ class CSVProfile(models.Model):
         Transaction.apply_autotags(transactions_list)
         created = Transaction.objects.bulk_create(transactions_list)
 
-        # Tag any transactions that match a parsed utility bill or a loan
-        # schedule. Imported locally to avoid a models <-> services import cycle.
-        # This is a best-effort convenience tag, not part of the core import, so a
-        # failure here must never break the import or its returned count (which the
-        # upload view relies on to show a success message).
-        from api.services.bill_services import match_transactions_to_bills
-        from api.services.loan_services import match_transactions_to_loans
-
-        try:
-            match_transactions_to_bills(created)
-            match_transactions_to_loans(created)
-        except Exception:
-            logger.exception(
-                "Bill/loan matching failed after importing %d transactions for "
-                "account %s; import succeeded, tagging skipped.",
-                len(transactions_list),
-                account,
-            )
-
-        return len(transactions_list)
+        # Best-effort bill/loan tagging is applied by the caller (the upload
+        # service) via api.services.tagging_services, keeping the models layer
+        # free of service imports. Return the created objects so the caller can
+        # tag them; callers wanting a count use len(...).
+        return created
 
     def _get_formatted_date(self, date_string):
         # Parse the original date using the input format

--- a/api/services/journal_entry_services.py
+++ b/api/services/journal_entry_services.py
@@ -10,6 +10,7 @@ from django.forms import BaseModelFormSet, modelformset_factory
 
 from api.forms import BaseJournalEntryItemFormset, JournalEntryItemForm
 from api.models import Account, Entity, JournalEntry, JournalEntryItem, Paystub, PaystubValue, Transaction
+from api.services.tagging_services import tag_transactions
 
 
 # Cached formset factory - created once at module load
@@ -543,7 +544,8 @@ def apply_autotags_to_open_transactions() -> int:
     )
 
     # Also re-attempt utility-bill matches so newly-arrived bills get applied.
-    from api.services.bill_services import match_transactions_to_bills
-
-    match_transactions_to_bills(open_transactions)
+    # Bills only: loan matching creates schedule rows and isn't safe to re-run on
+    # already-matched transactions. Isolated so a matcher failure can't break the
+    # re-tag (see api.services.tagging_services).
+    tag_transactions(open_transactions, include_loans=False)
     return len(open_transactions)

--- a/api/services/tagging_services.py
+++ b/api/services/tagging_services.py
@@ -1,0 +1,46 @@
+"""
+Advisory transaction tagging.
+
+Bill/loan matching is best-effort tagging: it sets suggested_account/entity/type
+so imported transactions surface pre-filled in the review table. It is never part
+of the core write, so a matcher blowing up must never break the operation that
+triggered it (a CSV import, the autotag re-apply). This module owns that
+isolation invariant in one place so every caller behaves the same.
+"""
+import logging
+from typing import Callable, Iterable, List
+
+from api.models import Transaction
+from api.services.bill_services import match_transactions_to_bills
+from api.services.loan_services import match_transactions_to_loans
+
+logger = logging.getLogger(__name__)
+
+Matcher = Callable[[Iterable[Transaction]], int]
+
+
+def _run_advisory(matcher: Matcher, transactions: Iterable[Transaction]) -> None:
+    """Run one matcher, swallowing + logging any failure. Matching is
+    best-effort tagging and must never break its caller."""
+    try:
+        matcher(transactions)
+    except Exception:
+        logger.exception(
+            "Advisory matcher %s failed; tagging skipped.", matcher.__name__
+        )
+
+
+def tag_transactions(
+    transactions: List[Transaction], *, include_loans: bool = True
+) -> None:
+    """
+    Bill (and, by default, loan) matching over ``transactions``, isolated so a
+    matcher failure never breaks the caller.
+
+    Loan matching creates schedule rows and links transactions, so it isn't safe
+    to re-run on already-matched transactions; callers that re-tag existing
+    transactions pass ``include_loans=False``.
+    """
+    _run_advisory(match_transactions_to_bills, transactions)
+    if include_loans:
+        _run_advisory(match_transactions_to_loans, transactions)

--- a/api/services/transaction_upload_services.py
+++ b/api/services/transaction_upload_services.py
@@ -1,9 +1,10 @@
 """
 Service functions for transaction CSV upload orchestration.
 
-Wraps the CSV import so parsing/import failures become clear, user-facing errors
-instead of an unhandled 500. Mirrors the result-dataclass pattern used by
-``api/services/paystub_upload_services.py``.
+Owns the import-and-tag unit of work: creates the transactions from the CSV, then
+runs best-effort bill/loan tagging. Parsing/import failures become clear,
+user-facing errors instead of an unhandled 500. Mirrors the result-dataclass
+pattern used by ``api/services/paystub_upload_services.py``.
 """
 import logging
 from dataclasses import dataclass
@@ -11,6 +12,7 @@ from typing import Optional
 
 from api.forms import UploadTransactionsForm
 from api.models import Account
+from api.services.tagging_services import tag_transactions
 
 logger = logging.getLogger(__name__)
 
@@ -27,12 +29,15 @@ def import_transactions_from_csv(
     form: UploadTransactionsForm,
 ) -> TransactionsUploadResult:
     """
-    Runs a validated ``UploadTransactionsForm``'s import inside error handling.
+    Imports a validated ``UploadTransactionsForm``, then applies best-effort
+    bill/loan tagging to the created transactions.
 
     The form must already be validated by the caller. Any exception raised while
     parsing/importing the CSV (e.g. unexpected columns or unparseable dates) is
     logged and returned as a user-facing error, so the upload view can always
-    render a clear success or error message instead of returning a 500.
+    render a clear success or error message instead of returning a 500. Tagging
+    runs after the import and isolates its own failures (see
+    ``api.services.tagging_services``), so it never affects the returned count.
 
     Returns:
         TransactionsUploadResult with the imported ``count`` and ``account`` on
@@ -40,7 +45,7 @@ def import_transactions_from_csv(
     """
     account = form.cleaned_data["account"]
     try:
-        count = form.save()
+        transactions = form.save()
     except Exception:
         logger.exception("Failed to import transactions from CSV for account %s", account)
         return TransactionsUploadResult(
@@ -51,4 +56,7 @@ def import_transactions_from_csv(
             ),
         )
 
-    return TransactionsUploadResult(success=True, count=count, account=account)
+    tag_transactions(transactions)
+    return TransactionsUploadResult(
+        success=True, count=len(transactions), account=account
+    )

--- a/api/tests/models/test_csvprofile.py
+++ b/api/tests/models/test_csvprofile.py
@@ -1,5 +1,3 @@
-from unittest.mock import patch
-
 from django.test import TestCase
 from api.models import CSVColumnValuePair, Transaction, AutoTag
 from api.tests.testing_factories import CSVProfileFactory, AccountFactory, PrefillFactory
@@ -162,23 +160,6 @@ class CSVProfileModelTest(TestCase):
         self.assertEqual(transaction.type, Transaction.TransactionType.PURCHASE)
         transaction = Transaction.objects.get(description='Dividends')
         self.assertEqual(transaction.type, Transaction.TransactionType.INCOME)
-
-    def test_import_succeeds_when_bill_matching_raises(self):
-        # Bill/loan matching is best-effort tagging that runs after the import.
-        # If it raises, the import (and its returned count) must not break — the
-        # upload view relies on that count to show a success message.
-        copied_list = list(csv_data)
-        copied_list.append({})
-        account = AccountFactory()
-
-        with patch(
-            'api.services.bill_services.match_transactions_to_bills',
-            side_effect=Exception('boom'),
-        ):
-            count = self.csv_profile.create_transactions_from_csv(copied_list, account)
-
-        self.assertEqual(count, 3)
-        self.assertEqual(Transaction.objects.filter(account=account).count(), 3)
 
 
     # search_string = models.CharField(max_length=20)

--- a/api/tests/services/test_tagging_services.py
+++ b/api/tests/services/test_tagging_services.py
@@ -1,0 +1,44 @@
+from unittest.mock import patch
+
+from django.test import TestCase
+
+from api.services.tagging_services import tag_transactions
+
+
+class TagTransactionsTest(TestCase):
+    def test_runs_bills_and_loans_by_default(self):
+        with patch(
+            "api.services.tagging_services.match_transactions_to_bills", autospec=True
+        ) as mock_bills, patch(
+            "api.services.tagging_services.match_transactions_to_loans", autospec=True
+        ) as mock_loans:
+            tag_transactions(["txn"])
+
+        mock_bills.assert_called_once_with(["txn"])
+        mock_loans.assert_called_once_with(["txn"])
+
+    def test_skips_loans_when_include_loans_false(self):
+        with patch(
+            "api.services.tagging_services.match_transactions_to_bills", autospec=True
+        ) as mock_bills, patch(
+            "api.services.tagging_services.match_transactions_to_loans", autospec=True
+        ) as mock_loans:
+            tag_transactions(["txn"], include_loans=False)
+
+        mock_bills.assert_called_once_with(["txn"])
+        mock_loans.assert_not_called()
+
+    def test_matcher_failure_is_isolated(self):
+        # A matcher blowing up must never propagate to the caller (a failed bill
+        # match can't break a CSV import or the autotag re-apply).
+        with patch(
+            "api.services.tagging_services.match_transactions_to_bills",
+            autospec=True,
+            side_effect=Exception("boom"),
+        ), patch(
+            "api.services.tagging_services.match_transactions_to_loans", autospec=True
+        ) as mock_loans:
+            tag_transactions(["txn"])  # must not raise
+
+        # Loan matching still runs even after bill matching fails.
+        mock_loans.assert_called_once_with(["txn"])

--- a/api/tests/services/test_transaction_upload_services.py
+++ b/api/tests/services/test_transaction_upload_services.py
@@ -25,18 +25,26 @@ class ImportTransactionsFromCsvTest(TestCase):
         return form
 
     def test_successful_import_returns_count_and_account(self):
+        # form.save() returns the created transactions; the service counts them
+        # and tags them (tagging is exercised in test_tagging_services).
         form = self._valid_form()
-        with patch.object(form, "save", return_value=5):
+        created = [object(), object(), object(), object(), object()]
+        with patch.object(form, "save", return_value=created), patch(
+            "api.services.transaction_upload_services.tag_transactions"
+        ) as mock_tag:
             result = import_transactions_from_csv(form)
 
         self.assertTrue(result.success)
         self.assertEqual(result.count, 5)
         self.assertEqual(result.account, self.account)
         self.assertIsNone(result.error)
+        mock_tag.assert_called_once_with(created)
 
     def test_zero_rows_is_still_success(self):
         form = self._valid_form()
-        with patch.object(form, "save", return_value=0):
+        with patch.object(form, "save", return_value=[]), patch(
+            "api.services.transaction_upload_services.tag_transactions"
+        ):
             result = import_transactions_from_csv(form)
 
         self.assertTrue(result.success)


### PR DESCRIPTION
## What & why

Bill/loan matching is best-effort tagging that must never break the operation that triggers it. After #402 that invariant lived as a **special case bolted onto one caller** — a `try/except` inside `CSVProfile.create_transactions_from_csv` (which also reached *up* from the models layer into the services layer). Meanwhile the "re-apply autotags to open transactions" path ran the same matcher with **no isolation at all**, so the exact failure a CSV import now survived would still 500 that path.

This PR owns the invariant in one place.

## Changes

- **New `api/services/tagging_services.py`** — `tag_transactions(transactions, *, include_loans=True)` runs bill (and optionally loan) matching, isolating each matcher's failure via a single `_run_advisory` wrapper so it can never break the caller.
- **`api/models.py`** — `create_transactions_from_csv` goes back to just creating transactions and returning the created list. The models layer no longer imports the services layer (removed the local `from api.services...` imports + the unused `logging`).
- **`api/services/transaction_upload_services.py`** — `import_transactions_from_csv` now genuinely owns the import-and-tag unit of work (`form.save()` to create, then `tag_transactions`), instead of being a passthrough shim.
- **`api/services/journal_entry_services.py`** — `apply_autotags_to_open_transactions` routes through `tag_transactions(..., include_loans=False)` and **gains failure isolation it previously lacked**. Bills-only is deliberate: loan matching creates schedule rows and isn't safe to re-run on already-matched transactions.

## Behavior

No user-facing change. #402's upload success/error messages are fully preserved; the autotag path additionally survives a matcher failure now.

## Tests

- New `api/tests/services/test_tagging_services.py` covers failure isolation and the `include_loans` toggle (the model-level isolation test moves here out of `test_csvprofile.py`).
- Full suite green excluding the pre-existing `@tag("e2e")` Playwright Settings flake (unrelated to this change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0174xTpCw8XLgrR8LYpUS3ip