### PR TITLE
Harden the unrealized-gains / cash-flow invariant (F3+F4+F5)

### DIFF
--- a/api/models.py
+++ b/api/models.py
@@ -284,7 +284,7 @@ class Reconciliation(models.Model):
         return str(self.date) + " " + self.account.name
 
     def plug_investment_change(self):
-        if self.account.sub_type not in Account.INVESTMENT_SUB_TYPES:
+        if not self.account.is_investment:
             raise ValidationError(
                 f"Cannot plug a gain/loss for {self.account.name}: reconciliation "
                 "gain/loss plugs mark an account to unrealized investment gains, "
@@ -741,6 +741,10 @@ class Account(models.Model):
 
         if self.tax_rate is not None and self.tax_amount is not None:
             raise ValidationError("Only one of tax_rate or tax_amount can be set.")
+
+    @property
+    def is_investment(self):
+        return self.sub_type in Account.INVESTMENT_SUB_TYPES
 
     @staticmethod
     def get_balance_from_debit_and_credit(account_type, debits, credits):

--- a/api/services/journal_entry_services.py
+++ b/api/services/journal_entry_services.py
@@ -282,6 +282,46 @@ class ValidationResult:
     errors: List[str]
 
 
+def validate_unrealized_gains_offset(
+    debits_data: List[dict],
+    credits_data: List[dict],
+) -> Optional[str]:
+    """Enforce the unrealized-gains / cash-flow invariant at the write layer.
+
+    A credit to the unrealized-gains account (special_type
+    UNREALIZED_GAINS_AND_LOSSES) marks an asset to fair value. The cash-flow
+    statement only cancels that mark cleanly when the offsetting debit is an
+    investment account (Account.INVESTMENT_SUB_TYPES). Marking any other account
+    leaves a permanent cash-flow residual, so we reject those entries here. See
+    Reconciliation.plug_investment_change for the sibling guard on the plug path.
+
+    Returns an error string, or None when valid. Only entries that actually
+    credit the unrealized-gains account are checked, so ordinary multi-leg
+    entries are unaffected.
+    """
+    credits_unrealized_gains = any(
+        item.get("account")
+        and item["account"].special_type
+        == Account.SpecialType.UNREALIZED_GAINS_AND_LOSSES
+        for item in credits_data
+    )
+    if not credits_unrealized_gains:
+        return None
+
+    for item in debits_data:
+        account = item.get("account")
+        if not account:
+            continue
+        if not account.is_investment:
+            return (
+                f"Cannot credit unrealized investment gains against {account.name}: "
+                "marking to unrealized gains is only valid for investment accounts "
+                "(securities, real estate, vehicles). Marking any other account "
+                "breaks the cash-flow reconciliation."
+            )
+    return None
+
+
 def validate_journal_entry_balance(
     transaction: Transaction,
     debits_data: List[dict],
@@ -303,6 +343,11 @@ def validate_journal_entry_balance(
     # Check balance
     if debit_total != credit_total:
         errors.append(f"Debits (${debit_total}) and Credits (${credit_total}) must balance.")
+
+    # Enforce the unrealized-gains / cash-flow invariant
+    invariant_error = validate_unrealized_gains_offset(debits_data, credits_data)
+    if invariant_error:
+        errors.append(invariant_error)
 
     # Check transaction match
     formset_data = debits_data if transaction.amount >= 0 else credits_data
@@ -364,6 +409,16 @@ def save_journal_entry(
     Returns SaveResult with journal_entry on success.
     """
     try:
+        # 0. Reject invariant-breaking entries before writing anything. This is
+        # the write-layer backstop shared by every producer (form + REST), so a
+        # caller that skips validate_journal_entry_balance still cannot persist a
+        # mark that would break the cash-flow reconciliation.
+        invariant_error = validate_unrealized_gains_offset(debits_data, credits_data)
+        if invariant_error:
+            return SaveResult(
+                success=False, journal_entry=None, error=invariant_error
+            )
+
         # 1. Get or create JournalEntry
         try:
             journal_entry = transaction_obj.journal_entry

--- a/api/tests/models/test_account.py
+++ b/api/tests/models/test_account.py
@@ -70,3 +70,13 @@ class AccountModelTest(TestCase):
         # Test balance calculation for income account within a date range
         balance = self.income_account.get_balance(end_date=self.income_statement_date, start_date=self.income_statement_date)
         self.assertEqual(balance, Decimal('50.00'), "Balance should be credits minus debits for income account")
+
+    def test_is_investment_true_for_investment_sub_types(self):
+        for sub_type in Account.INVESTMENT_SUB_TYPES:
+            account = AccountFactory(type=Account.Type.ASSET, sub_type=sub_type)
+            self.assertTrue(account.is_investment)
+
+    def test_is_investment_false_for_non_investment_sub_types(self):
+        for sub_type in [Account.SubType.CASH, Account.SubType.ACCOUNTS_RECEIVABLE]:
+            account = AccountFactory(type=Account.Type.ASSET, sub_type=sub_type)
+            self.assertFalse(account.is_investment)

--- a/api/tests/services/test_journal_entry_services.py
+++ b/api/tests/services/test_journal_entry_services.py
@@ -201,6 +201,74 @@ class ValidateJournalEntryBalanceTest(TestCase):
         # Should still pass - empty items are ignored
         self.assertTrue(result.is_valid)
 
+    def test_validate_unrealized_gains_offset_allows_investment_debit(self):
+        """Crediting unrealized gains is valid when offset by an investment debit."""
+        securities_account = AccountFactory(
+            type=Account.Type.ASSET,
+            sub_type=Account.SubType.SECURITIES_UNRESTRICTED,
+        )
+        gains_account = AccountFactory(
+            type=Account.Type.INCOME,
+            sub_type=Account.SubType.UNREALIZED_INVESTMENT_GAINS,
+            special_type=Account.SpecialType.UNREALIZED_GAINS_AND_LOSSES,
+        )
+        transaction = TransactionFactory(
+            account=securities_account, amount=Decimal("100.00")
+        )
+        debits_data = [
+            {"account": securities_account, "amount": Decimal("100.00"), "entity": None, "id": None}
+        ]
+        credits_data = [
+            {"account": gains_account, "amount": Decimal("100.00"), "entity": None, "id": None}
+        ]
+
+        result = validate_journal_entry_balance(transaction, debits_data, credits_data)
+
+        self.assertTrue(result.is_valid)
+
+    def test_validate_unrealized_gains_offset_rejects_non_investment_debit(self):
+        """Crediting unrealized gains against a receivable breaks cash flow."""
+        receivable_account = AccountFactory(
+            type=Account.Type.ASSET,
+            sub_type=Account.SubType.ACCOUNTS_RECEIVABLE,
+        )
+        gains_account = AccountFactory(
+            type=Account.Type.INCOME,
+            sub_type=Account.SubType.UNREALIZED_INVESTMENT_GAINS,
+            special_type=Account.SpecialType.UNREALIZED_GAINS_AND_LOSSES,
+        )
+        transaction = TransactionFactory(
+            account=receivable_account, amount=Decimal("100.00")
+        )
+        debits_data = [
+            {"account": receivable_account, "amount": Decimal("100.00"), "entity": None, "id": None}
+        ]
+        credits_data = [
+            {"account": gains_account, "amount": Decimal("100.00"), "entity": None, "id": None}
+        ]
+
+        result = validate_journal_entry_balance(transaction, debits_data, credits_data)
+
+        self.assertFalse(result.is_valid)
+        self.assertTrue(
+            any("unrealized investment gains" in error for error in result.errors)
+        )
+
+    def test_validate_unrealized_gains_offset_ignores_unrelated_entries(self):
+        """Entries that don't touch the gains account are unaffected."""
+        debits_data = [
+            {"account": self.asset_account, "amount": Decimal("100.00"), "entity": None, "id": None}
+        ]
+        credits_data = [
+            {"account": self.expense_account, "amount": Decimal("100.00"), "entity": None, "id": None}
+        ]
+
+        result = validate_journal_entry_balance(
+            self.transaction, debits_data, credits_data
+        )
+
+        self.assertTrue(result.is_valid)
+
 
 class CreateJournalEntryItemTest(TestCase):
     """Tests for _create_journal_entry_item() helper function."""
@@ -334,6 +402,37 @@ class SaveJournalEntryTest(TestCase):
         debit_item = items.filter(type=JournalEntryItem.JournalEntryType.DEBIT).first()
         self.assertEqual(debit_item.amount, Decimal("100.00"))
         self.assertEqual(debit_item.account, self.asset_account)
+
+    def test_save_rejects_unrealized_gains_against_non_investment(self):
+        """save_journal_entry refuses the invariant-breaking entry and writes nothing."""
+        receivable_account = AccountFactory(
+            type=Account.Type.ASSET,
+            sub_type=Account.SubType.ACCOUNTS_RECEIVABLE,
+        )
+        gains_account = AccountFactory(
+            type=Account.Type.INCOME,
+            sub_type=Account.SubType.UNREALIZED_INVESTMENT_GAINS,
+            special_type=Account.SpecialType.UNREALIZED_GAINS_AND_LOSSES,
+        )
+        transaction = TransactionFactory(
+            account=receivable_account, amount=Decimal("100.00"), is_closed=False
+        )
+        debits_data = [
+            {"account": receivable_account, "amount": Decimal("100.00"), "entity": None, "id": None}
+        ]
+        credits_data = [
+            {"account": gains_account, "amount": Decimal("100.00"), "entity": None, "id": None}
+        ]
+
+        result = save_journal_entry(
+            transaction, debits_data, credits_data, paystub_id=None
+        )
+
+        self.assertFalse(result.success)
+        self.assertIsNone(result.journal_entry)
+        self.assertFalse(
+            JournalEntry.objects.filter(transaction=transaction).exists()
+        )
 
     def test_save_updates_existing_items(self):
         """Test existing JournalEntryItems are bulk updated."""

--- a/api/tests/views/test_reconciliation_views.py
+++ b/api/tests/views/test_reconciliation_views.py
@@ -1,0 +1,76 @@
+"""Tests for the reconciliation HTMX view.
+
+Covers the two UI-facing follow-ups to the unrealized-gains guard:
+- F3: a rejected gain/loss plug re-renders the table (200) with an inline alert.
+- F4: the Plug button only renders for investment accounts.
+"""
+from decimal import Decimal
+
+from django.test import TestCase
+from django.urls import reverse
+
+from api import utils
+from api.models import Account, Reconciliation, Transaction
+from api.tests.test_helpers import HTMXViewTestCase
+from api.tests.testing_factories import AccountFactory
+
+try:
+    from bs4 import BeautifulSoup
+    HAS_BEAUTIFULSOUP = True
+except ImportError:
+    HAS_BEAUTIFULSOUP = False
+
+
+class ReconciliationPlugViewTest(HTMXViewTestCase):
+    def setUp(self):
+        super().setUp()
+        self.date = utils.get_last_day_of_last_month()
+        self.investment_account = AccountFactory(
+            name="brokerage",
+            type=Account.Type.ASSET,
+            sub_type=Account.SubType.SECURITIES_UNRESTRICTED,
+        )
+        self.receivable_account = AccountFactory(
+            name="espp receivable",
+            type=Account.Type.ASSET,
+            sub_type=Account.SubType.ACCOUNTS_RECEIVABLE,
+        )
+        self.investment_recon = Reconciliation.objects.create(
+            account=self.investment_account, date=self.date, amount=Decimal("200.00")
+        )
+        self.receivable_recon = Reconciliation.objects.create(
+            account=self.receivable_account, date=self.date, amount=Decimal("200.00")
+        )
+
+    def _post_plug(self, reconciliation):
+        return self.client.post(
+            reverse("reconciliation"),
+            {"plug": reconciliation.pk, "date": str(self.date)},
+        )
+
+    def test_plug_non_investment_shows_alert_and_writes_nothing(self):
+        response = self._post_plug(self.receivable_recon)
+
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, "alert-danger")
+        self.assertContains(response, "breaks the cash-flow reconciliation")
+        self.assertEqual(Transaction.objects.count(), 0)
+
+    def test_plug_button_only_renders_for_investment_accounts(self):
+        if not HAS_BEAUTIFULSOUP:
+            self.skipTest("BeautifulSoup not installed")
+
+        # Any post re-renders the table for the date; inspect the rendered rows.
+        response = self._post_plug(self.receivable_recon)
+        soup = BeautifulSoup(response.content, "html.parser")
+
+        rows_with_plug = {}
+        for row in soup.find_all("tr"):
+            name_cell = row.find("td", class_="td-name")
+            if not name_cell:
+                continue
+            has_plug = row.find("button", attrs={"name": "plug"}) is not None
+            rows_with_plug[name_cell.get_text(strip=True)] = has_plug
+
+        self.assertTrue(rows_with_plug[str(self.investment_account)])
+        self.assertFalse(rows_with_plug[str(self.receivable_account)])

--- a/api/views/reconciliation_views.py
+++ b/api/views/reconciliation_views.py
@@ -20,7 +20,7 @@ class ReconciliationTableMixin:
         balance = balance_sheet.get_balance(account)
         return balance
 
-    def get_reconciliation_html(self, reconciliations, date):
+    def get_reconciliation_html(self, reconciliations, date, error=None):
         reconciliations = reconciliations.select_related("account").order_by("account")
 
         balance_sheet = BalanceSheet(date)
@@ -53,6 +53,7 @@ class ReconciliationTableMixin:
                 "left_reconciliations": left_reconciliations,
                 "right_reconciliations": right_reconciliations,
                 "formset": formset,
+                "error": error,
             },
         )
 
@@ -104,6 +105,7 @@ class ReconciliationView(ReconciliationTableMixin, LoginRequiredMixin, View):
         return render_full_page(request, html)
 
     def post(self, request):
+        plug_error = None
         if request.POST.get("plug"):
             reconciliation = get_object_or_404(
                 Reconciliation, pk=request.POST.get("plug")
@@ -111,7 +113,7 @@ class ReconciliationView(ReconciliationTableMixin, LoginRequiredMixin, View):
             try:
                 reconciliation.plug_investment_change()
             except ValidationError as error:
-                return HttpResponse(error.messages[0], status=400)
+                plug_error = error.messages[0]
         else:
             ReconciliationFormset = modelformset_factory(
                 Reconciliation, ReconciliationForm, extra=0
@@ -126,7 +128,7 @@ class ReconciliationView(ReconciliationTableMixin, LoginRequiredMixin, View):
             reconciliations = filter_form.get_reconciliations()
 
         reconciliation_table = self.get_reconciliation_html(
-            reconciliations, date=filter_form.cleaned_data["date"]
+            reconciliations, date=filter_form.cleaned_data["date"], error=plug_error
         )
 
         return HttpResponse(reconciliation_table)

--- a/ledger/templates/api/tables/reconciliation-table.html
+++ b/ledger/templates/api/tables/reconciliation-table.html
@@ -7,6 +7,9 @@
     hx-include="#reconciliation-filter-form"
 >
     {% csrf_token %}
+    {% if error %}
+    {% include "api/components/_alert.html" with message=error extra_class="mt-3" %}
+    {% endif %}
     <div class="grid grid-2">
         <div>
             <table class="table">
@@ -32,7 +35,9 @@
                                 </div>
                             </td>
                             <td>
+                                {% if reconciliation.account.is_investment %}
                                 <button type="submit" name="plug" value="{{ form.instance.id }}" class="btn btn-secondary">Plug</button>
+                                {% endif %}
                             </td>
                         </tr>
                     {% endfor %}
@@ -63,7 +68,9 @@
                                 </div>
                             </td>
                             <td>
+                                {% if reconciliation.account.is_investment %}
                                 <button type="submit" name="plug" value="{{ form.instance.id }}" class="btn btn-secondary">Plug</button>
+                                {% endif %}
                             </td>
                         </tr>
                     {% endfor %}


### PR DESCRIPTION
## Context

Follow-ups to #418, which added `Account.INVESTMENT_SUB_TYPES` and a guard in `Reconciliation.plug_investment_change`. The invariant: **a credit to the unrealized-gains account must be offset by a debit to an investment account** (securities / real estate / vehicles), or the cash-flow statement leaves a permanent residual (a 2023 plug against an `accounts_receivable` ESPP account produced a stuck 49.99 discrepancy). The initial PR only covered the plug producer and swallowed its error. This closes the three code-review follow-ups.

## Changes

**F3 — Surface the plug rejection in the UI.** `ReconciliationView.post` now re-renders the table as a **200** with an inline `alert-danger` (reusing the shared `_alert.html` component) instead of returning a 400 that HTMX silently drops.

**F4 — Only show the Plug button for investment accounts.** New `Account.is_investment` property; the template gates both Plug buttons on it, so the UI no longer invites the invalid action.

**F5 — Enforce the invariant at the write layer.** New `validate_unrealized_gains_offset()` in `journal_entry_services.py`: if any credit leg is the unrealized-gains account, every debit leg must be an investment account. Wired into `validate_journal_entry_balance` (clean inline error UX) and re-checked at the top of `save_journal_entry` (write-layer backstop shared by the form path and both REST paths). Scoped to only fire on entries that touch the gains account, so ordinary entries are unaffected.

Enforcement lives in the service layer (not a model `clean()`), matching the repo's layering — `save_journal_entry` persists via `bulk_create`, which bypasses `Model.clean()`.

## Tests

- `test_account.py`: `is_investment` true/false coverage.
- `test_journal_entry_services.py`: valid securities offset passes; AR offset rejected; unrelated entries unaffected; `save_journal_entry` returns `success=False` writing no `JournalEntry`.
- New `test_reconciliation_views.py`: non-investment plug → 200 with alert and no `Transaction`; Plug button renders only for investment rows.

All touched suites green (110 tests incl. REST API + `api.tests.statement` — no cash-flow regressions).

🤖 Generated with [Claude Code](https://claude.com/claude-code)