### PR TITLE
Keep the prod host out of the public repo

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -21,5 +21,6 @@ jobs:
       - name: Deploy to Heroku
         env:
           HEROKU_API_KEY: ${{ secrets.HEROKU_API_KEY }}
+          HEROKU_APP_NAME: ${{ secrets.HEROKU_APP_NAME }}
         run: |
-          git push -f https://heroku:$HEROKU_API_KEY@git.heroku.com/fast-cliffs-86166.git HEAD:refs/heads/main
+          git push -f "https://heroku:$HEROKU_API_KEY@git.heroku.com/$HEROKU_APP_NAME.git" HEAD:refs/heads/main

--- a/mcp_server/README.md
+++ b/mcp_server/README.md
@@ -30,8 +30,9 @@ Dates are `YYYY-MM-DD`. Omit them to default to the last full calendar month.
 
 Two environment variables:
 
-- `LEDGER_API_BASE_URL` — e.g. `https://fast-cliffs-86166.herokuapp.com/api/v1`
-  (use `http://127.0.0.1:8000/api/v1` to point at a local dev server)
+- `LEDGER_API_BASE_URL` — your deployed Ledger API root, e.g.
+  `https://<your-app-host>/api/v1` (use `http://127.0.0.1:8000/api/v1` to point
+  at a local dev server)
 - `LEDGER_API_KEY` — the same value set as `LEDGER_API_KEY` on the server
 
 ### Register with Claude Code / Cowork
@@ -48,7 +49,7 @@ Add to your MCP config (e.g. `.mcp.json` or the Claude Code MCP settings):
         "python", "mcp_server/server.py"
       ],
       "env": {
-        "LEDGER_API_BASE_URL": "https://fast-cliffs-86166.herokuapp.com/api/v1",
+        "LEDGER_API_BASE_URL": "https://<your-app-host>/api/v1",
         "LEDGER_API_KEY": "your-api-key-here"
       }
     }

--- a/mcp_server/server.py
+++ b/mcp_server/server.py
@@ -9,7 +9,7 @@ API's read-only guarantee and needs no database credentials — only the base UR
 and the shared API key.
 
 Config (env vars):
-  LEDGER_API_BASE_URL  e.g. https://fast-cliffs-86166.herokuapp.com/api/v1
+  LEDGER_API_BASE_URL  your deployed Ledger API root, e.g. https://<your-app-host>/api/v1
   LEDGER_API_KEY       the same key the server checks (Authorization: Api-Key ...)
 
 Run:  uv run --with 'mcp[cli]' --with httpx python mcp_server/server.py


### PR DESCRIPTION
## What

Removes the deployed Heroku host / app name from tracked files so the public repo doesn't advertise the production URL.

- **`mcp_server/README.md`** and **`mcp_server/server.py`** — replace the hardcoded example host with a `https://<your-app-host>/api/v1` placeholder. The server already reads the real value from the `LEDGER_API_BASE_URL` env var at runtime, so nothing functional changes.
- **`.github/workflows/deploy.yml`** — read the Heroku app name from a new `HEROKU_APP_NAME` secret instead of hardcoding it in the `git push` URL.

## Follow-up (done)

The `HEROKU_APP_NAME` secret has already been set in the repo, so the deploy workflow will resolve it on the next merge to `main`.

## Verification

- MCP server verified end-to-end against a local API run (all 10 tools register and return data).
- Prod API confirmed live and enforcing key auth; the URL scrub is docs/CI only and doesn't touch runtime behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)