### PR TITLE
Reset the chart-of-accounts numbering system

### DIFF
--- a/api/management/commands/renumber_accounts.py
+++ b/api/management/commands/renumber_accounts.py
@@ -1,0 +1,205 @@
+from django.core.management.base import BaseCommand, CommandError
+from django.db import transaction as db_transaction
+
+from api.models import Account
+
+# Old 4-digit account-number prefix -> new prefix. The command rewrites only the
+# numeric prefix in each Account.name and preserves the label after the first
+# "-", so account labels are deliberately kept out of this file. Grouped by the
+# target band. Every account's current prefix must appear here, so the identity
+# entries (e.g. "5000": "5000") are intentional: they assert that the whole
+# chart is accounted for and let the command abort on any unmapped account.
+PREFIX_MAP = {
+    # --- Assets ---
+    # Cash (1000-1099): shift +10 to open 1000 for the first cash account
+    "0000": "1000",
+    "1000": "1010",
+    "1010": "1020",
+    "1020": "1030",
+    "1030": "1040",
+    "1031": "1050",
+    # Accounts Receivable (1100-1199): pull in the mis-banded receivables
+    "1100": "1100",
+    "1110": "1110",
+    "1001": "1120",  # was typed cash
+    "1420": "1130",  # was in securities band
+    "1430": "1140",
+    "1535": "1150",
+    "1536": "1160",
+    # Prepaid Expenses (1200-1249)
+    "1150": "1200",
+    # Securities - Unrestricted (1300-1399)
+    "1300": "1300",
+    "1310": "1310",
+    "1400": "1320",
+    "1410": "1330",
+    "1320": "1340",
+    # Securities - Retirement (1400-1599): 401k -> HSA -> IRA -> 529 -> stock comp
+    "1500": "1400",
+    "1501": "1410",
+    "1502": "1420",
+    "1520": "1430",
+    "1540": "1440",
+    "1510": "1450",
+    "1511": "1460",
+    "1530": "1470",
+    "1550": "1500",
+    "1560": "1510",
+    "1570": "1520",
+    "1580": "1530",
+    "1590": "1550",
+    "1311": "1560",  # was in unrestricted band
+    # Real Estate (1600-1699)
+    "1600": "1600",
+    "1610": "1610",
+    # Vehicles (1700-1799)
+    "1710": "1700",
+    # --- Liabilities ---
+    # Short-term Debt (2000-2099)
+    "2000": "2000",
+    "2010": "2010",
+    "2020": "2020",
+    # Taxes Payable (2100-2199)
+    "2100": "2100",
+    "2110": "2110",
+    "2120": "2120",
+    "2121": "2121",
+    "2130": "2130",
+    # Long-term Debt (2500-2599)
+    "2500": "2500",
+    "2505": "2510",
+    "2510": "2520",
+    "2515": "2530",
+    # --- Equity ---
+    "3000": "3000",
+    # --- Income ---
+    # Salary (4000-4099)
+    "4000": "4000",
+    "4010": "4010",
+    # Dividends & Interest (4100-4199)
+    "4020": "4100",
+    "4030": "4110",
+    # Other Income (4200-4299)
+    "4040": "4200",
+    "4045": "4210",
+    # Realized Investment Gains (4300-4399)
+    "4050": "4300",
+    # Unrealized Investment Gains (4400-4499)
+    "4100": "4400",
+    # --- Expenses ---
+    # Operating (5000-5899) + fees (5900-5989) - unchanged
+    "5000": "5000",
+    "5100": "5100",
+    "5200": "5200",
+    "5300": "5300",
+    "5301": "5301",
+    "5302": "5302",
+    "5400": "5400",
+    "5401": "5401",
+    "5410": "5410",
+    "5420": "5420",
+    "5500": "5500",
+    "5510": "5510",
+    "5520": "5520",
+    "5530": "5530",
+    "5600": "5600",
+    "5601": "5601",
+    "5610": "5610",
+    "5620": "5620",
+    "5700": "5700",
+    "5710": "5710",
+    "5800": "5800",
+    "5810": "5810",
+    "5820": "5820",
+    "5830": "5830",
+    "5840": "5840",
+    "5850": "5850",
+    "5900": "5900",
+    "5910": "5910",
+    "5920": "5920",
+    "5930": "5930",
+    # Depreciation (5990-5999)
+    "7000": "5990",
+    # Interest (6000-6099)
+    "6000": "6000",
+    "6005": "6010",
+    "6010": "6020",
+    "6015": "6030",
+    # Tax (6100-6199) - unchanged
+    "6100": "6100",
+    "6110": "6110",
+    "6120": "6120",
+    "6121": "6121",
+    "6130": "6130",
+    "6131": "6131",
+    "6140": "6140",
+}
+
+
+class Command(BaseCommand):
+    help = (
+        "Renumber the chart of accounts by rewriting the NNNN- prefix in each "
+        "account name. Labels are preserved; only the numeric prefix changes."
+    )
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--dry-run",
+            action="store_true",
+            help="Print the old -> new mapping and write nothing.",
+        )
+
+    def handle(self, *args, **options):
+        # Plan the rename; every account must have a known prefix or we abort so
+        # a partial run against the wrong database is impossible.
+        planned = []  # list of (account, new_name)
+        unmapped = []
+        for account in Account.objects.all():
+            prefix, sep, label = account.name.partition("-")
+            if not sep or prefix not in PREFIX_MAP:
+                unmapped.append(account.name)
+                continue
+            planned.append((account, f"{PREFIX_MAP[prefix]}-{label}"))
+
+        if unmapped:
+            raise CommandError(
+                "Aborting without changes: these accounts have no prefix mapping, "
+                "so this is the wrong database or the chart has drifted:\n  "
+                + "\n  ".join(sorted(unmapped))
+            )
+
+        changed = [
+            (account, new_name)
+            for account, new_name in planned
+            if account.name != new_name
+        ]
+        for account, new_name in sorted(changed, key=lambda p: p[1]):
+            self.stdout.write(f"  {account.name}  ->  {new_name}")
+
+        if options["dry_run"]:
+            self.stdout.write(
+                self.style.WARNING(
+                    f"Dry run: {len(changed)} of {len(planned)} accounts would "
+                    "change. No changes written."
+                )
+            )
+            return
+
+        # Two-phase rename inside one transaction. A new number can collide with
+        # an existing one mid-flight (e.g. 4020->4100 while 4100->4400), and name
+        # is unique, so first park each on a unique sentinel, then set final names.
+        accounts = [account for account, _new_name in changed]
+        with db_transaction.atomic():
+            for account, _new_name in changed:
+                account.name = f"TMP{account.id}"
+            Account.objects.bulk_update(accounts, ["name"])
+
+            for account, new_name in changed:
+                account.name = new_name
+            Account.objects.bulk_update(accounts, ["name"])
+
+        self.stdout.write(
+            self.style.SUCCESS(
+                f"Renumbered {len(changed)} of {len(planned)} accounts."
+            )
+        )

--- a/api/statement.py
+++ b/api/statement.py
@@ -632,6 +632,9 @@ class BalanceSheet(Statement):
         investment_gains_losses, net_retained_earnings = (
             self.get_retained_earnings_values()
         )
+        # These are synthetic display-only rows, not persisted accounts. The
+        # 9000-9199 number band is reserved for them across the chart of
+        # accounts, so real accounts must never use it.
         retained_earnings_account = Account(
             name="9000-Net Retained Earnings",
             type=Account.Type.EQUITY,

--- a/api/tests/test_renumber_accounts.py
+++ b/api/tests/test_renumber_accounts.py
@@ -1,0 +1,79 @@
+"""Tests for the renumber_accounts management command.
+
+The command maps by numeric prefix only, so these use synthetic labels.
+"""
+
+from io import StringIO
+
+from django.core.management import call_command
+from django.core.management.base import CommandError
+from django.test import TestCase
+
+from api.models import Account
+from api.tests.testing_factories import AccountFactory
+
+
+class RenumberAccountsTest(TestCase):
+    def _run(self, **kwargs):
+        out = StringIO()
+        call_command("renumber_accounts", stdout=out, **kwargs)
+        return out.getvalue()
+
+    def test_rewrites_prefix_and_preserves_label(self):
+        account = AccountFactory(name="1000-Checking Account")
+        self._run()
+        account.refresh_from_db()
+        self.assertEqual(account.name, "1010-Checking Account")
+
+    def test_preserves_labels_with_punctuation(self):
+        account = AccountFactory(name="5420-Food, Fuel, Fun")
+        self._run()
+        account.refresh_from_db()
+        # 5420 is unchanged in the map; the comma-laden label survives intact.
+        self.assertEqual(account.name, "5420-Food, Fuel, Fun")
+
+    def test_handles_colliding_targets_without_integrity_error(self):
+        # 4020 -> 4100 while 4100 -> 4400: the intermediate 4100 collides with a
+        # still-existing account, which the two-phase rename must absorb.
+        first = AccountFactory(name="4020-Account One")
+        second = AccountFactory(
+            name="4100-Account Two",
+            special_type=Account.SpecialType.UNREALIZED_GAINS_AND_LOSSES,
+        )
+        self._run()
+        first.refresh_from_db()
+        second.refresh_from_db()
+        self.assertEqual(first.name, "4100-Account One")
+        self.assertEqual(second.name, "4400-Account Two")
+        # special_type is left untouched by the rename.
+        self.assertEqual(
+            second.special_type,
+            Account.SpecialType.UNREALIZED_GAINS_AND_LOSSES,
+        )
+
+    def test_rebands_account_into_correct_band(self):
+        account = AccountFactory(name="1311-Holding")
+        self._run()
+        account.refresh_from_db()
+        self.assertEqual(account.name, "1560-Holding")
+
+    def test_unknown_prefix_aborts_without_writing(self):
+        valid = AccountFactory(name="1000-Checking Account")
+        AccountFactory(name="9999-Unmapped Account")
+        with self.assertRaises(CommandError):
+            self._run()
+        valid.refresh_from_db()
+        self.assertEqual(valid.name, "1000-Checking Account")
+
+    def test_name_without_prefix_aborts(self):
+        AccountFactory(name="No Prefix Here")
+        with self.assertRaises(CommandError):
+            self._run()
+
+    def test_dry_run_writes_nothing(self):
+        account = AccountFactory(name="1000-Checking Account")
+        output = self._run(dry_run=True)
+        account.refresh_from_db()
+        self.assertEqual(account.name, "1000-Checking Account")
+        self.assertIn("Dry run", output)
+        self.assertIn("1000-Checking Account  ->  1010-Checking Account", output)


### PR DESCRIPTION
## Context

The account "number" is a `NNNN-` prefix embedded inside the unique `Account.name` — there is **no dedicated number column**, and `Account.Meta.ordering = ("name",)` means the prefix is what drives display sort order. Nothing parses the numeric value; it's purely cosmetic/ordering.

Over time the live chart drifted: some accounts were numbered into the **wrong band for their `sub_type`**, and a couple of bands overlapped (e.g. where dividends/interest should expand).

## What this does

Adds a one-shot `renumber_accounts` management command that rewrites each prefix per a `PREFIX_MAP`, re-banding every account into the correct type/sub_type range. Account **labels** (the text after the first `-`) are preserved and deliberately kept out of the map, so no account names live in the codebase.

```
ASSETS   1000s cash · 1100s receivables · 1200s prepaid · 1300s unrestricted securities
         1400–1599 retirement · 1600s real estate · 1700s vehicles
LIAB     2000s short-term · 2100s taxes payable · 2500s long-term
EQUITY   3000s
INCOME   4000s salary · 4100 dividends/interest · 4200 other · 4300 realized · 4400 unrealized
EXPENSE  5000s operating · 5990 depreciation · 6000s interest · 6100s tax
RESERVED 9000–9199 (synthetic balance-sheet rows; kept empty)
```

Mechanism:
- **Prefix-driven** (numbers only), so it's DB-independent and self-checking — every account's current prefix must be in the map.
- **Two-phase, atomic `bulk_update`** — parks each changed account on a `TMP{id}` sentinel, then sets final names — to survive the `unique(name)` collisions that occur mid-flight.
- **Aborts with no writes** if any account's prefix is unmapped (wrong-DB / drift guard).
- `--dry-run` prints the diff and writes nothing.

Also documents the reserved `9000–9199` band in `statement.py`, where the synthetic balance-sheet equity rows live.

## Applying to live data

The live data isn't writable from CI. After merge/deploy, run against prod:

```bash
uv run python manage.py renumber_accounts --dry-run   # review the diff
uv run python manage.py renumber_accounts             # apply
```

## Testing

- New `api/tests/test_renumber_accounts.py` (7 tests, synthetic labels): prefix rewrite + label preservation (incl. punctuation), the collision pair, a re-band, `special_type` untouched, unmapped-prefix and no-prefix aborts, and `--dry-run`.
- Full suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)