### PR TITLE
Fix leaked template comment on income statement rows

### DIFF
--- a/ledger/templates/api/content/statement-detail-row.html
+++ b/ledger/templates/api/content/statement-detail-row.html
@@ -1,7 +1,9 @@
 {% load humanize %}
-{# Clickable account row that loads the account's drill-down into #detail.
-   Expects `balance`, `from_date`, `to_date` in context (passed through by the
-   including loop). Reused by the Income and Expenses sections. #}
+{% comment %}
+Clickable account row that loads the account's drill-down into #detail.
+Expects `balance`, `from_date`, `to_date` in context (passed through by the
+including loop). Reused by the Income and Expenses sections.
+{% endcomment %}
 <tr
     class="clickable-row"
     hx-get="{% url 'statement-detail' balance.account.id %}?from_date={{ from_date|date:"Y-m-d" }}&to_date={{ to_date|date:"Y-m-d" }}"


### PR DESCRIPTION
## Summary

The income statement was displaying raw Django template comment text (e.g. `{# Clickable account row that loads the account's drill-down into #detail... #}`) repeated once per account row in the Income and Expenses sections.

## Root cause

`ledger/templates/api/content/statement-detail-row.html` used a `{# ... #}` comment that spanned multiple lines. Django's `{# #}` syntax is **single-line only** — a multi-line version is not parsed as a comment and is emitted as literal text. Because the partial is included once per account in a loop, the leaked text was duplicated across every row.

## Fix

Replace the multi-line `{# #}` with a `{% comment %}...{% endcomment %}` block, which supports multiple lines and is correctly stripped from rendered output. Verified via grep that no other multi-line `{# #}` comments exist in the templates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)