### PR TITLE
Add Account column to the untagged payables/receivables table

### DIFF
--- a/api/services/entity_services.py
+++ b/api/services/entity_services.py
@@ -244,13 +244,14 @@ def get_untagged_journal_entry_items() -> UntaggedItemsData:
     """
     Gets journal entry items without an assigned entity.
 
-    Filters to liability and accounts receivable accounts and orders by date.
-    Returns items and the first item (for form pre-selection).
+    Filters to liability and accounts receivable accounts and orders by
+    account, then date. Returns items and the first item (for form
+    pre-selection).
     """
     untagged_items = list(
         JournalEntryItem.objects.filter(RELEVANT_ITEMS_Q, entity__isnull=True)
-        .select_related("journal_entry__transaction")
-        .order_by("journal_entry__date")
+        .select_related("journal_entry__transaction", "account")
+        .order_by("account__name", "journal_entry__date")
     )
 
     first_item = untagged_items[0] if untagged_items else None

--- a/api/tests/services/test_entity_services.py
+++ b/api/tests/services/test_entity_services.py
@@ -448,9 +448,8 @@ class GetUntaggedJournalEntryItemsTest(TestCase):
         )
 
         def _item(account, day):
-            je = JournalEntryFactory(date=date(2026, 1, day))
             return JournalEntryItemFactory(
-                journal_entry=je, account=account, entity=None,
+                journal_entry__date=date(2026, 1, day), account=account, entity=None,
                 type=JournalEntryItem.JournalEntryType.CREDIT, amount=Decimal("10.00"),
             )
 

--- a/api/tests/services/test_entity_services.py
+++ b/api/tests/services/test_entity_services.py
@@ -434,6 +434,39 @@ class GetUntaggedJournalEntryItemsTest(TestCase):
         self.assertEqual(len(result.items), 1)
         self.assertEqual(result.items[0].id, item.id)
 
+    def test_orders_by_account_then_date(self):
+        """Items are ordered by account name first, then by date."""
+        account_a = AccountFactory(
+            name="Aardvark AR",
+            type=Account.Type.ASSET,
+            sub_type=Account.SubType.ACCOUNTS_RECEIVABLE,
+        )
+        account_z = AccountFactory(
+            name="Zebra Debt",
+            type=Account.Type.LIABILITY,
+            sub_type=Account.SubType.LONG_TERM_DEBT,
+        )
+
+        def _item(account, day):
+            je = JournalEntryFactory(date=date(2026, 1, day))
+            return JournalEntryItemFactory(
+                journal_entry=je, account=account, entity=None,
+                type=JournalEntryItem.JournalEntryType.CREDIT, amount=Decimal("10.00"),
+            )
+
+        # Created out of order to prove sorting isn't insertion order.
+        z_early = _item(account_z, 1)
+        a_late = _item(account_a, 5)
+        a_early = _item(account_a, 2)
+
+        result = get_untagged_journal_entry_items()
+
+        self.assertEqual(
+            [i.id for i in result.items],
+            [a_early.id, a_late.id, z_early.id],
+        )
+        self.assertEqual(result.first_item, a_early)
+
     def test_filters_by_accounts_receivable_sub_type(self):
         """Test only accounts receivable items are returned."""
         journal_entry = JournalEntryFactory()

--- a/ledger/templates/api/tables/payables-receivables-table.html
+++ b/ledger/templates/api/tables/payables-receivables-table.html
@@ -17,7 +17,7 @@
                 hx-get="{% url 'tag-entities-form' payable_receivable.pk %}"
                 hx-target="#form"
             >
-                <td class="td-name">{{ payable_receivable.account.name }}</td>
+                <td class="td-name">{{ payable_receivable.account }}</td>
                 <td>{{ payable_receivable.journal_entry.transaction.date }}</td>
                 <td>{{ payable_receivable.type }}</td>
                 <td>{{ payable_receivable.amount }}</td>

--- a/ledger/templates/api/tables/payables-receivables-table.html
+++ b/ledger/templates/api/tables/payables-receivables-table.html
@@ -3,6 +3,7 @@
     <table class="table">
         <thead>
             <tr>
+                <th>Account</th>
                 <th>Date</th>
                 <th>Entry Type</th>
                 <th>Amount</th>
@@ -16,7 +17,8 @@
                 hx-get="{% url 'tag-entities-form' payable_receivable.pk %}"
                 hx-target="#form"
             >
-                <td class="td-name">{{ payable_receivable.journal_entry.transaction.date }}</td>
+                <td class="td-name">{{ payable_receivable.account.name }}</td>
+                <td>{{ payable_receivable.journal_entry.transaction.date }}</td>
                 <td>{{ payable_receivable.type }}</td>
                 <td>{{ payable_receivable.amount }}</td>
                 <td>{{ payable_receivable.journal_entry.transaction.description }}</td>


### PR DESCRIPTION
## Summary

Follow-up to #421. Adds an **Account** column to the untagged tagging inbox at the top of the Balances tab and orders those items by account first, so items group together by the account they belong to.

## What changed

- **`get_untagged_journal_entry_items`** (`api/services/entity_services.py`): order by `account__name`, then `journal_entry__date`; added `select_related("account")` to avoid an N+1 when the template renders the account name.
- **Template** (`payables-receivables-table.html`): new leading **Account** column rendering `{{ payable_receivable.account }}` (via `Account.__str__`), matching the account-column convention used by the other tables. The `td-name` emphasis moves to the new first column.
- **Test**: `test_orders_by_account_then_date` locks in account-first, then-date ordering (and that `first_item` follows it).

## Notes

- Balance math, grouping, history, and hide-zero behavior are unchanged.
- Known pre-existing quirk (not addressed here): the query sorts by `journal_entry__date` while the column displays `transaction.date`; those are set equal at creation, so display is correct in normal data.

## Testing

`api.tests.services.test_entity_services` (45) pass; live render confirms the Account header/cell appear and items come back grouped by account.

🤖 Generated with [Claude Code](https://claude.com/claude-code)