### PR TITLE
Tag trend rows with originating statement (fix depreciation double-count)

### DIFF
--- a/.claude/skills/finance-dashboard/SKILL.md
+++ b/.claude/skills/finance-dashboard/SKILL.md
@@ -1,117 +1,99 @@
 ---
 name: finance-dashboard
-description: Build or refresh an interactive, visual HTML dashboard of the user's finances (income statement, balance sheet, cash flow, KPIs, callouts, account drill-downs, month/quarter/year views) from the Ledger MCP server. Use when the user asks to create, update, or open a finance/accounting dashboard, or to visualize their ledger data. Reads only via the read-only `ledger` MCP tools; writes a self-contained dashboards/dashboard.html.
+description: Build or refresh an interactive, visual HTML dashboard of the user's finances (income statement, balance sheet, cash flow, KPIs, callouts, account drill-downs, month/quarter/year views) from the Ledger reporting API. Use when the user asks to create, update, or open a finance/accounting dashboard, or to visualize their ledger data. Read-only; writes a self-contained dashboards/dashboard.html.
 ---
 
 # Finance dashboard
 
-Fetch financial data through the read-only **`ledger` MCP server**, inject it into the
-prebuilt shell at `template.html` (in this skill's directory), and write a self-contained
-`dashboards/dashboard.html`. All interactivity — Month/Quarter/Year toggle, the three
-statements, KPI tiles, callouts, and account drill-downs — is already built into the
-template and runs client-side over the embedded JSON. Your job is just: **fetch → assemble
-one JSON blob → inject → write.**
+Fetch financial data, inject it into the prebuilt shell at `template.html` (in this skill's
+directory), and write a self-contained `dashboards/dashboard.html`. All interactivity —
+Month/Quarter/Year toggle, the three statements, KPI tiles, callouts, and account drill-downs
+— is already built into the template and runs client-side over the embedded JSON.
+
+**Do this with `fetch.py` (the fast path below), not by hand.** The script fetches, computes
+callouts, assembles the blob, injects it, and writes the file in one shot — in ~15s. Fetching
+piecemeal through MCP tools and re-transcribing the payloads by hand is the slow path and can
+take many minutes; only fall back to it if the script genuinely can't run.
 
 ## Critical guardrails
 
 - **Never commit the output.** `dashboards/dashboard.html` contains real financial figures;
-  this repo is public. `dashboards/` is gitignored — keep it that way, and don't `git add`
-  it. The skill files (`SKILL.md`, `template.html`) hold no data and are safe to commit.
-- **Read-only.** Only call the `mcp__ledger__*` GET tools. Never write to the DB or app.
-- **Don't print the API key** or the raw prod host in your replies.
+  this repo is public. `dashboards/` is gitignored — keep it that way, and don't `git add` it.
+  The skill files (`SKILL.md`, `template.html`, `fetch.py`) hold no data and are safe to commit.
+- **Read-only.** Only GET the reporting endpoints (`/api/v1/reports/*` + the account/entity
+  lists) — via `fetch.py` or the `mcp__ledger__*` tools. Never write to the DB or app.
+- **Don't print the API key or the raw prod host** in your replies. `fetch.py` reads them from
+  the environment / `mcp_server/.env` and never echoes them — keep it that way.
 
-## Step 1 — Preflight
+## Fast path — run the script
 
-Confirm the `ledger` MCP tools are available (`mcp__ledger__get_trend`, etc.). If they are
-not registered, stop and tell the user to register the server per `mcp_server/README.md`
-(set `LEDGER_API_BASE_URL` + `LEDGER_API_KEY`), then re-run.
+```bash
+python3 .claude/skills/finance-dashboard/fetch.py            # trailing 12 full months
+python3 .claude/skills/finance-dashboard/fetch.py --full     # drill EVERY open account (slower)
+python3 .claude/skills/finance-dashboard/fetch.py --from 2025-01-01 --to 2025-12-31
+python3 .claude/skills/finance-dashboard/fetch.py --top 20   # drill the 20 largest accounts (default 12)
+```
 
-## Step 2 — Choose the window
+It is stdlib-only (no install), reads `LEDGER_API_BASE_URL` / `LEDGER_API_KEY` from the env or
+`mcp_server/.env`, and:
 
-Default: **trailing 12 full months.** With today = the run date, `to_date` = the last day
-of last full month; `from_date` = the first day of the month 11 months before that. Build
-the list of month keys `months = ["YYYY-MM", ...]` (12 entries, chronological). Honor an
-explicit override if the user names a range or a different length.
+1. Picks the window (default: **trailing 12 full months** — `to_date` = last day of last full
+   month, `from_date` = first day of the month 11 months earlier). Override with `--from/--to`.
+2. Fetches `reports/trend/` (the backbone), then per-month `reports/cash-flow/` and
+   `reports/spending-by-entity/`, plus `accounts/` and `entities/` — concurrently.
+3. Drills `reports/account-detail/` for the largest accounts by default (`--top N`, `--full`
+   for all). The template degrades gracefully — undrilled accounts just show an empty panel.
+4. Computes 3–6 callouts, injects the blob into the `<script id="ledger-data">` placeholder,
+   and writes `dashboards/dashboard.html`.
 
-## Step 3 — Fetch (map tool output straight into the blob)
+Then verify and report (Step 6). If the run fails because the tools/creds aren't reachable,
+tell the user to register/point the server per `mcp_server/README.md`, or use the fallback.
 
-Dates are `YYYY-MM-DD`. Money fields come back as 2-dp **strings**; keep them as-is (the
-template parses them). Make these calls:
+## Fallback — MCP tools by hand (only if the script can't run)
 
-1. `get_trend(from_date, to_date)` — **the backbone.** One flat `balances` array of
-   `{account, account_type, sub_type, amount, flow_type, date}`. The template rebuilds the
-   income statement, balance sheet, all KPIs, and every rate/ratio from this for any
-   selected period, so this single call powers most of the dashboard. Put its `balances`
-   array at `trend`.
-2. For **each month** `m` in `months`, with that month's first/last day:
-   - `get_cash_flow(from, to)` → store the full response at `cash_flow_by_month[m]`
-     (cash flow can't be rebuilt from trend — it needs the operations/financing/investing
-     split).
-   - `spending_by_entity(from, to)` → store at `spending_by_month[m]` (entity breakdown
-     isn't in trend).
-   These 24 calls make the Cash Flow and Spending-by-Entity tabs dynamic per period.
-3. `list_accounts()` → `accounts` (gives the id↔name map the drill-down needs).
-   `list_entities()` → `entities`.
-4. `account_detail(account_id, from_date, to_date)` for each **open** account (from
-   `list_accounts`, `is_closed=false`) over the full window → store items at
-   `account_detail["<id>"]`. This is the slow step (~one call per account). If the user
-   asked for a fast build, fetch detail only for the largest accounts and note that the
-   rest will populate on a fuller re-run (the template degrades gracefully — accounts
-   without detail just show an empty drill-down).
-
-Run independent calls in parallel where the tooling allows.
-
-## Step 4 — Callouts
-
-From the fetched data, compute a short, curated list (aim for 3–6) of the most useful
-observations for the latest period and the window. Good candidates: largest expense
-category and its biggest payee; biggest month-over-month swing in net income or spending;
-savings-rate or tax-rate shift; any month that looks anomalous vs. its neighbors; notable
-change in total assets or debt. Each is `{severity, title, detail}` where `severity` is one
-of `good | bad | warn | info | neutral` (drives the badge color). Put them at `callouts`.
-
-## Step 5 — Assemble, inject, write
-
-Assemble one JSON object with exactly these keys:
+Use this only when `fetch.py` can't reach the API (e.g. no `.env`, or an MCP-only environment
+where the `mcp__ledger__*` tools work but the script's network/creds don't). It produces the
+same blob, just slowly. Call the tools, assemble one JSON object with **exactly** these keys,
+and inject it the same way the script does:
 
 ```
 {
   "meta": { "built_at": <ISO timestamp>, "from_date": ..., "to_date": ..., "months": [...] },
-  "trend": [ ...balances... ],
-  "cash_flow_by_month": { "YYYY-MM": {...}, ... },
-  "spending_by_month":  { "YYYY-MM": {...}, ... },
-  "accounts": [...], "entities": [...],
-  "account_detail": { "<id>": {...}, ... },
-  "callouts": [ {severity, title, detail}, ... ]
+  "trend": [ ...balances... ],                       # get_trend → .balances
+  "cash_flow_by_month": { "YYYY-MM": {...}, ... },   # get_cash_flow per month
+  "spending_by_month":  { "YYYY-MM": {...}, ... },   # spending_by_entity per month
+  "accounts": [...], "entities": [...],              # list_accounts / list_entities
+  "account_detail": { "<id>": { account, items:[{date,label,amount}] }, ... },  # account_detail per open account
+  "callouts": [ {severity, title, detail}, ... ]     # severity: good|bad|warn|info|neutral
 }
 ```
 
-Then:
-1. Read `template.html` from this skill's directory.
-2. Replace the entire contents of the `<script id="ledger-data" type="application/json">
-   ... </script>` block with the assembled JSON (the placeholder is the single-line
-   `{"meta":...}` object). Leave the rest of the file byte-for-byte unchanged.
-3. Write the result to `dashboards/dashboard.html` (create `dashboards/` if missing).
-
-Prefer doing the injection with a tiny script (read template, `json.dumps` the blob, string-
-replace the placeholder line, write output) rather than hand-editing — it's reliable and
-keeps the large JSON out of the transcript.
+`get_trend` is large and the harness spills it to a `tool-results/*.txt` file — read that file
+directly (jq) instead of through context. Do the injection with a tiny script (read
+`template.html`, `json.dumps` the blob, regex-replace the single-line `{"meta":...}`
+placeholder, write `dashboards/dashboard.html`) — never hand-edit the large JSON.
 
 ## Step 6 — Report
 
-Tell the user the output path and offer to open it (`open dashboards/dashboard.html` on
-macOS). Mention it needs an internet connection on open (Chart.js loads from CDN). Do **not**
-commit it. To refresh later, just re-run this skill — it re-fetches and overwrites.
+Tell the user the output path and offer to open it (`open dashboards/dashboard.html` on macOS).
+Mention it needs an internet connection on open (Chart.js loads from CDN). Note how many
+accounts were drilled (e.g. "top 12; re-run with `--full` for all"). Do **not** commit it.
 
 ## Notes on the data contract (so the blob lines up with the template)
 
 - **Signs:** income and expense `amount`s are positive; the template computes
-  `net_income = sum(income) − sum(expense)`. Ratios (`tax_rate`, `savings_rate`, balance-
-  sheet `metrics`) are floats or `null` — but the template recomputes these itself from
-  trend, so you don't need the dedicated income/balance-sheet endpoints.
+  `net_income = sum(income) − sum(expense)` and recomputes every ratio (`tax_rate`,
+  `savings_rate`, balance-sheet `metrics`) itself from `trend` — so the dedicated
+  income/balance-sheet endpoints aren't needed.
 - **Trend rows** carry a month-end `date`; the template keys periods off `date[:7]`.
   Income-statement rows are `flow_type:"flow"` with `account_type` income/expense; balance-
   sheet rows are `flow_type:"stock"`; it ignores the asset/liability flow rows so nothing
   double-counts.
-- **`spending_by_entity`** omits empty sections and pre-sorts descending — fine, the
-  template re-aggregates and re-sorts across the selected months.
+- **`spending_by_entity`** omits empty sections and pre-sorts descending — fine, the template
+  re-aggregates and re-sorts across the selected months.
+- **Trend row origin (important):** every `reports/trend/` row carries a `statement` field
+  (`"income_statement"` / `"balance_sheet"` / `"cash_flow"`). Filter on it — `flowRows` takes
+  `income_statement`, `stockRows` takes `balance_sheet`. Don't sum flow rows by
+  `flow_type`/`account_type` alone: the cash-flow statement re-emits non-cash expenses (e.g.
+  depreciation) as add-backs identical to the income-statement line, so you'd double-count.
+  (`template.html` keeps a dedupe fallback for servers that predate the field.)

--- a/.claude/skills/finance-dashboard/fetch.py
+++ b/.claude/skills/finance-dashboard/fetch.py
@@ -1,0 +1,265 @@
+#!/usr/bin/env python3
+"""
+Finance-dashboard fetcher — builds dashboards/dashboard.html in one shot.
+
+Talks directly to the same read-only Ledger reporting API the `ledger` MCP
+server wraps (`/api/v1/reports/*` + the account/entity lists), so no payload
+ever round-trips through the agent's context. Read-only by construction: only
+GETs the reporting endpoints, never writes. Reads LEDGER_API_BASE_URL /
+LEDGER_API_KEY from the environment or mcp_server/.env and never prints them.
+
+Usage:
+    python3 fetch.py                      # trailing 12 full months, top accounts drilled
+    python3 fetch.py --full               # drill EVERY open account (slower)
+    python3 fetch.py --from 2025-01-01 --to 2025-12-31
+    python3 fetch.py --top 20             # drill the 20 largest accounts (default 12)
+
+Stdlib only — no pip install needed. Run with any python3.
+"""
+import argparse, calendar, datetime, json, os, re, sys, urllib.parse, urllib.request
+from concurrent.futures import ThreadPoolExecutor
+
+SKILL_DIR = os.path.dirname(os.path.abspath(__file__))
+REPO_ROOT = os.path.abspath(os.path.join(SKILL_DIR, "..", "..", ".."))
+TEMPLATE  = os.path.join(SKILL_DIR, "template.html")
+OUT       = os.path.join(REPO_ROOT, "dashboards", "dashboard.html")
+ENV_FILE  = os.path.join(REPO_ROOT, "mcp_server", ".env")
+
+
+def load_env():
+    base = os.environ.get("LEDGER_API_BASE_URL", "")
+    key  = os.environ.get("LEDGER_API_KEY", "")
+    if (not base or not key) and os.path.exists(ENV_FILE):
+        with open(ENV_FILE) as f:
+            for line in f:
+                line = line.strip()
+                if not line or line.startswith("#") or "=" not in line:
+                    continue
+                k, v = line.split("=", 1)
+                v = v.strip().strip('"').strip("'")
+                if k.strip() == "LEDGER_API_BASE_URL" and not base:
+                    base = v
+                elif k.strip() == "LEDGER_API_KEY" and not key:
+                    key = v
+    if not base or not key:
+        sys.exit("LEDGER_API_BASE_URL / LEDGER_API_KEY not set (env or "
+                 "mcp_server/.env). See mcp_server/README.md.")
+    return base.rstrip("/"), key
+
+
+BASE, KEY = load_env()
+
+
+def get(path, **params):
+    """GET a reporting endpoint, return parsed JSON. Read-only."""
+    clean = {k: v for k, v in params.items() if v is not None}
+    url = f"{BASE}/{path.lstrip('/')}"
+    if clean:
+        url += "?" + urllib.parse.urlencode(clean)
+    req = urllib.request.Request(url, headers={"Authorization": f"Api-Key {KEY}"})
+    with urllib.request.urlopen(req, timeout=60) as r:
+        return json.load(r)
+
+
+def month_window(today):
+    """Trailing 12 full months ending with last month. Returns (from, to, [keys])."""
+    first_this = today.replace(day=1)
+    last_full_end = first_this - datetime.timedelta(days=1)          # end of last month
+    to_date = last_full_end
+    start = (to_date.replace(day=1))
+    for _ in range(11):                                              # step back 11 months
+        start = (start - datetime.timedelta(days=1)).replace(day=1)
+    keys, cur = [], start
+    while cur <= to_date:
+        keys.append(cur.strftime("%Y-%m"))
+        nxt = (cur.replace(day=28) + datetime.timedelta(days=7)).replace(day=1)
+        cur = nxt
+    return start.isoformat(), to_date.isoformat(), keys
+
+
+def month_bounds(key):
+    y, m = map(int, key.split("-"))
+    return f"{key}-01", f"{y:04d}-{m:02d}-{calendar.monthrange(y, m)[1]:02d}"
+
+
+def usd(n):
+    return ("-" if n < 0 else "") + "$" + f"{abs(n):,.0f}"
+
+
+def num(v):
+    try:
+        return float(v)
+    except (TypeError, ValueError):
+        return 0.0
+
+
+def build_callouts(trend, spending, months):
+    out = []
+    first, last = months[0], months[-1]
+    # net worth from balance-sheet (stock) rows — only the window endpoints, which
+    # is all the net-worth callout reads.
+    a = {first: 0.0, last: 0.0}; l = {first: 0.0, last: 0.0}
+    for r in trend:
+        if r.get("flow_type") != "stock":
+            continue
+        mk = r["date"][:7]
+        if mk not in a:
+            continue
+        if r["account_type"] == "asset":
+            a[mk] += num(r["amount"])
+        elif r["account_type"] == "liability":
+            l[mk] += num(r["amount"])
+    nw = {mk: a[mk] - l[mk] for mk in (first, last)}
+    net = {mk: num(spending[mk]["net_income"]) for mk in months if mk in spending}
+    inc = {mk: num(spending[mk]["income_total"]) for mk in months if mk in spending}
+    tot = sum(net.values())
+
+    out.append({"severity": "good" if nw[last] >= nw[first] else "bad",
+                "title": f"Net worth {usd(nw[last])}",
+                "detail": f"{'Up' if nw[last]>=nw[first] else 'Down'} "
+                          f"{usd(abs(nw[last]-nw[first]))} over the window "
+                          f"(from {usd(nw[first])} at {first})."})
+    if len(months) >= 2 and last in net:
+        prev = months[-2]
+        out.append({"severity": "bad" if net[last] < 0 else "good",
+                    "title": f"{last} net income {usd(net[last])}",
+                    "detail": f"Versus {usd(net.get(prev,0))} the month before "
+                              f"on {usd(inc.get(last,0))} of income."})
+    out.append({"severity": "info", "title": f"Trailing net income {usd(tot)}",
+                "detail": f"Total across {first}–{last}. Monthly swings are "
+                          f"dominated by unrealized investment gains/losses."})
+    # biggest MoM swing in net income
+    swing = max(((abs(net[months[i]]-net[months[i-1]]), months[i])
+                 for i in range(1, len(months)) if months[i] in net), default=(0, None))
+    if swing[1]:
+        mk = swing[1]
+        out.append({"severity": "warn",
+                    "title": f"Biggest month-over-month swing: {mk}",
+                    "detail": f"Net income moved {usd(swing[0])} vs. the prior month."})
+    # top expense category (latest month) + top payees (window)
+    cat = {}
+    for r in trend:
+        if r.get("flow_type") == "flow" and r["account_type"] == "expense" \
+                and r["date"][:7] == last:
+            cat[r["account"]] = cat.get(r["account"], 0) + num(r["amount"])
+    payee = {}
+    for mk in months:
+        for grp in spending.get(mk, {}).get("expense_sub_types", []):
+            for b in grp.get("balances", []):
+                payee[b["entity"]] = payee.get(b["entity"], 0) + num(b["amount"])
+    top_cat = sorted(cat.items(), key=lambda x: -x[1])[:1]
+    top_pay = sorted(payee.items(), key=lambda x: -x[1])[:3]
+    if top_cat:
+        out.append({"severity": "neutral",
+                    "title": f"Top spend category in {last}: {top_cat[0][0]}",
+                    "detail": f"{usd(top_cat[0][1])}. Largest payees over the window: "
+                              + ", ".join(f"{n} ({usd(v)})" for n, v in top_pay) + "."})
+    # largest debt move over the window
+    debt = {}
+    for r in trend:
+        if r.get("flow_type") == "stock" and r["account_type"] == "liability":
+            debt.setdefault(r["account"], {})[r["date"][:7]] = num(r["amount"])
+    moves = []
+    for name, series in debt.items():
+        f = series.get(first); L = series.get(last)
+        if f is not None and L is not None:
+            moves.append((L - f, name))
+    if moves:
+        d, name = max(moves, key=lambda x: abs(x[0]))
+        out.append({"severity": "warn" if d > 0 else "good",
+                    "title": f"Debt: {name} {'up' if d>0 else 'down'} {usd(abs(d))}",
+                    "detail": f"Largest liability change over {first}–{last}."})
+    return out[:6]
+
+
+def rank_accounts(trend, open_accts, months):
+    """Rank open accounts by magnitude for the default (partial) drill-down."""
+    last = months[-1]
+    mag = {}
+    for r in trend:
+        name = r["account"]
+        if r.get("flow_type") == "stock" and r["date"][:7] == last:
+            mag[name] = max(mag.get(name, 0), abs(num(r["amount"])))
+        elif r.get("flow_type") == "flow":
+            mag[name] = mag.get(name, 0) + abs(num(r["amount"]))
+    return sorted(open_accts, key=lambda ac: -mag.get(ac["name"], 0))
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--from", dest="frm"); ap.add_argument("--to", dest="to")
+    ap.add_argument("--full", action="store_true", help="drill every open account")
+    ap.add_argument("--top", type=int, default=12, help="how many accounts to drill (default 12)")
+    args = ap.parse_args()
+
+    today = datetime.date.today()
+    if args.frm and args.to:
+        frm, to = args.frm, args.to
+        months, cur = [], datetime.date.fromisoformat(frm).replace(day=1)
+        end = datetime.date.fromisoformat(to)
+        while cur <= end:
+            months.append(cur.strftime("%Y-%m"))
+            cur = (cur.replace(day=28) + datetime.timedelta(days=7)).replace(day=1)
+    else:
+        frm, to, months = month_window(today)
+
+    print(f"window {frm} → {to} ({len(months)} months)", file=sys.stderr)
+
+    # Each trend row carries a `statement` origin; the template filters on it so
+    # cash-flow add-backs (e.g. depreciation) aren't summed into the income statement.
+    trend    = get("reports/trend/", from_date=frm, to_date=to).get("balances", [])
+    accounts = get("accounts/").get("accounts", [])
+    entities = get("entities/").get("entities", [])
+    print(f"trend rows {len(trend)} | accounts {len(accounts)} | entities {len(entities)}",
+          file=sys.stderr)
+
+    cash_flow_by_month, spending_by_month = {}, {}
+
+    def fetch_month(mk):
+        f, t = month_bounds(mk)
+        return mk, get("reports/cash-flow/", from_date=f, to_date=t), \
+                   get("reports/spending-by-entity/", from_date=f, to_date=t)
+
+    open_accts = [a for a in accounts if not a.get("is_closed")]
+    drill = open_accts if args.full else rank_accounts(trend, open_accts, months)[:args.top]
+
+    def fetch_detail(ac):
+        return str(ac["id"]), get("reports/account-detail/", account_id=ac["id"],
+                                  from_date=frm, to_date=to)
+
+    with ThreadPoolExecutor(max_workers=8) as ex:
+        for mk, cf, sp in ex.map(fetch_month, months):
+            cash_flow_by_month[mk] = cf
+            spending_by_month[mk] = sp
+        account_detail = {}
+        for aid, det in ex.map(fetch_detail, drill):
+            if det.get("account") and det.get("items"):
+                account_detail[aid] = det
+    print(f"cash_flow {len(cash_flow_by_month)} | spending {len(spending_by_month)} | "
+          f"drilled {len(account_detail)}/{len(open_accts)} open accounts", file=sys.stderr)
+
+    blob = {
+        "meta": {"built_at": datetime.datetime.now().isoformat(timespec="seconds"),
+                 "from_date": frm, "to_date": to, "months": months},
+        "trend": trend,
+        "cash_flow_by_month": cash_flow_by_month,
+        "spending_by_month": spending_by_month,
+        "accounts": accounts, "entities": entities,
+        "account_detail": account_detail,
+        "callouts": build_callouts(trend, spending_by_month, months),
+    }
+
+    with open(TEMPLATE) as f:
+        html = f.read()
+    new = re.sub(r'^\{"meta":.*\}\s*$', lambda _: json.dumps(blob, ensure_ascii=False),
+                 html, count=1, flags=re.M)
+    if new == html:
+        sys.exit("ERROR: ledger-data placeholder not found in template.html")
+    os.makedirs(os.path.dirname(OUT), exist_ok=True)
+    with open(OUT, "w") as f:
+        f.write(new)
+    print(f"wrote {OUT}")
+
+
+if __name__ == "__main__":
+    main()

--- a/.claude/skills/finance-dashboard/template.html
+++ b/.claude/skills/finance-dashboard/template.html
@@ -222,6 +222,13 @@
 // ---- data + helpers -------------------------------------------------------
 const DATA = JSON.parse(document.getElementById('ledger-data').textContent);
 const CH = {}; // live Chart.js instances, keyed so we can destroy on re-render
+// Trend rows tag their originating statement ("income_statement" / "balance_sheet"
+// / "cash_flow"). We filter on it so the cash-flow statement's non-cash add-backs
+// (e.g. depreciation) aren't mistaken for income-statement lines.
+// TRANSITIONAL: fetch.py points at the live API, which may predate the `statement`
+// field; the flowRows/stockRows fallback below keeps the dashboard correct against
+// such a server. Drop HAS_ORIGIN and the fallback branches once it's deployed.
+const HAS_ORIGIN = DATA.trend.some(r => r.statement != null);
 
 const MONEY = v => { const n = parseFloat(v); return Number.isFinite(n) ? n : 0; };
 const usd = n => (n < 0 ? '-' : '') + '$' + Math.abs(n).toLocaleString('en-US',
@@ -267,12 +274,29 @@ const prevPeriod = () => STATE.periods[STATE.idx - 1] || null;
 // net income = sum(income) - sum(expense); metrics regroup the same rows.
 function flowRows(months) {
   const set = new Set(months);
-  return DATA.trend.filter(r => r.flow_type === 'flow'
-    && (r.account_type === 'income' || r.account_type === 'expense')
-    && set.has(mkey(r.date)));
+  if (HAS_ORIGIN) {
+    return DATA.trend.filter(r =>
+      set.has(mkey(r.date)) && r.statement === 'income_statement');
+  }
+  // Fallback for older servers that don't tag origin: the heuristic, plus a dedupe
+  // of identical rows — the cash-flow statement re-emits non-cash expenses (e.g.
+  // depreciation) as byte-identical add-backs, and the income statement has exactly
+  // one row per account/month, so any identical duplicate is a redundant re-emission.
+  const seen = new Set(), out = [];
+  for (const r of DATA.trend) {
+    if (!(r.flow_type === 'flow'
+          && (r.account_type === 'income' || r.account_type === 'expense')
+          && set.has(mkey(r.date)))) continue;
+    const k = r.account + '|' + r.date + '|' + r.amount;
+    if (seen.has(k)) continue;
+    seen.add(k); out.push(r);
+  }
+  return out;
 }
 function stockRows(lastMonth) {
-  return DATA.trend.filter(r => r.flow_type === 'stock' && mkey(r.date) === lastMonth);
+  return DATA.trend.filter(r => mkey(r.date) === lastMonth && (HAS_ORIGIN
+    ? r.statement === 'balance_sheet'
+    : r.flow_type === 'stock'));
 }
 // Aggregate a set of balance rows into type -> sub_type -> accounts, with totals.
 function hierarchy(rows, wantTypes) {

--- a/api/rest_api/report_serializers.py
+++ b/api/rest_api/report_serializers.py
@@ -107,9 +107,17 @@ def serialize_cash_flow_metrics(metrics: CashFlowMetrics) -> Dict[str, Any]:
 
 
 def serialize_trend_balances(balances: List[Balance]) -> List[Dict[str, Any]]:
-    """Monthly time-series rows; each balance carries its month-end date."""
+    """Monthly time-series rows; each balance carries its month-end date and the
+    statement it came from ("income_statement" / "balance_sheet" / "cash_flow"),
+    so a consumer can reconstruct one statement without double-counting rows the
+    cash-flow statement re-emits (e.g. depreciation add-backs)."""
     return [
-        {**serialize_balance(balance), "date": balance.date} for balance in balances
+        {
+            **serialize_balance(balance),
+            "date": balance.date,
+            "statement": getattr(balance, "statement", None),
+        }
+        for balance in balances
     ]
 
 

--- a/api/statement.py
+++ b/api/statement.py
@@ -1,3 +1,4 @@
+import copy
 from collections import namedtuple
 from datetime import date, datetime, timedelta
 
@@ -5,6 +6,22 @@ from dateutil.relativedelta import relativedelta
 from django.db.models import Case, DecimalField, Q, Sum, Value, When
 
 from api.models import Account, JournalEntryItem
+
+
+def _tagged_balances(rows, origin):
+    """Shallow-copy `rows`, labeling each with its originating statement.
+
+    Copying is load-bearing: the cash-flow statement reuses the income
+    statement's Balance instances for non-cash add-backs (see
+    CashFlowStatement.get_cash_from_operations_balances), so tagging in place
+    would relabel a row two statements share.
+    """
+    tagged = []
+    for row in rows:
+        clone = copy.copy(row)
+        clone.statement = origin
+        tagged.append(clone)
+    return tagged
 
 
 class Trend:
@@ -45,9 +62,16 @@ class Trend:
                 income_statement, balance_sheet_start, balance_sheet
             )
 
-            balances += income_statement.get_balances()
-            balances += balance_sheet.get_balances()
-            balances += cash_flow_statement.get_balances()
+            # Tag each row with its originating statement so a consumer can pick
+            # one statement's rows without double-counting the cash-flow
+            # statement's non-cash add-backs (e.g. depreciation).
+            balances += _tagged_balances(
+                income_statement.get_balances(), "income_statement"
+            )
+            balances += _tagged_balances(balance_sheet.get_balances(), "balance_sheet")
+            balances += _tagged_balances(
+                cash_flow_statement.get_balances(), "cash_flow"
+            )
 
         return balances
 
@@ -58,6 +82,11 @@ class Balance:
         self.amount = amount
         self.date = date
         self.type = type
+        # Which statement this row came from: "income_statement",
+        # "balance_sheet", or "cash_flow". Set by Trend (via _tagged_balances) so
+        # consumers can reconstruct a single statement without mistaking cash-flow
+        # add-backs (e.g. depreciation) for income-statement lines. None off Trend.
+        self.statement = None
 
 
 EntityBalance = namedtuple(

--- a/api/tests/rest_api/test_report_views.py
+++ b/api/tests/rest_api/test_report_views.py
@@ -148,6 +148,12 @@ class ReportEndpointsTest(TestCase):
         self.assertIsInstance(response.data["balances"], list)
         self.assertTrue(response.data["balances"])
         self.assertIn("date", response.data["balances"][0])
+        # every row carries its originating statement so consumers can rebuild a
+        # single statement without double-counting cash-flow add-backs
+        valid = {"income_statement", "balance_sheet", "cash_flow"}
+        self.assertTrue(
+            all(row.get("statement") in valid for row in response.data["balances"])
+        )
 
     def test_account_detail(self):
         response = self._get(

--- a/api/tests/statement/test_trend.py
+++ b/api/tests/statement/test_trend.py
@@ -1,7 +1,7 @@
 from datetime import date
 from decimal import Decimal
 from django.test import TestCase
-from api.statement import Trend
+from api.statement import IncomeStatement, Trend
 from api.models import Account
 from api.tests.scenario_builders import (
     create_closed_transaction_with_journal_entry,
@@ -101,3 +101,60 @@ class TrendTest(TestCase):
         trend = Trend('2023-01-01', date(2023, 6, 30))
         balances = trend.get_balances()
         self.assertTrue(balances)
+
+    def test_every_row_tagged_with_statement_origin(self):
+        trend = Trend('2023-01-01', date(2023, 6, 30))
+        valid = {'income_statement', 'balance_sheet', 'cash_flow'}
+        self.assertTrue(
+            all(b.statement in valid for b in trend.get_balances())
+        )
+
+    def test_depreciation_not_double_counted_in_income_rows(self):
+        # A non-cash expense (depreciation) is booked in the income statement AND
+        # re-emitted as a cash-flow operations add-back. The two must land as
+        # separate, origin-tagged trend rows so summing income_statement rows
+        # matches the standalone income statement (regression for 677 -> 1354).
+        vehicle = Account.objects.create(
+            name='1700-Vehicle',
+            type=Account.Type.ASSET,
+            sub_type=Account.SubType.VEHICLES,
+        )
+        deprec = Account.objects.create(
+            name='7000-Vehicle Depreciation',
+            type=Account.Type.EXPENSE,
+            sub_type=Account.SubType.OPERATING,
+            is_depreciation=True,
+        )
+        create_closed_transaction_with_journal_entry(
+            date='2023-03-15',
+            debit_account=deprec,
+            credit_account=vehicle,
+            amount=Decimal('677'),
+            transaction_account=vehicle,
+        )
+
+        trend = Trend('2023-03-01', date(2023, 3, 31))
+        balances = trend.get_balances()
+        deprec_rows = [b for b in balances if b.account.name == deprec.name]
+        is_rows = [b for b in deprec_rows if b.statement == 'income_statement']
+        cf_rows = [b for b in deprec_rows if b.statement == 'cash_flow']
+
+        # exactly one income-statement row (not two), and a separate cash-flow add-back
+        self.assertEqual(len(is_rows), 1)
+        self.assertEqual(is_rows[0].amount, Decimal('677'))
+        self.assertEqual(len(cf_rows), 1)
+
+        # reconstructing the income statement from tagged rows matches the engine
+        income_stmt = IncomeStatement(
+            end_date=date(2023, 3, 31), start_date=date(2023, 3, 1)
+        )
+        engine_expense = sum(
+            b.amount for b in income_stmt.get_balances()
+            if b.account.type == Account.Type.EXPENSE
+        )
+        tagged_expense = sum(
+            b.amount for b in balances
+            if b.statement == 'income_statement'
+            and b.account.type == Account.Type.EXPENSE
+        )
+        self.assertEqual(tagged_expense, engine_expense)

--- a/mcp_server/server.py
+++ b/mcp_server/server.py
@@ -108,7 +108,11 @@ def get_trend(
 ) -> Any:
     """Month-by-month balances across a range — the time series for dashboards.
 
-    Returns one row per account per month, each tagged with its month-end date.
+    Returns one row per account per month, each tagged with its month-end date
+    and a ``statement`` origin ("income_statement", "balance_sheet", or
+    "cash_flow"). Filter by ``statement`` to reconstruct a single statement: the
+    cash-flow rows re-emit non-cash expenses (e.g. depreciation) as add-backs, so
+    summing all flow rows would otherwise double-count them.
     """
     return _get("reports/trend/", {"from_date": from_date, "to_date": to_date})
 


### PR DESCRIPTION
## Problem

The finance dashboard rebuilt the income statement from `reports/trend/`, which concatenates income-statement + balance-sheet + **cash-flow** rows per month. The cash-flow statement re-emits non-cash expenses (e.g. `7000-Vehicle Depreciation`) as operations add-backs that are indistinguishable from the real income-statement line (`flow` / `expense` / same amount / same date). Summing flow rows therefore **double-counted** them — depreciation showed **$1,354** instead of **$677**. The app's own income statement (`reports/income/`) and the journal entries were always correct; only the trend reconstruction was ambiguous.

## Fix

Give every trend row an explicit `statement` origin (`income_statement` / `balance_sheet` / `cash_flow`) so a consumer can rebuild one statement without contamination.

- **`api/statement.py`** — `Balance.statement`; `Trend` tags each source via `_tagged_balances()`, which **shallow-copies** rows before tagging. This matters: the cash-flow statement reuses the income statement's `Balance` instances for depreciation add-backs (`get_cash_from_operations_balances`), so in-place tagging would relabel a row two statements share.
- **`api/rest_api/report_serializers.py`** — emit `statement` on trend rows only; shared `serialize_balance` is untouched, so `reports/income/` and `reports/cash-flow/` are byte-identical.
- **`mcp_server/server.py`** — document the new field on `get_trend` (passthrough; no logic change).
- **finance-dashboard skill** — `template.html` filters trend by `statement` (with a clearly-marked *transitional* fallback for a server that predates the field); new stdlib-only **`fetch.py`** fetches + assembles the dashboard directly against the reporting API in one shot (~15s) instead of round-tripping large payloads through the agent.

## Tests

- Every trend row carries a valid `statement`, asserted at the engine and via the REST endpoint.
- Regression: a depreciation entry lands as exactly one `income_statement` row **and** a separate `cash_flow` row, and income-statement-tagged expenses reconstruct the standalone `IncomeStatement` total.
- `api.tests.statement` + `test_report_views`: **48 passing**.

## Deploy note

Additive to the trend contract (no existing field changed). The dashboard's fallback keeps it correct against the current (un-deployed) server; once this ships, `reports/trend/` carries `statement` and the dashboard uses the clean origin filter automatically. The transitional fallback in `template.html` can then be removed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)