### PR TITLE
Coerce CSV date to a date object at the source

### DIFF
--- a/api/models.py
+++ b/api/models.py
@@ -1083,13 +1083,12 @@ class CSVProfile(models.Model):
         return created
 
     def _get_formatted_date(self, date_string):
-        # Parse the original date using the input format
-        original_date = datetime.datetime.strptime(date_string, self.date_format)
-
-        # Format the date to the desired output format
-        formatted_date = original_date.strftime("%Y-%m-%d")
-
-        return formatted_date
+        # Parse using the profile's input format and return a date object (not a
+        # string) so the in-memory Transaction carries the right type for its
+        # DateField. Advisory bill/loan tagging does date arithmetic on these
+        # objects before they're re-read from the DB, so a str would blow up
+        # (same class of bug as _get_coalesced_amount coercing to Decimal).
+        return datetime.datetime.strptime(date_string, self.date_format).date()
 
     def _get_coalesced_amount(self, row):
         # CSV cells are strings; coerce to Decimal so the in-memory Transaction

--- a/api/tests/models/test_csvprofile.py
+++ b/api/tests/models/test_csvprofile.py
@@ -1,3 +1,4 @@
+import datetime
 from decimal import Decimal
 
 from django.test import TestCase
@@ -153,9 +154,10 @@ class CSVProfileModelTest(TestCase):
         value = self.csv_profile._get_coalesced_amount({'Inflow': '', 'Outflow': ''})
         self.assertEqual(value, Decimal(0))
 
-    def test_created_transactions_have_decimal_amounts(self):
-        # Regression: bulk_create leaves the in-memory objects' amount as the
-        # raw CSV string; the model must coerce so callers (tagging) get Decimals.
+    def test_created_transactions_have_typed_amount_and_date(self):
+        # Regression: bulk_create leaves the in-memory objects' amount/date as
+        # the raw CSV strings; the model must coerce so callers (tagging, which
+        # does arithmetic on both) get a Decimal amount and a date object.
         copied_list = list(csv_data)
         copied_list.append({})
         account = AccountFactory()
@@ -165,13 +167,15 @@ class CSVProfileModelTest(TestCase):
         self.assertTrue(created)
         for transaction in created:
             self.assertIsInstance(transaction.amount, Decimal)
+            self.assertIsInstance(transaction.date, datetime.date)
 
-    def test_date_string_formatted(self):
+    def test_date_string_parsed_to_date_object(self):
         test_date = '31-2023-03'
         self.csv_profile.date_format = "%d-%Y-%m"
         self.csv_profile.save()
-        formatted_date = self.csv_profile._get_formatted_date(test_date)
-        self.assertEqual(formatted_date, '2023-03-31')
+        parsed = self.csv_profile._get_formatted_date(test_date)
+        self.assertEqual(parsed, datetime.date(2023, 3, 31))
+        self.assertIsInstance(parsed, datetime.date)
 
     def test_autotags_applied_to_transactions(self):
         copied_list = list(csv_data)


### PR DESCRIPTION
## Problem

Follow-up to #405. That PR fixed the string **amount** crash and added per-transaction isolation to the matchers. Once deployed, the isolation caught a second instance of the **same class of bug** on a different field — the transaction **date**:

```
delta = abs((txn.date - row.date).days)
TypeError: unsupported operand type(s) for -: 'str' and 'datetime.date'
```

`CSVProfile._get_formatted_date` parsed the CSV date cell into a `datetime` and then `strftime`'d it *back* into a **string**, so the in-memory `Transaction` carried a `str` date. `bulk_create` persisted it fine (the DB coerces on write), but the advisory loan/bill matchers do date arithmetic (`txn.date - row.date`) on the in-memory objects *before* they're re-read from the DB — so a `str` date raised `TypeError`. The #405 isolation caught and logged it, so the import survived but the transaction went untagged.

## Fix

Return a `datetime.date` from `_get_formatted_date` (drop the round-trip back to a string). `DateField` accepts a `date` natively. This mirrors the amount coercion from #405, at the same source choke point.

After this, the CSV-built `Transaction` has no remaining mistyped fields the matchers operate on (`amount`=Decimal, `date`=date, `account`=Account; `description`/`category` are legitimately strings).

## Tests

- `test_date_string_parsed_to_date_object` — `_get_formatted_date` now returns a `date`.
- `test_created_transactions_have_typed_amount_and_date` — extends the amount regression test to also assert `date` is a `datetime.date`.

Full suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)