### PR TITLE
Restrict reconciliation gain/loss plugs to investment accounts

### DIFF
--- a/api/models.py
+++ b/api/models.py
@@ -284,6 +284,15 @@ class Reconciliation(models.Model):
         return str(self.date) + " " + self.account.name
 
     def plug_investment_change(self):
+        if self.account.sub_type not in Account.INVESTMENT_SUB_TYPES:
+            raise ValidationError(
+                f"Cannot plug a gain/loss for {self.account.name}: reconciliation "
+                "gain/loss plugs mark an account to unrealized investment gains, "
+                "which is only valid for investment accounts (securities, real "
+                "estate, vehicles). Marking any other account breaks the "
+                "cash-flow reconciliation."
+            )
+
         GAIN_LOSS_ACCOUNT = Account.objects.get(
             special_type=Account.SpecialType.UNREALIZED_GAINS_AND_LOSSES
         )
@@ -652,6 +661,20 @@ class Account(models.Model):
         ],
         Type.EXPENSE: [SubType.OPERATING, SubType.INTEREST, SubType.TAX],
     }
+
+    # Asset classes carried at fair value, whose balance changes can be non-cash
+    # marks (unrealized gains/losses). The cash flow statement excludes these
+    # marks from investing (get_cash_from_investing_balances) and from net income
+    # (net_income_less_gains_and_losses), so a mark cancels out cleanly. Marking
+    # any *other* account to unrealized gains has no such offset and breaks the
+    # cash-flow reconciliation, so plug_investment_change is restricted to this
+    # set.
+    INVESTMENT_SUB_TYPES = [
+        SubType.SECURITIES_UNRESTRICTED,
+        SubType.SECURITIES_RETIREMENT,
+        SubType.REAL_ESTATE,
+        SubType.VEHICLES,
+    ]
 
     name = models.CharField(max_length=200, unique=True)
     type = models.CharField(max_length=9, choices=Type.choices)

--- a/api/statement.py
+++ b/api/statement.py
@@ -423,12 +423,7 @@ class CashFlowStatement(Statement):
     def get_cash_from_investing_balances(self):
         start_date = self.income_statement.start_date
         end_date = self.income_statement.end_date
-        account_sub_types = [
-            Account.SubType.SECURITIES_RETIREMENT,
-            Account.SubType.SECURITIES_UNRESTRICTED,
-            Account.SubType.REAL_ESTATE,
-            Account.SubType.VEHICLES,
-        ]
+        account_sub_types = Account.INVESTMENT_SUB_TYPES
         # Drop entries whose offsetting leg is non-cash: an unrealized-gain mark
         # or a depreciation drawdown. A real purchase or sale touches neither,
         # so it stays in investing. One .exclude() keeps it to a single subquery.

--- a/api/tests/models/test_reconciliation.py
+++ b/api/tests/models/test_reconciliation.py
@@ -1,6 +1,7 @@
 import datetime
 from decimal import Decimal
 from django.test import TestCase
+from django.core.exceptions import ValidationError
 from django.db.utils import IntegrityError
 from api.models import Reconciliation, Account, JournalEntryItem
 from api.tests.testing_factories import AccountFactory, EntityFactory, TransactionFactory, JournalEntryFactory, JournalEntryItemFactory
@@ -45,9 +46,10 @@ class ReconciliationTests(TestCase):
             type=Account.Type.INCOME,
             special_type=Account.SpecialType.UNREALIZED_GAINS_AND_LOSSES
         )
-        cash_account = AccountFactory(
-            name='cash',
-            type=Account.Type.ASSET
+        investment_account = AccountFactory(
+            name='brokerage',
+            type=Account.Type.ASSET,
+            sub_type=Account.SubType.SECURITIES_UNRESTRICTED
         )
         income_account = AccountFactory(
             name='income',
@@ -64,7 +66,7 @@ class ReconciliationTests(TestCase):
         )
         journal_entry_item = JournalEntryItemFactory(
             journal_entry=journal_entry,
-            account=cash_account,
+            account=investment_account,
             amount=100,
             type=JournalEntryItem.JournalEntryType.DEBIT
         )
@@ -75,21 +77,43 @@ class ReconciliationTests(TestCase):
             type=JournalEntryItem.JournalEntryType.CREDIT
         )
         reconciliation = Reconciliation.objects.create(
-            account=cash_account,
+            account=investment_account,
             date=today,
             amount=Decimal('200.00')
         )
         reconciliation.plug_investment_change()
 
         self.assertEqual(reconciliation.transaction.amount, 100)
-        self.assertEqual(cash_account.get_balance(end_date=today), 200)
+        self.assertEqual(investment_account.get_balance(end_date=today), 200)
         self.assertEqual(unrealized_account.get_balance(today,start_date=today), 100)
 
         reconciliation.amount = Decimal('50.00')
         reconciliation.plug_investment_change()
         self.assertEqual(reconciliation.transaction.amount, Decimal('-50.00'))
-        self.assertEqual(cash_account.get_balance(today), 50)
+        self.assertEqual(investment_account.get_balance(today), 50)
         self.assertEqual(unrealized_account.get_balance(today,start_date=today), Decimal('-50.00'))
+
+    def test_plug_rejects_non_investment_account(self):
+        # A gain/loss plug marks an account to unrealized investment gains, which
+        # only reconciles for investment accounts. Plugging anything else (here a
+        # receivable) would leave a permanent cash-flow discrepancy, so it must
+        # raise instead of writing the entry.
+        today = datetime.date.today()
+        # No unrealized-gains account is needed: the guard rejects before the
+        # plug ever looks one up.
+        receivable_account = AccountFactory(
+            name='espp',
+            type=Account.Type.ASSET,
+            sub_type=Account.SubType.ACCOUNTS_RECEIVABLE
+        )
+        reconciliation = Reconciliation.objects.create(
+            account=receivable_account,
+            date=today,
+            amount=Decimal('200.00')
+        )
+        with self.assertRaises(ValidationError):
+            reconciliation.plug_investment_change()
+        self.assertIsNone(reconciliation.transaction)
 
     def _plug_items_for_account_entity(self, entity):
         today = datetime.date.today()
@@ -100,6 +124,7 @@ class ReconciliationTests(TestCase):
         investment_account = AccountFactory(
             name='vanguard',
             type=Account.Type.ASSET,
+            sub_type=Account.SubType.SECURITIES_UNRESTRICTED,
             entity=entity
         )
         reconciliation = Reconciliation.objects.create(

--- a/api/views/reconciliation_views.py
+++ b/api/views/reconciliation_views.py
@@ -1,4 +1,5 @@
 from django.contrib.auth.mixins import LoginRequiredMixin
+from django.core.exceptions import ValidationError
 from django.forms import modelformset_factory
 from django.http import HttpResponse
 from django.shortcuts import get_object_or_404
@@ -107,7 +108,10 @@ class ReconciliationView(ReconciliationTableMixin, LoginRequiredMixin, View):
             reconciliation = get_object_or_404(
                 Reconciliation, pk=request.POST.get("plug")
             )
-            reconciliation.plug_investment_change()
+            try:
+                reconciliation.plug_investment_change()
+            except ValidationError as error:
+                return HttpResponse(error.messages[0], status=400)
         else:
             ReconciliationFormset = modelformset_factory(
                 Reconciliation, ReconciliationForm, extra=0


### PR DESCRIPTION
## What

Guards `Reconciliation.plug_investment_change` so it only marks **investment** accounts (securities / real estate / vehicles) to unrealized gains, and makes the cash-flow investing bucket reference the same shared definition.

## Why

A gain/loss plug credits the unrealized-gains account and debits the reconciled account. That only reconciles for investment accounts, because the cash-flow statement cancels the mark on both sides:

- `net_income_less_gains_and_losses` strips the unrealized-gain income leg from operations, and
- `get_cash_from_investing_balances` excludes the offsetting asset leg — **only** for `sub_type in {securities_unrestricted, securities_retirement, real_estate, vehicles}`.

Plug any *other* account (a 2023 plug hit the `accounts_receivable` ESPP account) and the asset delta stays in operations with no offset → a permanent, all-time cash-flow discrepancy (this is the 49.99 the diagnostic command traced to JE 890).

## Change

- **`Account.INVESTMENT_SUB_TYPES`** — one definition of "assets carried at fair value, whose marks the cash-flow statement cancels."
- **`plug_investment_change`** — raises `ValidationError` for accounts outside that set (short-circuits before any DB read/write).
- **`get_cash_from_investing_balances`** — references the shared constant instead of an inline copy, so the guard boundary and the statement boundary can't drift.
- **`ReconciliationView.post`** — catches the error so the plug button can't 500.
- Tests: updated plug tests to investment accounts; added a rejection test.

## Follow-ups (tracked, not in this PR)

- Surface the rejection in the HTMX UI (the current `400` body is swallowed by htmx — re-render the table with an inline alert).
- Hide the Plug button on non-investment rows (`Account.is_investment` + template `{% if %}`).
- Enforce the same invariant at the journal-entry level, so a manual entry crediting unrealized gains against a non-investment account can't reproduce the bug.

## Notes

- No PII. Full test suite green (`api.tests.models`, `api.tests.statement`, `api.tests.services`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)