### PR TITLE
Add Autotags settings section (CRUD + re-apply)

### DIFF
--- a/api/forms.py
+++ b/api/forms.py
@@ -15,6 +15,7 @@ from api.services.tax_services import get_tax_accounts
 from api.models import (
     Account,
     Amortization,
+    AutoTag,
     CSVProfile,
     DocSearch,
     Entity,
@@ -709,6 +710,39 @@ class DocSearchForm(forms.ModelForm):
             "account",
             "journal_entry_item_type",
             "selection",
+            "entity",
+        ]
+
+
+class AutoTagForm(forms.ModelForm):
+    """User-facing form for creating/editing autotags via the Settings page.
+
+    An autotag is a rule: when ``search_string`` appears (case-insensitively) in
+    an incoming transaction's description, the transaction is pre-filled with the
+    tag's account/entity/prefill and transaction type. Only ``search_string`` is
+    required; the target fields are optional. Mirrors ``UtilityBillRuleForm``.
+    """
+
+    account = forms.ModelChoiceField(
+        queryset=Account.objects.filter(is_closed=False).order_by("name"),
+        required=False,
+    )
+    prefill = forms.ModelChoiceField(
+        queryset=Prefill.objects.filter(is_closed=False).order_by("name"),
+        required=False,
+    )
+    entity = forms.ModelChoiceField(
+        queryset=Entity.objects.all().order_by("name"),
+        required=False,
+    )
+
+    class Meta:
+        model = AutoTag
+        fields = [
+            "search_string",
+            "account",
+            "transaction_type",
+            "prefill",
             "entity",
         ]
 

--- a/api/services/autotag_services.py
+++ b/api/services/autotag_services.py
@@ -1,0 +1,80 @@
+"""
+Service layer for AutoTag config CRUD (Settings page).
+
+An AutoTag is a rule: when its ``search_string`` appears (case-insensitively) in
+an incoming transaction's description, the transaction is pre-filled with the
+tag's account/entity/prefill and transaction type (see
+``Transaction.apply_autotags``). This module exposes the list/create/update/
+delete operations the Settings UI needs, delegating writes to the shared
+``crud`` helpers.
+
+Mirrors ``entity_services`` (single-model config CRUD).
+"""
+
+from dataclasses import dataclass
+from typing import Any, Dict, List, Optional, Tuple
+
+from api.models import Account, AutoTag, Entity, Prefill
+from api.services import crud
+
+
+@dataclass
+class AutoTagResult:
+    """Result of an autotag create/update/delete operation."""
+    success: bool
+    autotag: Optional[AutoTag] = None
+    error: Optional[str] = None
+
+
+def get_autotags() -> List[AutoTag]:
+    """Returns all autotags ordered by search string, with the account
+    pre-fetched for the list display (the only relation the list renders)."""
+    return list(
+        AutoTag.objects.select_related("account").order_by("search_string")
+    )
+
+
+def get_autotag_form_options() -> Tuple[List[Account], List[Prefill], List[Entity]]:
+    """Returns the DB-backed dropdown options for the AutoTag form: open
+    accounts, open prefills, and all entities. The static transaction-type
+    choices live on ``Transaction.TransactionType`` and are supplied by the
+    helper, matching ``get_docsearch_form_options``."""
+    accounts = list(Account.objects.filter(is_closed=False).order_by("name"))
+    prefills = list(Prefill.objects.filter(is_closed=False).order_by("name"))
+    entities = list(Entity.objects.all().order_by("name"))
+    return accounts, prefills, entities
+
+
+AUTOTAG_FIELDS = (
+    "search_string",
+    "account",
+    "transaction_type",
+    "prefill",
+    "entity",
+)
+
+
+def save_autotag(
+    cleaned_data: Dict[str, Any], instance: Optional[AutoTag] = None
+) -> AutoTagResult:
+    """Creates or updates an autotag from validated form data. ``instance`` is
+    the autotag being edited (None to create)."""
+    autotag, error = crud.save_model(
+        AutoTag, AUTOTAG_FIELDS, cleaned_data, instance
+    )
+    return AutoTagResult(success=error is None, autotag=autotag, error=error)
+
+
+def delete_autotag(autotag_id: int) -> AutoTagResult:
+    """Deletes an autotag by pk.
+
+    Nothing references AutoTag and its own FKs are CASCADE, so a ProtectedError
+    isn't expected; the shared helper still handles it for parity.
+    """
+    autotag, error = crud.delete_model(
+        AutoTag,
+        autotag_id,
+        not_found="Auto tag not found.",
+        protected="Can't delete this auto tag — it's still referenced.",
+    )
+    return AutoTagResult(success=error is None, autotag=autotag, error=error)

--- a/api/tests/services/test_autotag_services.py
+++ b/api/tests/services/test_autotag_services.py
@@ -1,0 +1,125 @@
+"""Tests for autotag_services — the Settings CRUD over AutoTags."""
+
+from django.test import TestCase
+
+from api.models import AutoTag, Transaction
+from api.services.autotag_services import (
+    AutoTagResult,
+    delete_autotag,
+    get_autotag_form_options,
+    get_autotags,
+    save_autotag,
+)
+from api.tests.testing_factories import (
+    AccountFactory,
+    AutoTagFactory,
+    EntityFactory,
+    PrefillFactory,
+)
+
+
+class GetAutotagsTest(TestCase):
+    """Tests for get_autotags() — the Settings list query."""
+
+    def test_orders_by_search_string(self):
+        AutoTagFactory(search_string="charlie")
+        AutoTagFactory(search_string="alpha")
+        AutoTagFactory(search_string="bravo")
+
+        strings = [t.search_string for t in get_autotags()]
+        self.assertEqual(strings, ["alpha", "bravo", "charlie"])
+
+
+class SaveAutotagTest(TestCase):
+    """Tests for save_autotag() create/update."""
+
+    def test_creates_autotag(self):
+        account = AccountFactory()
+        result = save_autotag(
+            {
+                "search_string": "amazon",
+                "account": account,
+                "transaction_type": Transaction.TransactionType.PURCHASE,
+                "prefill": None,
+                "entity": None,
+            }
+        )
+
+        self.assertIsInstance(result, AutoTagResult)
+        self.assertTrue(result.success)
+        self.assertEqual(result.autotag.search_string, "amazon")
+        self.assertEqual(result.autotag.account_id, account.id)
+        self.assertEqual(AutoTag.objects.count(), 1)
+
+    def test_creates_autotag_with_only_search_string(self):
+        result = save_autotag(
+            {
+                "search_string": "venmo",
+                "account": None,
+                "transaction_type": "",
+                "prefill": None,
+                "entity": None,
+            }
+        )
+
+        self.assertTrue(result.success)
+        self.assertIsNone(result.autotag.account)
+        self.assertEqual(AutoTag.objects.count(), 1)
+
+    def test_updates_autotag(self):
+        autotag = AutoTagFactory(search_string="old")
+        entity = EntityFactory()
+
+        result = save_autotag(
+            {
+                "search_string": "new",
+                "account": autotag.account,
+                "transaction_type": Transaction.TransactionType.INCOME,
+                "prefill": None,
+                "entity": entity,
+            },
+            instance=autotag,
+        )
+
+        self.assertTrue(result.success)
+        autotag.refresh_from_db()
+        self.assertEqual(autotag.search_string, "new")
+        self.assertEqual(autotag.entity_id, entity.id)
+        self.assertEqual(AutoTag.objects.count(), 1)
+
+
+class DeleteAutotagTest(TestCase):
+    """Tests for delete_autotag()."""
+
+    def test_deletes_autotag(self):
+        autotag = AutoTagFactory()
+
+        result = delete_autotag(autotag.id)
+
+        self.assertTrue(result.success)
+        self.assertEqual(AutoTag.objects.count(), 0)
+
+    def test_not_found_returns_error(self):
+        result = delete_autotag(999)
+
+        self.assertFalse(result.success)
+        self.assertEqual(result.error, "Auto tag not found.")
+
+
+class GetAutotagFormOptionsTest(TestCase):
+    """Tests for get_autotag_form_options() — the dropdown options."""
+
+    def test_excludes_closed_accounts_and_prefills(self):
+        open_account = AccountFactory(is_closed=False)
+        AccountFactory(is_closed=True)
+        open_prefill = PrefillFactory(is_closed=False)
+        PrefillFactory(is_closed=True)
+        entity = EntityFactory()
+
+        accounts, prefills, entities = get_autotag_form_options()
+
+        self.assertIn(open_account, accounts)
+        self.assertTrue(all(not a.is_closed for a in accounts))
+        self.assertIn(open_prefill, prefills)
+        self.assertTrue(all(not p.is_closed for p in prefills))
+        self.assertIn(entity, entities)

--- a/api/tests/views/test_autotag_settings_views.py
+++ b/api/tests/views/test_autotag_settings_views.py
@@ -1,0 +1,102 @@
+"""Tests for the Autotags Settings section HTMX views."""
+
+from django.urls import reverse
+
+from api.models import AutoTag, Transaction
+from api.tests.test_helpers import HTMXViewTestCase
+from api.tests.testing_factories import (
+    AccountFactory,
+    AutoTagFactory,
+)
+
+
+class AutoTagSettingsViewTest(HTMXViewTestCase):
+    def test_requires_login(self):
+        self.client.logout()
+        response = self.client.get(reverse("settings-autotags"))
+        self.assertEqual(response.status_code, 302)
+        self.assertIn("/login/", response.url)
+
+    def test_panel_loads_and_lists_autotags(self):
+        AutoTagFactory(search_string="listedtag")
+
+        response = self.client.get(reverse("settings-autotags"))
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, "listedtag")
+        self.assertContains(response, "Auto Tags")
+        # The re-apply button reuses the existing trigger endpoint.
+        self.assertContains(response, reverse("trigger-autotag"))
+
+    def test_new_autotag_form_view(self):
+        response = self.client.get(reverse("settings-autotag-new-form"))
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, "New auto tag")
+        # No Delete button on a blank create form.
+        self.assertNotContains(response, 'value="delete"')
+
+    def test_autotag_form_view_loads_autotag(self):
+        autotag = AutoTagFactory(search_string="editable")
+        response = self.client.get(
+            reverse("settings-autotag-form", args=[autotag.id])
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, "editable")
+        self.assertContains(response, 'value="delete"')
+
+    def test_create_autotag(self):
+        account = AccountFactory(is_closed=False)
+        data = {
+            "action": "save",
+            "search_string": "amazon",
+            "account": str(account.id),
+            "transaction_type": Transaction.TransactionType.PURCHASE,
+            "prefill": "",
+            "entity": "",
+        }
+        response = self.client.post(reverse("settings-autotags"), data=data)
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue(AutoTag.objects.filter(search_string="amazon").exists())
+        self.assertContains(response, "Auto tag created.")
+
+    def test_update_autotag(self):
+        account = AccountFactory(is_closed=False)
+        autotag = AutoTagFactory(search_string="before", account=account)
+        data = {
+            "action": "save",
+            "search_string": "after",
+            "account": str(autotag.account_id),
+            "transaction_type": Transaction.TransactionType.INCOME,
+            "prefill": "",
+            "entity": "",
+        }
+        response = self.client.post(
+            reverse("settings-autotag", args=[autotag.id]), data=data
+        )
+        self.assertEqual(response.status_code, 200)
+        autotag.refresh_from_db()
+        self.assertEqual(autotag.search_string, "after")
+        self.assertContains(response, "Auto tag updated.")
+
+    def test_delete_autotag(self):
+        autotag = AutoTagFactory()
+        response = self.client.post(
+            reverse("settings-autotag", args=[autotag.id]),
+            data={"action": "delete"},
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertFalse(AutoTag.objects.filter(pk=autotag.id).exists())
+        self.assertContains(response, "Auto tag deleted.")
+
+    def test_create_without_search_string_shows_form_error(self):
+        data = {
+            "action": "save",
+            "search_string": "",
+            "account": "",
+            "transaction_type": "",
+            "prefill": "",
+            "entity": "",
+        }
+        response = self.client.post(reverse("settings-autotags"), data=data)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(AutoTag.objects.count(), 0)
+        self.assertContains(response, "This field is required")

--- a/api/views/autotag_settings_helpers.py
+++ b/api/views/autotag_settings_helpers.py
@@ -1,0 +1,60 @@
+"""
+Helper functions for rendering the Autotags Settings section.
+
+Pure functions that take data and return HTML strings via ``render_to_string``.
+No database writes and no business logic. Mirrors ``entity_settings_helpers``.
+"""
+
+from typing import List, Optional
+
+from django.template.loader import render_to_string
+
+from api.forms import AutoTagForm
+from api.models import Account, AutoTag, Entity, Prefill, Transaction
+from api.views.form_helpers import resolve_form_values
+
+
+def render_autotags_content(
+    autotags: List[AutoTag],
+    autotag_form_html: str,
+    selected_id: Optional[int] = None,
+) -> str:
+    """Combines the header + table + form into the swappable Autotags fragment."""
+    return render_to_string(
+        "api/content/autotags-content.html",
+        {
+            "autotags": autotags,
+            "total": len(autotags),
+            "selected_id": selected_id,
+            "autotag_form": autotag_form_html,
+        },
+    )
+
+
+def render_autotag_form(
+    accounts: List[Account],
+    prefills: List[Prefill],
+    entities: List[Entity],
+    autotag: Optional[AutoTag] = None,
+    change: Optional[str] = None,
+    error: Optional[str] = None,
+    form: Optional[AutoTagForm] = None,
+) -> str:
+    """Renders the autotag add/edit form HTML."""
+    context = {
+        "accounts": accounts,
+        "prefills": prefills,
+        "entities": entities,
+        "type_choices": Transaction.TransactionType.choices,
+        "autotag": autotag,
+        "change": change,
+        "error": error,
+        "form": form,
+        "values": resolve_form_values(
+            autotag,
+            form,
+            text=("search_string", "transaction_type"),
+            fks=("account", "prefill", "entity"),
+        ),
+    }
+    return render_to_string("api/entry_forms/autotag-form.html", context)

--- a/api/views/autotag_settings_views.py
+++ b/api/views/autotag_settings_views.py
@@ -1,0 +1,134 @@
+"""
+Views for the Autotags Settings section.
+
+Loaded as an HTML fragment into the Settings shell: config CRUD over AutoTag
+(mirrors EntitySettingsView / PrefillSettingsView).
+
+Views parse requests, call services for business logic, and call helpers for
+rendering. No database writes and no HTML building here.
+"""
+
+from typing import Optional
+
+from django.contrib.auth.mixins import LoginRequiredMixin
+from django.http import HttpResponse
+from django.shortcuts import get_object_or_404
+from django.views import View
+
+from api.forms import AutoTagForm
+from api.models import AutoTag
+from api.services import autotag_services
+from api.views import autotag_settings_helpers
+
+
+class AutoTagSettingsView(LoginRequiredMixin, View):
+    login_url = "/login/"
+    redirect_field_name = "next"
+
+    def _render_content(
+        self,
+        autotag: Optional[AutoTag] = None,
+        change: Optional[str] = None,
+        error: Optional[str] = None,
+        form: Optional[AutoTagForm] = None,
+        selected_id: Optional[int] = None,
+    ) -> str:
+        """Builds the swappable Autotags fragment (header + table + form)."""
+        accounts, prefills, entities = autotag_services.get_autotag_form_options()
+        autotag_form_html = autotag_settings_helpers.render_autotag_form(
+            accounts=accounts,
+            prefills=prefills,
+            entities=entities,
+            autotag=autotag,
+            change=change,
+            error=error,
+            form=form,
+        )
+        autotags = autotag_services.get_autotags()
+        return autotag_settings_helpers.render_autotags_content(
+            autotags=autotags,
+            autotag_form_html=autotag_form_html,
+            selected_id=selected_id,
+        )
+
+    def get(self, request):
+        return HttpResponse(self._render_content())
+
+    def post(self, request, autotag_id=None):
+        action = request.POST.get("action")
+
+        if action == "clear":
+            return HttpResponse(self._render_content())
+
+        if action == "delete":
+            result = autotag_services.delete_autotag(autotag_id)
+            if result.success:
+                return HttpResponse(self._render_content(change="delete"))
+            return HttpResponse(
+                self._render_content(
+                    autotag=result.autotag,
+                    error=result.error,
+                    selected_id=result.autotag.id if result.autotag else None,
+                )
+            )
+
+        if autotag_id:
+            autotag = get_object_or_404(AutoTag, pk=autotag_id)
+            form = AutoTagForm(request.POST, instance=autotag)
+            change = "update"
+        else:
+            autotag = None
+            form = AutoTagForm(request.POST)
+            change = "create"
+
+        if not form.is_valid():
+            return HttpResponse(
+                self._render_content(
+                    autotag=autotag,
+                    form=form,
+                    selected_id=autotag.id if autotag else None,
+                )
+            )
+
+        result = autotag_services.save_autotag(
+            form.cleaned_data, instance=autotag
+        )
+        if not result.success:
+            return HttpResponse(
+                self._render_content(
+                    autotag=autotag,
+                    form=form,
+                    error=result.error,
+                    selected_id=autotag.id if autotag else None,
+                )
+            )
+
+        return HttpResponse(
+            self._render_content(
+                autotag=result.autotag,
+                change=change,
+                selected_id=result.autotag.id,
+            )
+        )
+
+
+class AutoTagFormView(LoginRequiredMixin, View):
+    """Loads an autotag (or a blank create form) into the edit form.
+
+    Used on table row clicks (existing autotag) and the New Auto Tag button (no
+    autotag_id -> blank form).
+    """
+
+    login_url = "/login/"
+    redirect_field_name = "next"
+
+    def get(self, request, autotag_id=None):
+        autotag = get_object_or_404(AutoTag, pk=autotag_id) if autotag_id else None
+        accounts, prefills, entities = autotag_services.get_autotag_form_options()
+        form_html = autotag_settings_helpers.render_autotag_form(
+            accounts=accounts,
+            prefills=prefills,
+            entities=entities,
+            autotag=autotag,
+        )
+        return HttpResponse(form_html)

--- a/ledger/templates/api/content/autotags-content.html
+++ b/ledger/templates/api/content/autotags-content.html
@@ -1,0 +1,75 @@
+<div x-data="searchList({{ total }}, 'autotags', {{ selected_id|default:'null' }})">
+
+  <div class="card-head">
+    <div class="card-head-left">
+      <h2 class="card-title">Auto Tags</h2>
+      <span class="card-count" x-text="countLabel()"></span>
+    </div>
+    <div class="card-head-right">
+      {% include "api/components/search-box.html" with placeholder="Search auto tags" %}
+      <button class="btn btn-secondary"
+              hx-get="{% url 'trigger-autotag' %}"
+              hx-target="#autotag-reapply-result"
+              hx-swap="innerHTML">Re-apply to open transactions</button>
+      <button class="btn btn-primary"
+              @click="selectedId = null"
+              hx-get="{% url 'settings-autotag-new-form' %}"
+              hx-target="#autotag-form-div">New Auto Tag</button>
+    </div>
+  </div>
+
+  <div id="autotag-reapply-result"></div>
+
+  <div class="table-scroll has-list">
+  <table class="table">
+    <thead>
+      <tr>
+        <th>Search string</th>
+        <th>Account</th>
+        <th>Type</th>
+      </tr>
+    </thead>
+    <tbody>
+      {% for autotag in autotags %}
+      <tr class="row"
+          data-search="{{ autotag.search_string|lower }}"
+          :class="{ selected: selectedId === {{ autotag.id }} }"
+          x-show="matches($el)"
+          @click="selectedId = {{ autotag.id }}"
+          hx-get="{% url 'settings-autotag-form' autotag.id %}"
+          hx-target="#autotag-form-div">
+        <td class="td-name">{{ autotag.search_string }}</td>
+        <td class="td-muted">{{ autotag.account.name|default:"—" }}</td>
+        <td class="td-muted">{{ autotag.get_transaction_type_display|default:"—" }}</td>
+      </tr>
+      {% endfor %}
+    </tbody>
+  </table>
+  </div>
+
+  <div class="list">
+    {% for autotag in autotags %}
+    <div class="lrow"
+         data-search="{{ autotag.search_string|lower }}"
+         :class="{ selected: selectedId === {{ autotag.id }} }"
+         x-show="matches($el)"
+         @click="selectedId = {{ autotag.id }}"
+         hx-get="{% url 'settings-autotag-form' autotag.id %}"
+         hx-target="#autotag-form-div">
+      <div class="lrow-top">
+        <span class="lname">{{ autotag.search_string }}</span>
+        <span class="lmeta-right">{{ autotag.get_transaction_type_display|default:"—" }}</span>
+      </div>
+      <div class="lmeta">{{ autotag.account.name|default:"No account" }}</div>
+    </div>
+    {% endfor %}
+  </div>
+
+  <div class="table-empty" x-show="visible() === 0" x-cloak>
+    No auto tags match "<span x-text="q"></span>".
+  </div>
+
+  <div id="autotag-form-div">
+    {{ autotag_form }}
+  </div>
+</div>

--- a/ledger/templates/api/entry_forms/autotag-form.html
+++ b/ledger/templates/api/entry_forms/autotag-form.html
@@ -1,0 +1,88 @@
+<div class="form">
+
+  <div class="form-header">
+    {% if autotag %}Edit auto tag{% else %}New auto tag{% endif %}
+  </div>
+
+  {% if change == "create" %}
+    <div class="alert alert-success">Auto tag created.</div>
+  {% elif change == "update" %}
+    <div class="alert alert-success">Auto tag updated.</div>
+  {% elif change == "delete" %}
+    <div class="alert alert-success">Auto tag deleted.</div>
+  {% endif %}
+  {% if error %}
+    <div class="alert alert-danger">{{ error }}</div>
+  {% endif %}
+  {% if form.non_field_errors %}
+    <div class="alert alert-danger">{{ form.non_field_errors }}</div>
+  {% endif %}
+
+  <form method="post"
+        {% if autotag %}hx-post="{% url 'settings-autotag' autotag.id %}"{% else %}hx-post="{% url 'settings-autotags' %}"{% endif %}
+        hx-target="#autotags-content"
+        hx-swap="innerHTML">
+    {% csrf_token %}
+
+    <p class="muted fs-body">When <strong>search string</strong> appears in a transaction's description, the transaction is pre-filled with the account, entity, prefill, and type below.</p>
+
+    <div class="grid grid-4 grid-end">
+      <div>
+        <label class="label">Search string</label>
+        <input class="input" name="search_string" value="{{ values.search_string }}" maxlength="20" placeholder="e.g. amazon" />
+        {% for e in form.search_string.errors %}<div class="field-error">{{ e }}</div>{% endfor %}
+      </div>
+      <div>
+        <label class="label">Account</label>
+        <select class="select" name="account">
+          <option value="" {% if not values.account %}selected{% endif %}>Select…</option>
+          {% for account in accounts %}
+          <option value="{{ account.id }}" {% if values.account == account.id|stringformat:'s' %}selected{% endif %}>{{ account.name }}</option>
+          {% endfor %}
+        </select>
+        {% for e in form.account.errors %}<div class="field-error">{{ e }}</div>{% endfor %}
+      </div>
+      <div>
+        <label class="label">Type</label>
+        <select class="select" name="transaction_type">
+          <option value="" {% if not values.transaction_type %}selected{% endif %}>Select…</option>
+          {% for value, label in type_choices %}
+          <option value="{{ value }}" {% if values.transaction_type == value %}selected{% endif %}>{{ label }}</option>
+          {% endfor %}
+        </select>
+        {% for e in form.transaction_type.errors %}<div class="field-error">{{ e }}</div>{% endfor %}
+      </div>
+      <div>
+        <label class="label">Prefill</label>
+        <select class="select" name="prefill">
+          <option value="" {% if not values.prefill %}selected{% endif %}>Select…</option>
+          {% for prefill in prefills %}
+          <option value="{{ prefill.id }}" {% if values.prefill == prefill.id|stringformat:'s' %}selected{% endif %}>{{ prefill.name }}</option>
+          {% endfor %}
+        </select>
+        {% for e in form.prefill.errors %}<div class="field-error">{{ e }}</div>{% endfor %}
+      </div>
+      <div>
+        <label class="label">Entity</label>
+        <select class="select" name="entity">
+          <option value="" {% if not values.entity %}selected{% endif %}>Select…</option>
+          {% for entity in entities %}
+          <option value="{{ entity.id }}" {% if values.entity == entity.id|stringformat:'s' %}selected{% endif %}>{{ entity.name }}</option>
+          {% endfor %}
+        </select>
+        {% for e in form.entity.errors %}<div class="field-error">{{ e }}</div>{% endfor %}
+      </div>
+    </div>
+
+    <div class="actions">
+      <button type="submit" name="action" value="save" class="btn btn-primary">{% if autotag %}Save{% else %}Create{% endif %}</button>
+      {% if autotag %}
+      <button type="submit" name="action" value="delete" class="btn btn-danger">Delete</button>
+      {% endif %}
+      <button type="button" class="btn btn-ghost"
+              @click="selectedId = null"
+              hx-get="{% url 'settings-autotag-new-form' %}"
+              hx-target="#autotag-form-div">Clear</button>
+    </div>
+  </form>
+</div>

--- a/ledger/templates/api/views/settings.html
+++ b/ledger/templates/api/views/settings.html
@@ -3,7 +3,6 @@
         sections: ['Accounts', 'Bill Rules', 'Utility Bills', 'Loans', 'Entities', 'Prefills', 'Paystubs', 'Auto Tags', 'CSV Profiles'],
         stubs: {
           'Paystubs': 'Saved paystub templates parsed via AWS Textract.',
-          'Auto Tags': 'Rules that auto-categorize incoming transactions.',
           'CSV Profiles': 'Column mappings for each bank\'s CSV export format.'
         }
      }">
@@ -63,6 +62,14 @@
       <div x-show="section === 'Prefills'">
         <div id="prefills-content"
              hx-get="{% url 'settings-prefills' %}" hx-trigger="load">
+          <div class="table-empty">Loading…</div>
+        </div>
+      </div>
+
+      <!-- Auto Tags (functional, lazy-loaded) -->
+      <div x-show="section === 'Auto Tags'">
+        <div id="autotags-content"
+             hx-get="{% url 'settings-autotags' %}" hx-trigger="load">
           <div class="table-empty">Loading…</div>
         </div>
       </div>

--- a/ledger/urls.py
+++ b/ledger/urls.py
@@ -50,6 +50,10 @@ from api.views.loan_views import (
     LoanScheduleView,
     LoanSettingsView,
 )
+from api.views.autotag_settings_views import (
+    AutoTagFormView,
+    AutoTagSettingsView,
+)
 from api.views.prefill_settings_views import (
     DocSearchFormView,
     DocSearchView,
@@ -375,6 +379,27 @@ urlpatterns = [
         "settings/prefills/<int:prefill_id>/docsearches/<int:docsearch_id>/form/",
         DocSearchFormView.as_view(),
         name="settings-docsearch-form",
+    ),
+    # Settings — autotags (config CRUD)
+    path(
+        "settings/autotags/",
+        AutoTagSettingsView.as_view(),
+        name="settings-autotags",
+    ),
+    path(
+        "settings/autotags/new/form/",
+        AutoTagFormView.as_view(),
+        name="settings-autotag-new-form",
+    ),
+    path(
+        "settings/autotags/<int:autotag_id>/",
+        AutoTagSettingsView.as_view(),
+        name="settings-autotag",
+    ),
+    path(
+        "settings/autotags/<int:autotag_id>/form/",
+        AutoTagFormView.as_view(),
+        name="settings-autotag-form",
     ),
     path("tag/", TagEntitiesView.as_view(), name="tag-entities"),
     path("tag/balances/", EntityGroupedBalancesView.as_view(), name="entity-balances"),


### PR DESCRIPTION
## What

Builds the previously-stubbed **Auto Tags** section on the Settings page into a full CRUD, following the established Prefills/Entities pattern. Autotag rules can now be created, edited, and deleted from the UI instead of only through the Django admin.

An autotag is a rule: when its `search_string` appears (case-insensitively) in an incoming transaction's description, the transaction is pre-filled with the tag's account, entity, prefill, and transaction type (via the existing `Transaction.apply_autotags`).

## Changes

- **Form** — `AutoTagForm` with FK `ModelChoiceField`s (open accounts/prefills, all entities) and the `transaction_type` choice. Only `search_string` is required.
- **Service** — `api/services/autotag_services.py`: `get_autotags`, `get_autotag_form_options`, `save_autotag`, `delete_autotag`, delegating writes to the shared `crud` helpers.
- **Views/helpers** — `AutoTagSettingsView` + `AutoTagFormView` (HTTP orchestration only) and pure `render_to_string` helpers.
- **Templates** — list fragment (Search string / Account / Type columns) + add/edit form, plus a **Re-apply to open transactions** button that reuses the existing `trigger-autotag` endpoint.
- **Shell** — converts the "Auto Tags" stub into a functional lazy-loaded section.

## Testing

- New: `test_autotag_services.py` (list ordering, create/update/delete, not-found, form options) and `test_autotag_settings_views.py` (login-required, list, create/update/delete, form-validation error) — 15 tests, all passing.
- Full suite green (the one flaky Playwright e2e failure is pre-existing and unrelated; passes in isolation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)