### PR TITLE
Add "Re-run loan matching" button to Settings → Loans

### DIFF
--- a/api/services/loan_services.py
+++ b/api/services/loan_services.py
@@ -303,3 +303,17 @@ def _tag_one_transaction(
     txn.type = Transaction.TransactionType.PAYMENT
     txn.save()
     return True
+
+
+def rematch_open_transactions() -> int:
+    """Re-run loan matching on open transactions not already linked to a loan
+    payment, returning the number newly tagged.
+
+    The ``loan_payment__isnull=True`` filter is what makes repeated runs safe:
+    ``match_transactions_to_loans`` is not idempotent on already-matched
+    transactions (it would double-book a row or duplicate an off-schedule
+    payment), and a transaction tagged on one run is excluded from the next.
+    """
+    return match_transactions_to_loans(
+        Transaction.objects.filter(is_closed=False, loan_payment__isnull=True)
+    )

--- a/api/tests/services/test_loan_services.py
+++ b/api/tests/services/test_loan_services.py
@@ -10,6 +10,7 @@ from api.services.loan_services import (
     get_loan_form_options,
     get_loans,
     match_transactions_to_loans,
+    rematch_open_transactions,
     save_loan,
     save_schedule_row,
 )
@@ -317,4 +318,49 @@ class MatchScopingTest(TestCase):
             amount=Decimal("1000.00"), date=datetime.date(2026, 7, 2)
         )
         count = match_transactions_to_loans([txn])
+        self.assertEqual(count, 0)
+
+
+class RematchOpenTransactionsTest(TestCase):
+    def test_tags_unmatched_open_transaction(self):
+        loan = make_loan()
+        txn = TransactionFactory(
+            amount=Decimal("-1000.00"), date=datetime.date(2026, 7, 2)
+        )
+
+        count = rematch_open_transactions()
+
+        self.assertEqual(count, 1)
+        txn.refresh_from_db()
+        self.assertEqual(txn.type, Transaction.TransactionType.PAYMENT)
+        self.assertEqual(txn.suggested_account_id, loan.principal_account_id)
+        self.assertTrue(LoanPayment.objects.filter(transaction=txn).exists())
+
+    def test_is_idempotent_on_second_run(self):
+        # The safety property: a transaction tagged on the first run gains a
+        # loan_payment link and is excluded from the next, so re-running never
+        # double-books a row or creates a duplicate off-schedule payment.
+        make_loan()
+        TransactionFactory(
+            amount=Decimal("-1000.00"), date=datetime.date(2026, 7, 2)
+        )
+
+        first = rematch_open_transactions()
+        payments_after_first = LoanPayment.objects.count()
+        second = rematch_open_transactions()
+
+        self.assertEqual(first, 1)
+        self.assertEqual(second, 0)
+        self.assertEqual(LoanPayment.objects.count(), payments_after_first)
+
+    def test_skips_closed_transactions(self):
+        make_loan()
+        TransactionFactory(
+            amount=Decimal("-1000.00"),
+            date=datetime.date(2026, 7, 2),
+            is_closed=True,
+        )
+
+        count = rematch_open_transactions()
+
         self.assertEqual(count, 0)

--- a/api/tests/views/test_loan_views.py
+++ b/api/tests/views/test_loan_views.py
@@ -9,7 +9,7 @@ from django.urls import reverse
 
 from api.models import Account, Loan
 from api.tests.test_helpers import HTMXViewTestCase
-from api.tests.testing_factories import AccountFactory
+from api.tests.testing_factories import AccountFactory, TransactionFactory
 
 
 def make_loan(**kwargs):
@@ -88,3 +88,17 @@ class LoanScheduleRowSaveTest(HTMXViewTestCase):
         self.assertEqual(response.status_code, 200)
         loan.refresh_from_db()
         self.assertFalse(loan.payments.filter(balance_override__isnull=False).exists())
+
+
+class LoanRematchViewTest(HTMXViewTestCase):
+    def test_get_rematches_and_reports_count(self):
+        # View-level: the button wires to the service and renders its count.
+        # The tagging side effects are covered by the service tests.
+        make_loan()
+        TransactionFactory(amount=Decimal("-1000.00"), date=datetime.date(2026, 7, 2))
+
+        response = self.client.get(reverse("settings-loan-rematch"))
+
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, "Loan matching complete")
+        self.assertContains(response, "(1 transactions)")

--- a/api/views/journal_entry_views.py
+++ b/api/views/journal_entry_views.py
@@ -30,7 +30,7 @@ from api.views.journal_entry_helpers import (
     render_paystubs_table,
 )
 from api.views import transaction_helpers
-from api.views.page_utils import render_full_page
+from api.views.page_utils import render_action_status, render_full_page
 
 
 class TriggerAutoTagView(LoginRequiredMixin, View):
@@ -39,9 +39,7 @@ class TriggerAutoTagView(LoginRequiredMixin, View):
 
     def get(self, request):
         count = apply_autotags_to_open_transactions()
-        return HttpResponse(
-            f"<small class=text-success>Autotag complete ({count} transactions)</small>"
-        )
+        return HttpResponse(render_action_status("Autotag complete", count))
 
 
 # Called every time the page is filtered

--- a/api/views/loan_views.py
+++ b/api/views/loan_views.py
@@ -20,7 +20,7 @@ from django.views import View
 from api.forms import LoanForm
 from api.models import Loan, LoanPayment
 from api.services import loan_services
-from api.views import loan_helpers
+from api.views import loan_helpers, page_utils
 
 
 class LoanSettingsView(LoginRequiredMixin, View):
@@ -195,3 +195,18 @@ class LoanScheduleView(LoginRequiredMixin, View):
         loan.refresh_from_db()
         rows = loan_services.get_schedule(loan.id)
         return HttpResponse(loan_helpers.render_loan_schedule(loan, rows, message=message))
+
+
+class LoanRematchView(LoginRequiredMixin, View):
+    """Re-run loan matching over open, unmatched transactions on demand.
+
+    Mirrors TriggerAutoTagView: a GET that returns a small success fragment
+    HTMX-swapped into the Loans settings result div.
+    """
+
+    login_url = "/login/"
+    redirect_field_name = "next"
+
+    def get(self, request):
+        count = loan_services.rematch_open_transactions()
+        return HttpResponse(page_utils.render_action_status("Loan matching complete", count))

--- a/api/views/page_utils.py
+++ b/api/views/page_utils.py
@@ -16,3 +16,9 @@ from django.shortcuts import render
 def render_full_page(request, content_html: str) -> HttpResponse:
     """Wrap a pre-rendered content fragment in the base.html shell."""
     return render(request, "api/shell.html", {"content": content_html})
+
+
+def render_action_status(message: str, count: int) -> str:
+    """A small success fragment reporting how many transactions a batch action
+    affected, HTMX-swapped into a result div (autotag re-apply, loan re-match)."""
+    return f"<small class=text-success>{message} ({count} transactions)</small>"

--- a/ledger/templates/api/content/loans-content.html
+++ b/ledger/templates/api/content/loans-content.html
@@ -7,12 +7,18 @@
     </div>
     <div class="card-head-right">
       {% include "api/components/search-box.html" with placeholder="Search loans" %}
+      <button class="btn btn-secondary"
+              hx-get="{% url 'settings-loan-rematch' %}"
+              hx-target="#loan-rematch-result"
+              hx-swap="innerHTML">Re-run loan matching</button>
       <button class="btn btn-primary"
               @click="selectedId = null"
               hx-get="{% url 'settings-loan-new-form' %}"
               hx-target="#loan-form-div">New Loan</button>
     </div>
   </div>
+
+  <div id="loan-rematch-result"></div>
 
   <div class="table-scroll has-list">
   <table class="table">

--- a/ledger/urls.py
+++ b/ledger/urls.py
@@ -47,6 +47,7 @@ from api.views.bill_settings_views import (
 )
 from api.views.loan_views import (
     LoanFormView,
+    LoanRematchView,
     LoanScheduleView,
     LoanSettingsView,
 )
@@ -318,6 +319,11 @@ urlpatterns = [
         "settings/loans/new/form/",
         LoanFormView.as_view(),
         name="settings-loan-new-form",
+    ),
+    path(
+        "settings/loans/rematch/",
+        LoanRematchView.as_view(),
+        name="settings-loan-rematch",
     ),
     path(
         "settings/loans/<int:loan_id>/",


### PR DESCRIPTION
## Problem

Loan matching only runs at CSV import time. If a loan is created *after* its payments were imported (or an import's loan-matching pass didn't match them), those transactions never get matched — and the only remedy today is running a manual shell script against prod. This adds a self-serve button on **Settings → Loans** that re-runs loan matching on demand.

## What it does

- **Service** — `rematch_open_transactions()` (`api/services/loan_services.py`) runs the matcher over `Transaction.objects.filter(is_closed=False, loan_payment__isnull=True)`.
- **View** — `LoanRematchView` mirrors the existing `TriggerAutoTagView`: a GET that returns a small success fragment HTMX-swapped into a result div on the Loans card.
- **Template** — a `btn-secondary` "Re-run loan matching" button in the Loans card head + a `#loan-rematch-result` div. Reuses existing classes, no new CSS.

## Safety (the key design decision)

`match_transactions_to_loans` is **not idempotent** on already-matched transactions — a naive re-run would re-link a transaction to a second scheduled row or create a duplicate off-schedule payment and re-amortize, corrupting the loan balance. (This is the same reason the autotag re-apply path passes `include_loans=False`.)

The `loan_payment__isnull=True` filter makes repeated runs safe: a transaction tagged on one run gains a `loan_payment` link and is excluded from the next. The idempotency test pins this — a second run returns 0 and creates no new `LoanPayment` rows.

## Cleanup

Extracted the duplicated `<small class=text-success>…(N transactions)</small>` fragment into `page_utils.render_action_status`, now shared by both `LoanRematchView` and `TriggerAutoTagView` (removes inline HTML from the views, per the Views→Helpers layering rule).

## Tests

- Service: tags an unmatched open transaction; **idempotent on second run** (0 tagged, no new rows); skips closed transactions.
- View: GET renders the count fragment.

Full suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)