### PR TITLE
Include all liability accounts in the Balances tab

### DIFF
--- a/api/services/entity_services.py
+++ b/api/services/entity_services.py
@@ -18,6 +18,14 @@ from api.models import Account, Entity, JournalEntryItem
 from api.services import crud
 
 
+# Journal-entry items in scope for the Balances/Payables-Receivables tab:
+# all liability accounts plus Accounts Receivable.
+RELEVANT_ITEMS_Q = (
+    Q(account__type=Account.Type.LIABILITY)
+    | Q(account__sub_type=Account.SubType.ACCOUNTS_RECEIVABLE)
+)
+
+
 @dataclass
 class EntityResult:
     """Result of an entity create/update/delete operation."""
@@ -84,17 +92,14 @@ class UntaggedItemsData:
 
 def get_entities_balances() -> List[EntityBalance]:
     """
-    Gets aggregated balances for all entities with accounts receivable activity.
+    Gets aggregated balances for all entities with liability or accounts
+    receivable activity.
 
     Returns balances ordered by absolute balance (descending), then by
     most recent activity date.
     """
     entities_balances_qs = (
-        JournalEntryItem.objects.filter(
-            account__sub_type__in=[
-                Account.SubType.ACCOUNTS_RECEIVABLE,
-            ]
-        )
+        JournalEntryItem.objects.filter(RELEVANT_ITEMS_Q)
         .exclude(entity__isnull=True)
         .values("entity__id", "entity__name")
         .annotate(
@@ -142,7 +147,8 @@ def get_entities_balances() -> List[EntityBalance]:
 
 def get_grouped_entities_balances(hide_zero: bool = True) -> List[GroupedEntityBalances]:
     """
-    Gets entity balances grouped by account for all AR-type accounts.
+    Gets entity balances grouped by account for all liability and accounts
+    receivable accounts.
 
     Returns one GroupedEntityBalances per account, ordered by account name.
     Within each group, rows are ordered by absolute balance (desc), then by
@@ -152,9 +158,7 @@ def get_grouped_entities_balances(hide_zero: bool = True) -> List[GroupedEntityB
     zero_eps = Decimal("0.005")
 
     qs = (
-        JournalEntryItem.objects.filter(
-            account__sub_type__in=[Account.SubType.ACCOUNTS_RECEIVABLE]
-        )
+        JournalEntryItem.objects.filter(RELEVANT_ITEMS_Q)
         .exclude(entity__isnull=True)
         .values(
             "account__id",
@@ -240,17 +244,11 @@ def get_untagged_journal_entry_items() -> UntaggedItemsData:
     """
     Gets journal entry items without an assigned entity.
 
-    Filters to accounts receivable sub_type and orders by date.
+    Filters to liability and accounts receivable accounts and orders by date.
     Returns items and the first item (for form pre-selection).
     """
-    relevant_account_types = [
-        Account.SubType.ACCOUNTS_RECEIVABLE,
-    ]
-
     untagged_items = list(
-        JournalEntryItem.objects.filter(
-            entity__isnull=True, account__sub_type__in=relevant_account_types
-        )
+        JournalEntryItem.objects.filter(RELEVANT_ITEMS_Q, entity__isnull=True)
         .select_related("journal_entry__transaction")
         .order_by("journal_entry__date")
     )
@@ -266,12 +264,13 @@ def get_entity_history(
     """
     Gets the transaction history for an entity with running balances.
 
-    When account_id is supplied, history is scoped to that account only.
-    Returns items ordered by date with a calculated running balance.
+    Scoped to liability and accounts receivable accounts. When account_id is
+    supplied, history is scoped to that account only. Returns items ordered by
+    date with a calculated running balance.
     """
     qs = JournalEntryItem.objects.filter(
+        RELEVANT_ITEMS_Q,
         entity__pk=entity_id,
-        account__sub_type__in=[Account.SubType.ACCOUNTS_RECEIVABLE],
     )
     if account_id is not None:
         qs = qs.filter(account__pk=account_id)

--- a/api/tests/services/test_entity_services.py
+++ b/api/tests/services/test_entity_services.py
@@ -83,6 +83,10 @@ class GetEntitiesBalancesTest(TestCase):
             type=Account.Type.ASSET,
             sub_type=Account.SubType.CASH,
         )
+        self.liability_account = AccountFactory(
+            type=Account.Type.LIABILITY,
+            sub_type=Account.SubType.SHORT_TERM_DEBT,
+        )
         self.entity1 = EntityFactory(name="Entity One")
         self.entity2 = EntityFactory(name="Entity Two")
 
@@ -186,6 +190,23 @@ class GetEntitiesBalancesTest(TestCase):
 
         self.assertEqual(len(balances), 0)
 
+    def test_includes_liability_accounts(self):
+        """Liability account activity is included alongside AR."""
+        journal_entry = JournalEntryFactory()
+        JournalEntryItemFactory(
+            journal_entry=journal_entry,
+            account=self.liability_account,
+            entity=self.entity1,
+            type=JournalEntryItem.JournalEntryType.CREDIT,
+            amount=Decimal("100.00"),
+        )
+
+        balances = get_entities_balances()
+
+        self.assertEqual(len(balances), 1)
+        self.assertEqual(balances[0].entity_id, self.entity1.id)
+        self.assertEqual(balances[0].balance, Decimal("100.00"))
+
     def test_returns_empty_list_when_no_data(self):
         """Test returns empty list when no matching items."""
         balances = get_entities_balances()
@@ -205,6 +226,11 @@ class GetGroupedEntitiesBalancesTest(TestCase):
         self.non_ar_account = AccountFactory(
             type=Account.Type.ASSET,
             sub_type=Account.SubType.CASH,
+        )
+        self.liability_account = AccountFactory(
+            type=Account.Type.LIABILITY,
+            sub_type=Account.SubType.SHORT_TERM_DEBT,
+            is_closed=False,
         )
         self.entity1 = EntityFactory(name="Entity One")
         self.entity2 = EntityFactory(name="Entity Two")
@@ -285,12 +311,26 @@ class GetGroupedEntitiesBalancesTest(TestCase):
         self.assertEqual(len(result[0].rows), 2)
         self.assertEqual(result[0].zero_count, 0)
 
-    def test_excludes_non_ar_accounts(self):
+    def test_excludes_non_ar_non_liability_accounts(self):
         self._make_item(self.non_ar_account, self.entity1, JournalEntryItem.JournalEntryType.CREDIT, "100.00")
 
         result = get_grouped_entities_balances()
 
         self.assertEqual(result, [])
+
+    def test_includes_liability_account_group(self):
+        """A liability account produces its own group alongside AR accounts."""
+        self._make_item(self.ar_account, self.entity1, JournalEntryItem.JournalEntryType.CREDIT, "100.00")
+        # Liability net: credits 120 - debits 20 = 100
+        self._make_item(self.liability_account, self.entity2, JournalEntryItem.JournalEntryType.CREDIT, "120.00")
+        self._make_item(self.liability_account, self.entity2, JournalEntryItem.JournalEntryType.DEBIT, "20.00")
+
+        result = get_grouped_entities_balances(hide_zero=False)
+
+        by_account = {g.account_id: g for g in result}
+        self.assertIn(self.ar_account.id, by_account)
+        self.assertIn(self.liability_account.id, by_account)
+        self.assertEqual(by_account[self.liability_account.id].net_balance, Decimal("100.00"))
 
     def test_excludes_items_without_entity(self):
         je = JournalEntryFactory()
@@ -371,6 +411,10 @@ class GetUntaggedJournalEntryItemsTest(TestCase):
             type=Account.Type.ASSET,
             sub_type=Account.SubType.CASH,
         )
+        self.liability_account = AccountFactory(
+            type=Account.Type.LIABILITY,
+            sub_type=Account.SubType.LONG_TERM_DEBT,
+        )
         self.entity = EntityFactory()
 
     def test_returns_items_with_null_entity(self):
@@ -404,6 +448,22 @@ class GetUntaggedJournalEntryItemsTest(TestCase):
         result = get_untagged_journal_entry_items()
 
         self.assertEqual(len(result.items), 0)
+
+    def test_includes_untagged_liability_items(self):
+        """Untagged liability items appear in the tagging inbox."""
+        journal_entry = JournalEntryFactory()
+        item = JournalEntryItemFactory(
+            journal_entry=journal_entry,
+            account=self.liability_account,
+            entity=None,
+            type=JournalEntryItem.JournalEntryType.CREDIT,
+            amount=Decimal("100.00"),
+        )
+
+        result = get_untagged_journal_entry_items()
+
+        self.assertEqual(len(result.items), 1)
+        self.assertEqual(result.items[0].id, item.id)
 
     def test_excludes_items_with_entity(self):
         """Test items with entity are excluded."""
@@ -451,6 +511,10 @@ class GetEntityHistoryTest(TestCase):
             type=Account.Type.ASSET,
             sub_type=Account.SubType.ACCOUNTS_RECEIVABLE,
         )
+        self.liability_account = AccountFactory(
+            type=Account.Type.LIABILITY,
+            sub_type=Account.SubType.SHORT_TERM_DEBT,
+        )
         self.entity = EntityFactory()
 
     def test_returns_items_for_entity(self):
@@ -496,6 +560,23 @@ class GetEntityHistoryTest(TestCase):
         # Credits increase balance, debits decrease
         self.assertIn(Decimal("100.00"), balances)
         self.assertIn(Decimal("70.00"), balances)
+
+    def test_includes_liability_items_in_history(self):
+        """Liability items are included in an entity's history."""
+        journal_entry = JournalEntryFactory()
+        item = JournalEntryItemFactory(
+            journal_entry=journal_entry,
+            account=self.liability_account,
+            entity=self.entity,
+            type=JournalEntryItem.JournalEntryType.CREDIT,
+            amount=Decimal("100.00"),
+        )
+
+        result = get_entity_history(self.entity.id)
+
+        self.assertEqual(len(result.items), 1)
+        self.assertEqual(result.items[0].journal_entry_item.id, item.id)
+        self.assertEqual(result.items[0].running_balance, Decimal("100.00"))
 
     def test_returns_empty_for_no_items(self):
         """Test returns empty list when entity has no items."""


### PR DESCRIPTION
## Summary

The **Balances** tab (Payables/Receivables) was hard-scoped to the `ACCOUNTS_RECEIVABLE` sub_type, so only receivables appeared. This widens its scope to also consider **every liability account**, making it a true payables-and-receivables view. AR stays included.

## What changed

- Added a single shared filter `RELEVANT_ITEMS_Q` in `api/services/entity_services.py`: `Q(account__type=LIABILITY) | Q(account__sub_type=ACCOUNTS_RECEIVABLE)`. Filtering on `type` (not an enumerated sub_type list) means future liability sub_types are auto-included.
- Routed all four entity query functions through it: `get_entities_balances`, `get_grouped_entities_balances`, `get_untagged_journal_entry_items`, `get_entity_history`.
- No view, helper, or template changes — the balance math (`credits − debits`), grouping-by-account, running-balance history, and hide-zero logic are all account-agnostic.

## Behavior notes

- **Full treatment:** untagged liability items now appear in the tagging inbox and can be assigned to entities, just like AR.
- **Uniform balance formula kept:** `credits − debits` for every row (credit-normal convention). Payables show positive/green; AR keeps its existing negative-when-owed-to-you display. No sign flipping by account type.
- Closed accounts remain included so residual balances still surface in balances/history.

## Testing

- Extended `api/tests/services/test_entity_services.py` with liability-inclusion coverage across balances, grouped balances (net = credits − debits), the untagged inbox, and history.
- `api.tests.services.test_entity_services` (44) pass; full views+services suite (448) passes.
- Runtime check confirms the widened queries execute against real data and pick up liability accounts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)