### PR TITLE
Rename Securities-Retirement subtype to Securities-Restricted

### DIFF
--- a/api/management/commands/diagnose_cash_flow_discrepancy.py
+++ b/api/management/commands/diagnose_cash_flow_discrepancy.py
@@ -15,7 +15,7 @@ GLOBAL_END = "2500-01-01"
 
 # The sub_types that feed the investing section (get_cash_from_investing_balances).
 INVESTING_SUB_TYPES = [
-    Account.SubType.SECURITIES_RETIREMENT,
+    Account.SubType.SECURITIES_RESTRICTED,
     Account.SubType.SECURITIES_UNRESTRICTED,
     Account.SubType.REAL_ESTATE,
     Account.SubType.VEHICLES,

--- a/api/management/commands/renumber_accounts.py
+++ b/api/management/commands/renumber_accounts.py
@@ -34,7 +34,7 @@ PREFIX_MAP = {
     "1400": "1320",
     "1410": "1330",
     "1320": "1340",
-    # Securities - Retirement (1400-1599): 401k -> HSA -> IRA -> 529 -> stock comp
+    # Securities - Restricted (1400-1599): 401k -> HSA -> IRA -> 529 -> stock comp
     "1500": "1400",
     "1501": "1410",
     "1502": "1420",

--- a/api/management/commands/seed_test_data.py
+++ b/api/management/commands/seed_test_data.py
@@ -213,8 +213,8 @@ class Command(BaseCommand):
 
             # Securities
             ('Vanguard Brokerage', Account.Type.ASSET, Account.SubType.SECURITIES_UNRESTRICTED, entities.get('self')),
-            ('Fidelity 401k', Account.Type.ASSET, Account.SubType.SECURITIES_RETIREMENT, entities.get('self')),
-            ('Partner Roth IRA', Account.Type.ASSET, Account.SubType.SECURITIES_RETIREMENT, entities.get('partner')),
+            ('Fidelity 401k', Account.Type.ASSET, Account.SubType.SECURITIES_RESTRICTED, entities.get('self')),
+            ('Partner Roth IRA', Account.Type.ASSET, Account.SubType.SECURITIES_RESTRICTED, entities.get('partner')),
 
             # Other assets
             ('Home', Account.Type.ASSET, Account.SubType.REAL_ESTATE, entities.get('joint')),

--- a/api/migrations/0038_rename_securities_retirement_to_restricted.py
+++ b/api/migrations/0038_rename_securities_retirement_to_restricted.py
@@ -1,0 +1,31 @@
+from django.db import migrations, models
+
+
+def rename_retirement_to_restricted(apps, schema_editor):
+    Account = apps.get_model('api', 'Account')
+    Account.objects.filter(sub_type='securities_retirement').update(
+        sub_type='securities_restricted'
+    )
+
+
+def reverse_rename(apps, schema_editor):
+    Account = apps.get_model('api', 'Account')
+    Account.objects.filter(sub_type='securities_restricted').update(
+        sub_type='securities_retirement'
+    )
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('api', '0037_recharacterizechange_recharacterizechangeitem'),
+    ]
+
+    operations = [
+        migrations.RunPython(rename_retirement_to_restricted, reverse_rename),
+        migrations.AlterField(
+            model_name='account',
+            name='sub_type',
+            field=models.CharField(choices=[('short_term_debt', 'Short-term Debt'), ('taxes_payable', 'Taxes Payable'), ('long_term_debt', 'Long-term Debt'), ('cash', 'Cash'), ('accounts_receivable', 'Accounts Receivable'), ('prepaid_expenses', 'Prepaid Expenses'), ('securities_unrestricted', 'Securities-Unrestricted'), ('securities_restricted', 'Securities-Restricted'), ('real_estate', 'Real Estate'), ('vehicles', 'Vehicles'), ('retained_earnings', 'Retained Earnings'), ('salary', 'Salary'), ('dividends_and_interest', 'Dividends & Interest'), ('realized_investment_gains', 'Realized Investment Gains'), ('other_income', 'Other Income'), ('unrealized_investment_gains', 'Unrealized Investment Gains'), ('operating', 'Operating'), ('tax', 'Tax'), ('interest', 'Interest Expense')], max_length=30),
+        ),
+    ]

--- a/api/models.py
+++ b/api/models.py
@@ -613,7 +613,7 @@ class Account(models.Model):
             "securities_unrestricted",
             _("Securities-Unrestricted"),
         )
-        SECURITIES_RETIREMENT = ("securities_retirement", _("Securities-Retirement"))
+        SECURITIES_RESTRICTED = ("securities_restricted", _("Securities-Restricted"))
         REAL_ESTATE = "real_estate", _("Real Estate")
         VEHICLES = "vehicles", _("Vehicles")
         # Equity types
@@ -647,7 +647,7 @@ class Account(models.Model):
             SubType.ACCOUNTS_RECEIVABLE,
             SubType.PREPAID_EXPENSES,
             SubType.SECURITIES_UNRESTRICTED,
-            SubType.SECURITIES_RETIREMENT,
+            SubType.SECURITIES_RESTRICTED,
             SubType.REAL_ESTATE,
             SubType.VEHICLES,
         ],
@@ -671,7 +671,7 @@ class Account(models.Model):
     # set.
     INVESTMENT_SUB_TYPES = [
         SubType.SECURITIES_UNRESTRICTED,
-        SubType.SECURITIES_RETIREMENT,
+        SubType.SECURITIES_RESTRICTED,
         SubType.REAL_ESTATE,
         SubType.VEHICLES,
     ]

--- a/api/rest_api/report_serializers.py
+++ b/api/rest_api/report_serializers.py
@@ -96,8 +96,8 @@ def serialize_cash_flow_metrics(metrics: CashFlowMetrics) -> Dict[str, Any]:
         "cash_from_investing": metrics.cash_from_investing,
         "net_cash_flow": metrics.net_cash_flow,
         "levered_cash_flow": metrics.levered_cash_flow,
-        "levered_cash_flow_post_retirement": (
-            metrics.levered_cash_flow_post_retirement
+        "levered_cash_flow_post_restricted": (
+            metrics.levered_cash_flow_post_restricted
         ),
         "cash_flow_discrepancy": metrics.cash_flow_discrepancy,
         "operations_flows": [serialize_balance(b) for b in metrics.operations_flows],

--- a/api/services/statement_services.py
+++ b/api/services/statement_services.py
@@ -101,7 +101,7 @@ class CashFlowMetrics:
     cash_from_investing: Decimal
     net_cash_flow: Decimal
     levered_cash_flow: Decimal
-    levered_cash_flow_post_retirement: Decimal
+    levered_cash_flow_post_restricted: Decimal
     cash_flow_discrepancy: Optional[Decimal]
 
 
@@ -479,6 +479,6 @@ def calculate_cash_flow_metrics(from_date: date, to_date: date) -> CashFlowMetri
         cash_from_investing=get_summary_value("Cash Flow From Investing"),
         net_cash_flow=get_summary_value("Net Cash Flow"),
         levered_cash_flow=cash_statement.get_levered_after_tax_cash_flow(),
-        levered_cash_flow_post_retirement=cash_statement.get_levered_after_tax_after_retirement_cash_flow(),
+        levered_cash_flow_post_restricted=cash_statement.get_levered_after_tax_after_restricted_cash_flow(),
         cash_flow_discrepancy=cash_flow_discrepancy,
     )

--- a/api/statement.py
+++ b/api/statement.py
@@ -266,8 +266,8 @@ class CashFlowStatement(Statement):
                 self.get_levered_after_tax_cash_flow(),
             ),
             Metric(
-                "Levered post-tax post-retirement Free Cash Flow",
-                self.get_levered_after_tax_after_retirement_cash_flow(),
+                "Levered post-tax post-restricted Free Cash Flow",
+                self.get_levered_after_tax_after_restricted_cash_flow(),
             ),
         ]
 
@@ -317,17 +317,17 @@ class CashFlowStatement(Statement):
             ]
         )
 
-    def get_levered_after_tax_after_retirement_cash_flow(self):
+    def get_levered_after_tax_after_restricted_cash_flow(self):
         levered_after_tax_cash_flow = self.get_levered_after_tax_cash_flow()
         cash_from_investing_balances = self.cash_from_investing_balances
-        retirement_cash_flow = sum(
+        restricted_cash_flow = sum(
             [
                 balance.amount
                 for balance in cash_from_investing_balances
-                if balance.account.sub_type == Account.SubType.SECURITIES_RETIREMENT
+                if balance.account.sub_type == Account.SubType.SECURITIES_RESTRICTED
             ]
         )
-        return levered_after_tax_cash_flow + retirement_cash_flow
+        return levered_after_tax_cash_flow + restricted_cash_flow
 
     def get_balance_sheet_account_deltas(self):
         accounts = Account.objects.filter(

--- a/api/tests/scenario_builders.py
+++ b/api/tests/scenario_builders.py
@@ -145,7 +145,7 @@ def create_chart_of_accounts(include_special=True):
     result['accounts']['401k'] = Account.objects.create(
         name='401k',
         type=Account.Type.ASSET,
-        sub_type=Account.SubType.SECURITIES_RETIREMENT,
+        sub_type=Account.SubType.SECURITIES_RESTRICTED,
     )
     result['accounts']['home'] = Account.objects.create(
         name='Home',
@@ -403,7 +403,7 @@ class StatementTestScenario:
         self.accounts['retirement'] = Account.objects.create(
             name='7000-Vanguard',
             type=Account.Type.ASSET,
-            sub_type=Account.SubType.SECURITIES_RETIREMENT,
+            sub_type=Account.SubType.SECURITIES_RESTRICTED,
         )
 
         # Liabilities

--- a/api/tests/services/test_statement_services.py
+++ b/api/tests/services/test_statement_services.py
@@ -511,7 +511,7 @@ class CalculateCashFlowMetricsTest(TestCase):
         )
 
         self.assertIsNotNone(result.levered_cash_flow)
-        self.assertIsNotNone(result.levered_cash_flow_post_retirement)
+        self.assertIsNotNone(result.levered_cash_flow_post_restricted)
 
     def test_filters_closed_accounts_in_flows(self):
         """Closed accounts with zero balance should be filtered from flows."""

--- a/api/tests/statement/test_balance_sheet.py
+++ b/api/tests/statement/test_balance_sheet.py
@@ -48,7 +48,7 @@ def create_standard_statement_scenario():
     accounts['vanguard'] = Account.objects.create(
         name='7000-Vanguard',
         type=Account.Type.ASSET,
-        sub_type=Account.SubType.SECURITIES_RETIREMENT
+        sub_type=Account.SubType.SECURITIES_RESTRICTED
     )
     accounts['income'] = Account.objects.create(
         name='8000-Income',

--- a/api/tests/statement/test_cash_flow.py
+++ b/api/tests/statement/test_cash_flow.py
@@ -47,7 +47,7 @@ def create_cash_flow_scenario():
     accounts['vanguard'] = Account.objects.create(
         name='7000-Vanguard',
         type=Account.Type.ASSET,
-        sub_type=Account.SubType.SECURITIES_RETIREMENT
+        sub_type=Account.SubType.SECURITIES_RESTRICTED
     )
     accounts['income'] = Account.objects.create(
         name='8000-Income',
@@ -233,7 +233,7 @@ class CashFlowTest(TestCase):
             cash_flow_statement.get_levered_after_tax_cash_flow()
         )
 
-    def test_levered_cash_flow_post_retirement(self):
+    def test_levered_cash_flow_post_restricted(self):
         cash_flow_statement = CashFlowStatement(
             self.income_statement,
             self.start_balance_sheet,
@@ -241,7 +241,7 @@ class CashFlowTest(TestCase):
         )
         self.assertEqual(
             540,
-            cash_flow_statement.get_levered_after_tax_after_retirement_cash_flow()
+            cash_flow_statement.get_levered_after_tax_after_restricted_cash_flow()
         )
 
     def test_get_balance_sheet_account_deltas(self):

--- a/api/views/statement_helpers.py
+++ b/api/views/statement_helpers.py
@@ -190,7 +190,7 @@ def render_cash_flow_statement(metrics: CashFlowMetrics) -> str:
         "cash_from_investing": metrics.cash_from_investing,
         "net_cash_flow": metrics.net_cash_flow,
         "levered_cash_flow": metrics.levered_cash_flow,
-        "levered_cash_flow_post_retirement": metrics.levered_cash_flow_post_retirement,
+        "levered_cash_flow_post_restricted": metrics.levered_cash_flow_post_restricted,
         "cash_flow_discrepancy": metrics.cash_flow_discrepancy,
     }
 

--- a/ledger/templates/api/content/cash-flow-content.html
+++ b/ledger/templates/api/content/cash-flow-content.html
@@ -19,8 +19,8 @@
         <div class="kpi-label">Levered Cash Flow</div>
     </div>
     <div class="kpi">
-        <div class="kpi-value">${{ levered_cash_flow_post_retirement|floatformat:0|intcomma }}</div>
-        <div class="kpi-label">Levered CF, post-Retirement</div>
+        <div class="kpi-value">${{ levered_cash_flow_post_restricted|floatformat:0|intcomma }}</div>
+        <div class="kpi-label">Levered CF, post-Restricted</div>
     </div>
 </div>
 


### PR DESCRIPTION
## Summary

Renames the account `sub_type` **Securities-Retirement → Securities-Restricted**, pairing it with the existing **Securities-Unrestricted** as a clean antonym. "Restricted" spans retirement-style holdings (401k, HSA, IRA, 529, stock comp) — carried at fair value but not freely liquid.

This is a **full re-key**, not just a label change:

- **Stored DB value**: `securities_retirement → securities_restricted`, via data migration `0038` (bulk `filter().update()` forward + reverse, modeled on the existing `0025` rename migration).
- **Python enum**: `Account.SubType.SECURITIES_RETIREMENT → SECURITIES_RESTRICTED` (and its entries in `SUBTYPE_TO_TYPE_MAP` / `INVESTMENT_SUB_TYPES`).
- **Display label**: `Securities-Retirement → Securities-Restricted` (flows to the account form and settings UI automatically via `get_sub_type_display`).

The derived cash-flow metric that reads from this subtype is renamed to match:

- method `get_levered_after_tax_after_retirement_cash_flow → ..._after_restricted_...`
- field/serializer key `levered_cash_flow_post_retirement → levered_cash_flow_post_restricted`
- KPI label `Levered CF, post-Retirement → Levered CF, post-Restricted`

## Notes

- Historical migrations (`0001`–`0027`) keep the old value in their snapshots by design — only the new `0038` migrates live rows.
- The renamed REST serializer key has no external consumer (`mcp_server/` and the finance-dashboard template don't read it).
- The generated `dashboards/dashboard.html` artifact carries a stale embedded data snapshot until it's regenerated; its JS never reads the renamed key, so nothing breaks.

## Test plan

- [x] `makemigrations --check` → no pending migrations (snapshot matches model)
- [x] `migrate` applies cleanly
- [x] Full suite: **665 tests pass**
- [x] `/simplify` multi-angle cleanup review → clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)