### PR TITLE
Fix CSV imports never applying bill/loan tags (string amount crash)

### DIFF
--- a/api/forms.py
+++ b/api/forms.py
@@ -55,9 +55,7 @@ class CommaDecimalField(DecimalField):
         if value is None or "":
             return value
         try:
-            value = str(value).replace(",", "")
-            value = str(value).replace("$", "")
-            value = Decimal(value)
+            value = utils.parse_currency(value)
         except InvalidOperation:
             return None
         return super().to_python(value)

--- a/api/models.py
+++ b/api/models.py
@@ -15,7 +15,7 @@ from api.aws_services import (
     create_textract_job,
     get_textract_results,
 )
-from api.utils import short_error_label
+from api.utils import parse_currency, short_error_label
 from api.validators import non_zero
 
 
@@ -1054,14 +1054,17 @@ class CSVProfile(models.Model):
 
         transactions_list = []
         for row in cleared_rows_csv:
-            if row == {} or self._get_coalesced_amount(row) == 0:
+            if row == {}:
+                break
+            amount = self._get_coalesced_amount(row)
+            if amount == 0:
                 break
 
             # Set defaults
             transaction = Transaction(
                 date=self._get_formatted_date(row[self.date]),
                 account=account,
-                amount=self._get_coalesced_amount(row),
+                amount=amount,
                 description=row[self.description],
                 category=row[self.category],
                 suggested_account=None,  # Default value
@@ -1089,10 +1092,15 @@ class CSVProfile(models.Model):
         return formatted_date
 
     def _get_coalesced_amount(self, row):
-        if row[self.inflow]:
-            return row[self.inflow]
-        else:
-            return row[self.outflow]
+        # CSV cells are strings; coerce to Decimal so the in-memory Transaction
+        # carries the right type (its amount is a DecimalField). Advisory
+        # bill/loan tagging runs on these in-memory objects before they're
+        # re-read from the DB, and does arithmetic on amount, so a raw string
+        # would blow it up. parse_currency also tolerates thousands separators
+        # and dollar signs, matching CommaDecimalField.
+        raw = row[self.inflow] or row[self.outflow]
+        # A blank amount marks the end-of-data row the caller breaks on.
+        return parse_currency(raw) if raw else Decimal(0)
 
     def _clear_prepended_rows(self, csv_data):
         if not self.clear_prepended_until_value:

--- a/api/services/bill_services.py
+++ b/api/services/bill_services.py
@@ -167,11 +167,16 @@ def match_transactions_to_bills(transactions: Iterable[Transaction]) -> int:
     # results without reliable pk/__eq__; bills always have a stable pk.
     txns_for_bill: dict = defaultdict(list)
     bills_for_txn: dict = defaultdict(list)
-    for bill in bills:
-        for txn in txns:
-            if _bill_matches_transaction(bill, txn):
-                txns_for_bill[bill.id].append(txn)
-                bills_for_txn[id(txn)].append(bill)
+    for txn in txns:
+        # Isolate each transaction: advisory tagging is best-effort, so one bad
+        # row must never abort matching for the rest of the batch.
+        try:
+            for bill in bills:
+                if _bill_matches_transaction(bill, txn):
+                    txns_for_bill[bill.id].append(txn)
+                    bills_for_txn[id(txn)].append(bill)
+        except Exception:
+            logger.exception("Bill matching failed for transaction %s", txn.pk)
 
     txns_to_update: List[Transaction] = []
     bills_to_update: List[UtilityBill] = []

--- a/api/services/loan_services.py
+++ b/api/services/loan_services.py
@@ -7,6 +7,7 @@ functions, which return dataclass result objects (per the service-layer
 pattern). Mirrors bill_rule_services + bill_services.match_transactions_to_bills.
 """
 
+import logging
 from dataclasses import dataclass
 from decimal import Decimal
 from typing import Any, Dict, Iterable, List, Optional, Tuple
@@ -16,6 +17,8 @@ from django.db.models import Max, QuerySet
 
 from api.models import Account, Entity, Loan, LoanPayment, Transaction
 from api.services import crud
+
+logger = logging.getLogger(__name__)
 
 
 @dataclass
@@ -263,27 +266,40 @@ def match_transactions_to_loans(transactions: Iterable[Transaction]) -> int:
     matched = 0
     taken_row_ids: set = set()
     for txn in transactions:
-        candidates = _candidate_loans(txn, loans)
-        if len(candidates) != 1:
-            continue
-        loan = candidates[0]
-        amount = abs(txn.amount)
-
-        row = _match_scheduled_row(loan, txn, amount, taken_row_ids)
-        if row is not None:
-            row.transaction = txn
-            row.save()
-        else:
-            # _record_off_schedule creates and links the payment itself.
-            row = _record_off_schedule(loan, txn, amount)
-            if row is None:
-                continue
-        taken_row_ids.add(row.id)
-
-        txn.suggested_account = loan.principal_account
-        txn.suggested_entity = loan.entity
-        txn.type = Transaction.TransactionType.PAYMENT
-        txn.save()
-        matched += 1
+        # Isolate each transaction: advisory tagging is best-effort, so one bad
+        # row must never abort matching for the rest of the batch.
+        try:
+            if _tag_one_transaction(txn, loans, taken_row_ids):
+                matched += 1
+        except Exception:
+            logger.exception("Loan matching failed for transaction %s", txn.pk)
 
     return matched
+
+
+def _tag_one_transaction(
+    txn: Transaction, loans: List[Loan], taken_row_ids: set
+) -> bool:
+    """Match and tag a single transaction. Returns True if it was tagged."""
+    candidates = _candidate_loans(txn, loans)
+    if len(candidates) != 1:
+        return False
+    loan = candidates[0]
+    amount = abs(txn.amount)
+
+    row = _match_scheduled_row(loan, txn, amount, taken_row_ids)
+    if row is not None:
+        row.transaction = txn
+        row.save()
+    else:
+        # _record_off_schedule creates and links the payment itself.
+        row = _record_off_schedule(loan, txn, amount)
+        if row is None:
+            return False
+    taken_row_ids.add(row.id)
+
+    txn.suggested_account = loan.principal_account
+    txn.suggested_entity = loan.entity
+    txn.type = Transaction.TransactionType.PAYMENT
+    txn.save()
+    return True

--- a/api/tests/models/test_csvprofile.py
+++ b/api/tests/models/test_csvprofile.py
@@ -1,3 +1,5 @@
+from decimal import Decimal
+
 from django.test import TestCase
 from api.models import CSVColumnValuePair, Transaction, AutoTag
 from api.tests.testing_factories import CSVProfileFactory, AccountFactory, PrefillFactory
@@ -127,6 +129,42 @@ class CSVProfileModelTest(TestCase):
         }
         value = self.csv_profile._get_coalesced_amount(test_row)
         self.assertEqual(value, 500)
+
+    def test_get_coalesced_amount_coerces_string_cells_to_decimal(self):
+        # CSV cells arrive as strings; the amount must come back as a Decimal so
+        # advisory bill/loan tagging (which does arithmetic on the in-memory
+        # Transaction before it's re-read from the DB) doesn't blow up.
+        value = self.csv_profile._get_coalesced_amount(
+            {'Inflow': '', 'Outflow': '-805.36'}
+        )
+        self.assertEqual(value, Decimal('-805.36'))
+        self.assertIsInstance(value, Decimal)
+
+    def test_get_coalesced_amount_tolerates_thousands_and_dollar_signs(self):
+        # Reuses utils.parse_currency, so formatted CSV cells no longer raise.
+        value = self.csv_profile._get_coalesced_amount(
+            {'Inflow': '$1,234.56', 'Outflow': ''}
+        )
+        self.assertEqual(value, Decimal('1234.56'))
+
+    def test_get_coalesced_amount_blank_row_returns_zero(self):
+        # A blank amount marks the end-of-data row the importer breaks on; it
+        # must return 0 rather than raise on Decimal('').
+        value = self.csv_profile._get_coalesced_amount({'Inflow': '', 'Outflow': ''})
+        self.assertEqual(value, Decimal(0))
+
+    def test_created_transactions_have_decimal_amounts(self):
+        # Regression: bulk_create leaves the in-memory objects' amount as the
+        # raw CSV string; the model must coerce so callers (tagging) get Decimals.
+        copied_list = list(csv_data)
+        copied_list.append({})
+        account = AccountFactory()
+
+        created = self.csv_profile.create_transactions_from_csv(copied_list, account)
+
+        self.assertTrue(created)
+        for transaction in created:
+            self.assertIsInstance(transaction.amount, Decimal)
 
     def test_date_string_formatted(self):
         test_date = '31-2023-03'

--- a/api/tests/services/test_loan_services.py
+++ b/api/tests/services/test_loan_services.py
@@ -188,6 +188,27 @@ class MatchScheduledTest(TestCase):
         linked = LoanPayment.objects.get(transaction=txn)
         self.assertEqual(linked.kind, LoanPayment.Kind.SCHEDULED)
 
+    def test_bad_transaction_does_not_abort_batch(self):
+        # A single transaction blowing up during matching (here: a str amount,
+        # the exact bug that broke CSV imports) must not stop the rest of the
+        # batch from being tagged. The failure is isolated + logged.
+        loan = make_loan()
+        bad = TransactionFactory(
+            amount=Decimal("-1000.00"), date=datetime.date(2026, 7, 2)
+        )
+        bad.amount = "-1000.00"  # simulate the un-coerced CSV string
+        good = TransactionFactory(
+            amount=Decimal("-1000.00"), date=datetime.date(2026, 7, 2)
+        )
+
+        with self.assertLogs("api.services.loan_services", level="ERROR"):
+            count = match_transactions_to_loans([bad, good])
+
+        self.assertEqual(count, 1)
+        good.refresh_from_db()
+        self.assertEqual(good.suggested_account_id, loan.principal_account_id)
+        self.assertTrue(LoanPayment.objects.filter(transaction=good).exists())
+
     def test_outside_date_window_no_match(self):
         make_loan(date_window_days=3)
         # 2026-07-20 is >3 days from both the 07-01 and 08-01 scheduled rows.

--- a/api/tests/test_utils.py
+++ b/api/tests/test_utils.py
@@ -1,6 +1,25 @@
+from decimal import Decimal, InvalidOperation
+
 from django.test import SimpleTestCase
 
-from api.utils import friendly_error_message, short_error_label
+from api.utils import friendly_error_message, parse_currency, short_error_label
+
+
+class ParseCurrencyTest(SimpleTestCase):
+    def test_parses_plain_and_signed_numbers(self):
+        self.assertEqual(parse_currency("805.36"), Decimal("805.36"))
+        self.assertEqual(parse_currency("-805.36"), Decimal("-805.36"))
+
+    def test_strips_thousands_separators_and_dollar_signs(self):
+        self.assertEqual(parse_currency("$1,234.56"), Decimal("1234.56"))
+        self.assertEqual(parse_currency("-1,000"), Decimal("-1000"))
+
+    def test_returns_decimal_type(self):
+        self.assertIsInstance(parse_currency("10"), Decimal)
+
+    def test_raises_on_garbage(self):
+        with self.assertRaises(InvalidOperation):
+            parse_currency("not a number")
 
 
 class ErrorLabelTest(SimpleTestCase):

--- a/api/utils.py
+++ b/api/utils.py
@@ -1,5 +1,14 @@
 import calendar
 from datetime import date, datetime, timedelta
+from decimal import Decimal
+
+
+def parse_currency(value) -> Decimal:
+    """Parse a currency string like '$1,234.56', '-805.36', or a plain number
+    into a Decimal, stripping thousands separators and dollar signs. Raises
+    decimal.InvalidOperation on an unparseable value (same as bare Decimal())."""
+    cleaned = str(value).replace(",", "").replace("$", "")
+    return Decimal(cleaned)
 
 
 def format_datetime_to_string(form_date):


### PR DESCRIPTION
## Problem

CSV import silently applied **zero bill or loan tags** on every import, while reporting success.

`CSVProfile._get_coalesced_amount` returned the raw CSV cell (a `str`), so every imported `Transaction` had `amount` as a string. `bulk_create` persisted fine, but the **in-memory** instances handed to `tag_transactions` kept the string. Both advisory matchers then threw a `TypeError` on the first transaction:

- `loan_services.py` → `txn.amount >= 0` → `'>=' not supported between 'str' and 'int'`
- `bill_services.py` → `abs(txn.amount)` → `bad operand type for abs(): 'str'`

`_run_advisory` swallowed the exception (advisory tagging is best-effort), so the whole batch got no tagging and the import still returned 200. This is why a correctly-configured loan/bill never matched an imported transaction.

## Fixes

1. **Coerce at the source** — `_get_coalesced_amount` now returns a `Decimal`, so the in-memory objects carry the right type for every consumer. This is the single choke point for CSV amounts; all other `Transaction.amount` assignments already pass Decimals.
2. **Per-transaction isolation** — both matchers now isolate each transaction (loan matching extracted into `_tag_one_transaction`; bill matching wrapped per transaction), so one bad row can never silently abort tagging for the rest of the batch again.
3. **Shared currency parsing** — extracted the string→Decimal cleaning (strip thousands separators + dollar signs) into `utils.parse_currency`, reused by both `CommaDecimalField` and the CSV importer. Formatted cells like `"$1,234.56"` now import instead of raising.

## Tests

- Regression: created transactions carry `Decimal` amounts; string/blank/formatted cells parse correctly.
- Isolation: a bad transaction in a batch no longer prevents the good ones from being tagged (asserts the failure is logged).
- `parse_currency` unit tests.

Full suite: 643 tests passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)