### PR TITLE
Separate Unrealized Gains into its own group on the Income Statement

### DIFF
--- a/api/views/statement_helpers.py
+++ b/api/views/statement_helpers.py
@@ -77,7 +77,8 @@ def render_income_statement(
     tax_rate: Optional[float],
     savings_rate: Optional[float],
     realized_income: Decimal,
-    income_balances: List,
+    realized_income_balances: List,
+    unrealized_gains_balances: List,
     from_date: date,
     to_date: date,
 ) -> str:
@@ -89,7 +90,8 @@ def render_income_statement(
         tax_rate: Effective tax rate (or None)
         savings_rate: Savings rate (or None)
         realized_income: Income excluding unrealized gains (the Savings Rate base)
-        income_balances: Income account rows, unrealized gains ordered last
+        realized_income_balances: Income account rows excluding unrealized gains
+        unrealized_gains_balances: Unrealized-gains rows, rendered as a separate group
         from_date: Start date
         to_date: End date
 
@@ -104,7 +106,8 @@ def render_income_statement(
         "tax_rate": tax_rate if tax_rate is not None else 0,
         "savings_rate": savings_rate if savings_rate is not None else 0,
         "realized_income": realized_income,
-        "income_balances": income_balances,
+        "realized_income_balances": realized_income_balances,
+        "unrealized_gains_balances": unrealized_gains_balances,
         "from_date": from_date,
         "to_date": to_date,
     }

--- a/api/views/statement_views.py
+++ b/api/views/statement_views.py
@@ -131,8 +131,8 @@ class StatementView(LoginRequiredMixin, View):
             tax_rate=income_statement.get_tax_rate(),
             savings_rate=income_statement.get_savings_rate(),
             realized_income=income_statement.get_realized_income(),
-            # Realized rows first, unrealized gains last (its own line at the bottom).
-            income_balances=realized_balances + unrealized_balances,
+            realized_income_balances=realized_balances,
+            unrealized_gains_balances=unrealized_balances,
             from_date=from_date,
             to_date=to_date,
         )

--- a/ledger/templates/api/content/income-content.html
+++ b/ledger/templates/api/content/income-content.html
@@ -22,24 +22,31 @@
         <div class="grid grid-2">
             <div>
                 <h4>Income: ${{ summary.income.total|floatformat:"0"|intcomma }}</h4>
-                <table class="table">
+                <table class="table mb-4">
                     <tbody>
                         <tr>
                             <td class="td-strong">Realized Income</td>
                             <td class="right td-strong">${{ realized_income|floatformat:"0"|intcomma }}</td>
                         </tr>
-                        {% for balance in income_balances %}
-                        <tr
-                            class="clickable-row"
-                            hx-get="{% url 'statement-detail' balance.account.id %}?from_date={{ from_date|date:"Y-m-d" }}&to_date={{ to_date|date:"Y-m-d" }}"
-                            hx-target="#detail"
-                        >
-                            <td class="td-name">{{ balance.account }}</td>
-                            <td class="right">${{ balance.amount|floatformat:"0"|intcomma }}</td>
-                        </tr>
+                        {% for balance in realized_income_balances %}
+                        {% include "api/content/statement-detail-row.html" %}
                         {% endfor %}
                     </tbody>
                 </table>
+
+                {% if unrealized_gains_balances %}
+                <table class="table">
+                    <tbody>
+                        <tr>
+                            <td class="td-strong">Unrealized Gains/Losses</td>
+                            <td></td>
+                        </tr>
+                        {% for balance in unrealized_gains_balances %}
+                        {% include "api/content/statement-detail-row.html" %}
+                        {% endfor %}
+                    </tbody>
+                </table>
+                {% endif %}
             </div>
 
             <div>
@@ -52,14 +59,7 @@
                             <td class="right td-strong">${{ account.total|floatformat:"0"|intcomma }}</td>
                         </tr>
                         {% for balance in account.balances %}
-                        <tr
-                            class="clickable-row"
-                            hx-get="{% url 'statement-detail' balance.account.id %}?from_date={{ from_date|date:"Y-m-d" }}&to_date={{ to_date|date:"Y-m-d" }}"
-                            hx-target="#detail"
-                        >
-                            <td class="td-name">{{ balance.account }}</td>
-                            <td class="right">${{ balance.amount|floatformat:"0"|intcomma }}</td>
-                        </tr>
+                        {% include "api/content/statement-detail-row.html" %}
                         {% endfor %}
                     </tbody>
                 </table>

--- a/ledger/templates/api/content/statement-detail-row.html
+++ b/ledger/templates/api/content/statement-detail-row.html
@@ -1,0 +1,12 @@
+{% load humanize %}
+{# Clickable account row that loads the account's drill-down into #detail.
+   Expects `balance`, `from_date`, `to_date` in context (passed through by the
+   including loop). Reused by the Income and Expenses sections. #}
+<tr
+    class="clickable-row"
+    hx-get="{% url 'statement-detail' balance.account.id %}?from_date={{ from_date|date:"Y-m-d" }}&to_date={{ to_date|date:"Y-m-d" }}"
+    hx-target="#detail"
+>
+    <td class="td-name">{{ balance.account }}</td>
+    <td class="right">${{ balance.amount|floatformat:"0"|intcomma }}</td>
+</tr>


### PR DESCRIPTION
Follow-up to #424 (already merged), which added the **Realized Income** subtotal.

## Problem

After #424, unrealized gains rendered as the last row *inside* the Realized Income group, so it looked like part of realized income rather than a separate item.

## What this does

- Renders **Unrealized Gains/Losses** as its own visually gapped group with a bold header, below the Realized Income group — so it clearly reads as a distinct item.
- Extracts a shared `statement-detail-row.html` partial for the clickable drill-down row, reused across the Realized Income, Unrealized Gains, and Expenses loops (the markup was duplicated 3× in the template).

```
Income: $31,842
  Realized Income          $62,561     ← subtotal (Savings Rate base)
    4000-Income, Salary     $48,462
    4110-Dividends, Taxable  $7,962
    …
                                        ← gap
  Unrealized Gains/Losses              ← now its own group
    4400-Unrealized Gains  -$30,719
```

## Implementation

- `api/views/statement_views.py` + `statement_helpers.py` — pass the realized and unrealized row groups separately (`partition_income_balances`, added in #424, already returns them).
- `ledger/templates/api/content/income-content.html` — render the two groups; loop bodies now `{% include %}` the new partial.
- `ledger/templates/api/content/statement-detail-row.html` — new shared row partial.

## Testing

Full statement + services + views suites pass (492 tests). Verified the rendered income section shows the two separated groups with drill-down intact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)