### PR TITLE
Remove redundant Paystubs stub from Settings

### DIFF
--- a/api/tests/views/test_settings_views.py
+++ b/api/tests/views/test_settings_views.py
@@ -24,7 +24,7 @@ class SettingsViewTest(HTMXViewTestCase):
     def test_page_contains_flat_menu_sections(self):
         response = self.client.get(reverse("settings"))
         # The flat menu is client-rendered from this section list.
-        self.assertContains(response, "'Entities', 'Prefills', 'Paystubs', 'Auto Tags', 'CSV Profiles'")
+        self.assertContains(response, "'Entities', 'Prefills', 'Auto Tags', 'CSV Profiles'")
 
     def test_new_account_form_view(self):
         response = self.client.get(reverse("settings-account-new-form"))

--- a/ledger/templates/api/views/settings.html
+++ b/ledger/templates/api/views/settings.html
@@ -1,8 +1,7 @@
 <div x-data="{
         section: 'Accounts',
-        sections: ['Accounts', 'Bill Rules', 'Utility Bills', 'Loans', 'Entities', 'Prefills', 'Paystubs', 'Auto Tags', 'CSV Profiles'],
+        sections: ['Accounts', 'Bill Rules', 'Utility Bills', 'Loans', 'Entities', 'Prefills', 'Auto Tags', 'CSV Profiles'],
         stubs: {
-          'Paystubs': 'Saved paystub templates parsed via AWS Textract.',
           'CSV Profiles': 'Column mappings for each bank\'s CSV export format.'
         }
      }">


### PR DESCRIPTION
The Paystubs Settings tab was a non-functional stub. Its implied functionality already exists elsewhere: parsing config lives in the Prefills section (Prefill + DocSearch), and paystub upload and parsed records live on the Journal Entry / Upload Transactions pages. The stub copy also referenced the deprecated Textract path (parsing runs on Gemini now). Remove the dead menu entry and update the section-list test.